### PR TITLE
STA-33: Add wallet endpoints (create + demo-fund)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -42,11 +42,23 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+val gitDir: File = rootProject.projectDir.resolve("../.git").let { dotGit ->
+    if (dotGit.isFile) {
+        // Worktree: .git is a file containing "gitdir: <path>". Resolve the main repo hooks dir.
+        val gitdirLine = dotGit.readText().trim()
+        val gitdirPath = gitdirLine.removePrefix("gitdir: ")
+        // Navigate from .git/worktrees/<name> up to .git/hooks
+        file(gitdirPath).resolve("../../hooks")
+    } else {
+        dotGit.resolve("hooks")
+    }
+}
+
 val installGitHooks by tasks.registering(Copy::class) {
     description = "Installs git hooks from backend/.githooks into .git/hooks"
     group = "setup"
     from("${projectDir}/.githooks")
-    into("${rootProject.projectDir}/../.git/hooks")
+    into(gitDir)
     filePermissions {
         unix("rwxr-xr-x")
     }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-webmvc-test")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.4.1")
     testImplementation("org.testcontainers:junit-jupiter:1.21.4")
     testImplementation("org.testcontainers:postgresql:1.21.4")

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.domain.exception.InsufficientBalanceException;
+import com.stablepay.domain.exception.TreasuryDepletedException;
+import com.stablepay.domain.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.exception.WalletNotFoundException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +34,26 @@ public class GlobalExceptionHandler {
         log.warn("Insufficient balance: {}", ex.getMessage());
         return ErrorResponse.builder()
                 .errorCode("SP-0002")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(TreasuryDepletedException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ErrorResponse handleTreasuryDepleted(TreasuryDepletedException ex) {
+        log.warn("Treasury depleted: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0007")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(WalletAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleWalletAlreadyExists(WalletAlreadyExistsException ex) {
+        log.warn("Wallet already exists: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0008")
                 .message(ex.getMessage())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.stablepay.application.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.stablepay.application.dto.ErrorResponse;
+import com.stablepay.domain.exception.InsufficientBalanceException;
+import com.stablepay.domain.exception.WalletNotFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleWalletNotFound(WalletNotFoundException ex) {
+        log.warn("Wallet not found: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0006")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(InsufficientBalanceException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInsufficientBalance(InsufficientBalanceException ex) {
+        log.warn("Insufficient balance: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0002")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(MethodArgumentNotValidException ex) {
+        var message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + "; " + b)
+                .orElse("Validation failed");
+        log.warn("Validation error: {}", message);
+        return ErrorResponse.builder()
+                .errorCode("SP-0003")
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/WalletController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/WalletController.java
@@ -1,0 +1,41 @@
+package com.stablepay.application.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.application.dto.CreateWalletRequest;
+import com.stablepay.application.dto.FundWalletRequest;
+import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.application.mapper.WalletApiMapper;
+import com.stablepay.domain.port.inbound.WalletService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/wallets")
+@RequiredArgsConstructor
+public class WalletController {
+
+    private final WalletService walletService;
+    private final WalletApiMapper walletApiMapper;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public WalletResponse createWallet(@Valid @RequestBody CreateWalletRequest request) {
+        var wallet = walletService.create(request.userId());
+        return walletApiMapper.toResponse(wallet);
+    }
+
+    @PostMapping("/{id}/fund")
+    public WalletResponse fundWallet(@PathVariable Long id, @Valid @RequestBody FundWalletRequest request) {
+        var wallet = walletService.fund(id, request.amount());
+        return walletApiMapper.toResponse(wallet);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
@@ -1,0 +1,10 @@
+package com.stablepay.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record CreateWalletRequest(
+    @NotBlank String userId
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.stablepay.application.dto;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ErrorResponse(
+    String errorCode,
+    String message
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/FundWalletRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/FundWalletRequest.java
@@ -1,0 +1,13 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record FundWalletRequest(
+    @NotNull @Positive BigDecimal amount
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
@@ -1,0 +1,17 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record WalletResponse(
+    Long id,
+    String userId,
+    String solanaAddress,
+    BigDecimal availableBalance,
+    BigDecimal totalBalance,
+    Instant createdAt,
+    Instant updatedAt
+) {}

--- a/backend/src/main/java/com/stablepay/application/mapper/WalletApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/mapper/WalletApiMapper.java
@@ -1,0 +1,11 @@
+package com.stablepay.application.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.domain.model.Wallet;
+
+@Mapper(componentModel = "spring")
+public interface WalletApiMapper {
+    WalletResponse toResponse(Wallet wallet);
+}

--- a/backend/src/main/java/com/stablepay/domain/exception/TreasuryDepletedException.java
+++ b/backend/src/main/java/com/stablepay/domain/exception/TreasuryDepletedException.java
@@ -1,0 +1,17 @@
+package com.stablepay.domain.exception;
+
+import java.math.BigDecimal;
+
+public class TreasuryDepletedException extends RuntimeException {
+
+    public static TreasuryDepletedException insufficientTreasury(
+            BigDecimal requested, BigDecimal available) {
+        return new TreasuryDepletedException(
+                "SP-0007: Insufficient treasury balance. Requested: "
+                        + requested + ", Available: " + available);
+    }
+
+    private TreasuryDepletedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/exception/WalletAlreadyExistsException.java
+++ b/backend/src/main/java/com/stablepay/domain/exception/WalletAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.stablepay.domain.exception;
+
+public class WalletAlreadyExistsException extends RuntimeException {
+
+    public static WalletAlreadyExistsException forUserId(String userId) {
+        return new WalletAlreadyExistsException(
+                "SP-0008: Wallet already exists for user: " + userId);
+    }
+
+    private WalletAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/exception/WalletNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/exception/WalletNotFoundException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.exception;
+
+public class WalletNotFoundException extends RuntimeException {
+
+    public static WalletNotFoundException byId(Long id) {
+        return new WalletNotFoundException("SP-0006: Wallet not found: " + id);
+    }
+
+    private WalletNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/port/outbound/TreasuryService.java
+++ b/backend/src/main/java/com/stablepay/domain/port/outbound/TreasuryService.java
@@ -1,0 +1,7 @@
+package com.stablepay.domain.port.outbound;
+
+import java.math.BigDecimal;
+
+public interface TreasuryService {
+    void transferFromTreasury(String destinationAddress, BigDecimal amount);
+}

--- a/backend/src/main/java/com/stablepay/domain/port/outbound/TreasuryService.java
+++ b/backend/src/main/java/com/stablepay/domain/port/outbound/TreasuryService.java
@@ -3,5 +3,6 @@ package com.stablepay.domain.port.outbound;
 import java.math.BigDecimal;
 
 public interface TreasuryService {
+    BigDecimal getBalance();
     void transferFromTreasury(String destinationAddress, BigDecimal amount);
 }

--- a/backend/src/main/java/com/stablepay/domain/service/WalletServiceImpl.java
+++ b/backend/src/main/java/com/stablepay/domain/service/WalletServiceImpl.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.exception.TreasuryDepletedException;
+import com.stablepay.domain.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.exception.WalletNotFoundException;
 import com.stablepay.domain.model.Wallet;
 import com.stablepay.domain.port.inbound.WalletService;
@@ -28,6 +30,9 @@ public class WalletServiceImpl implements WalletService {
     @Override
     public Wallet create(String userId) {
         log.info("Creating wallet for user: {}", userId);
+        walletRepository.findByUserId(userId).ifPresent(existing -> {
+            throw WalletAlreadyExistsException.forUserId(userId);
+        });
         var solanaAddress = mpcWalletClient.generateKey();
         var wallet = Wallet.builder()
                 .userId(userId)
@@ -45,6 +50,10 @@ public class WalletServiceImpl implements WalletService {
         log.info("Funding wallet {} with {} USDC", walletId, amount);
         var wallet = walletRepository.findById(walletId)
                 .orElseThrow(() -> WalletNotFoundException.byId(walletId));
+        var treasuryBalance = treasuryService.getBalance();
+        if (treasuryBalance.compareTo(amount) < 0) {
+            throw TreasuryDepletedException.insufficientTreasury(amount, treasuryBalance);
+        }
         treasuryService.transferFromTreasury(wallet.solanaAddress(), amount);
         var funded = wallet.toBuilder()
                 .availableBalance(wallet.availableBalance().add(amount))

--- a/backend/src/main/java/com/stablepay/domain/service/WalletServiceImpl.java
+++ b/backend/src/main/java/com/stablepay/domain/service/WalletServiceImpl.java
@@ -1,0 +1,57 @@
+package com.stablepay.domain.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.exception.WalletNotFoundException;
+import com.stablepay.domain.model.Wallet;
+import com.stablepay.domain.port.inbound.WalletService;
+import com.stablepay.domain.port.outbound.MpcWalletClient;
+import com.stablepay.domain.port.outbound.TreasuryService;
+import com.stablepay.domain.port.outbound.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WalletServiceImpl implements WalletService {
+
+    private final WalletRepository walletRepository;
+    private final MpcWalletClient mpcWalletClient;
+    private final TreasuryService treasuryService;
+
+    @Override
+    public Wallet create(String userId) {
+        log.info("Creating wallet for user: {}", userId);
+        var solanaAddress = mpcWalletClient.generateKey();
+        var wallet = Wallet.builder()
+                .userId(userId)
+                .solanaAddress(solanaAddress)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+        var saved = walletRepository.save(wallet);
+        log.info("Wallet created with id: {} for user: {}", saved.id(), userId);
+        return saved;
+    }
+
+    @Override
+    public Wallet fund(Long walletId, BigDecimal amount) {
+        log.info("Funding wallet {} with {} USDC", walletId, amount);
+        var wallet = walletRepository.findById(walletId)
+                .orElseThrow(() -> WalletNotFoundException.byId(walletId));
+        treasuryService.transferFromTreasury(wallet.solanaAddress(), amount);
+        var funded = wallet.toBuilder()
+                .availableBalance(wallet.availableBalance().add(amount))
+                .totalBalance(wallet.totalBalance().add(amount))
+                .build();
+        var saved = walletRepository.save(funded);
+        log.info("Wallet {} funded successfully. New balance: {}", walletId, saved.availableBalance());
+        return saved;
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -14,6 +14,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class TreasuryServiceAdapter implements TreasuryService {
 
+    private static final BigDecimal HARDCODED_BALANCE = BigDecimal.valueOf(1_000_000);
+
+    @Override
+    public BigDecimal getBalance() {
+        log.info("Querying treasury balance (hardcoded): {}", HARDCODED_BALANCE);
+        return HARDCODED_BALANCE;
+    }
+
     @Override
     public void transferFromTreasury(String destinationAddress, BigDecimal amount) {
         log.info("Treasury transfer: {} USDC to {}", amount, destinationAddress);

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -1,0 +1,21 @@
+package com.stablepay.infrastructure.solana;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.port.outbound.TreasuryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TreasuryServiceAdapter implements TreasuryService {
+
+    @Override
+    public void transferFromTreasury(String destinationAddress, BigDecimal amount) {
+        log.info("Treasury transfer: {} USDC to {}", amount, destinationAddress);
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/WalletControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.stablepay.application.mapper.WalletApiMapperImpl;
+import com.stablepay.domain.exception.TreasuryDepletedException;
+import com.stablepay.domain.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.exception.WalletNotFoundException;
 import com.stablepay.domain.model.Wallet;
 import com.stablepay.domain.port.inbound.WalletService;
@@ -112,7 +114,7 @@ class WalletControllerTest {
 
     @Test
     void shouldReturn400WhenUserIdBlank() throws Exception {
-        // given — blank userId in request body
+        // given -- blank userId in request body
 
         // when / then
         mockMvc.perform(post("/api/wallets")
@@ -122,6 +124,41 @@ class WalletControllerTest {
                                 """))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0003"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void shouldReturn503WhenTreasuryDepleted() throws Exception {
+        // given
+        given(walletService.fund(WALLET_ID, BigDecimal.valueOf(50)))
+                .willThrow(TreasuryDepletedException.insufficientTreasury(
+                        BigDecimal.valueOf(50), BigDecimal.valueOf(10)));
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"amount": 50}
+                                """))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.errorCode").value("SP-0007"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void shouldReturn409WhenWalletAlreadyExists() throws Exception {
+        // given
+        given(walletService.create(USER_ID))
+                .willThrow(WalletAlreadyExistsException.forUserId(USER_ID));
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"userId": "user-42"}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0008"))
                 .andExpect(jsonPath("$.message").exists());
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/WalletControllerTest.java
@@ -1,0 +1,127 @@
+package com.stablepay.application.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.stablepay.application.mapper.WalletApiMapperImpl;
+import com.stablepay.domain.exception.WalletNotFoundException;
+import com.stablepay.domain.model.Wallet;
+import com.stablepay.domain.port.inbound.WalletService;
+
+@WebMvcTest(WalletController.class)
+@Import(WalletApiMapperImpl.class)
+class WalletControllerTest {
+
+    private static final Long WALLET_ID = 1L;
+    private static final String USER_ID = "user-42";
+    private static final String SOLANA_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
+    private static final Instant CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    private static final Instant UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private WalletService walletService;
+
+    @Test
+    void shouldCreateWallet() throws Exception {
+        // given
+        var wallet = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(CREATED_AT)
+                .updatedAt(UPDATED_AT)
+                .build();
+
+        given(walletService.create(USER_ID)).willReturn(wallet);
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"userId": "user-42"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(WALLET_ID))
+                .andExpect(jsonPath("$.userId").value(USER_ID))
+                .andExpect(jsonPath("$.solanaAddress").value(SOLANA_ADDRESS))
+                .andExpect(jsonPath("$.availableBalance").value(0))
+                .andExpect(jsonPath("$.totalBalance").value(0));
+    }
+
+    @Test
+    void shouldFundWallet() throws Exception {
+        // given
+        var fundedWallet = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.valueOf(50))
+                .totalBalance(BigDecimal.valueOf(50))
+                .createdAt(CREATED_AT)
+                .updatedAt(UPDATED_AT)
+                .build();
+
+        given(walletService.fund(WALLET_ID, BigDecimal.valueOf(50))).willReturn(fundedWallet);
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"amount": 50}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(WALLET_ID))
+                .andExpect(jsonPath("$.availableBalance").value(50))
+                .andExpect(jsonPath("$.totalBalance").value(50));
+    }
+
+    @Test
+    void shouldReturn404WhenWalletNotFound() throws Exception {
+        // given
+        given(walletService.fund(WALLET_ID, BigDecimal.valueOf(50)))
+                .willThrow(WalletNotFoundException.byId(WALLET_ID));
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"amount": 50}
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0006"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void shouldReturn400WhenUserIdBlank() throws Exception {
+        // given — blank userId in request body
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"userId": ""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0003"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/service/WalletServiceImplTest.java
+++ b/backend/src/test/java/com/stablepay/domain/service/WalletServiceImplTest.java
@@ -1,0 +1,139 @@
+package com.stablepay.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.exception.WalletNotFoundException;
+import com.stablepay.domain.model.Wallet;
+import com.stablepay.domain.port.outbound.MpcWalletClient;
+import com.stablepay.domain.port.outbound.TreasuryService;
+import com.stablepay.domain.port.outbound.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WalletServiceImplTest {
+
+    private static final String USER_ID = "user-42";
+    private static final String SOLANA_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
+    private static final Long WALLET_ID = 1L;
+    private static final BigDecimal FUND_AMOUNT = BigDecimal.valueOf(50);
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private MpcWalletClient mpcWalletClient;
+
+    @Mock
+    private TreasuryService treasuryService;
+
+    @InjectMocks
+    private WalletServiceImpl walletService;
+
+    @Test
+    void shouldCreateWalletWithMpcGeneratedAddress() {
+        // given
+        var newWallet = Wallet.builder()
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+        var savedWallet = newWallet.toBuilder()
+                .id(WALLET_ID)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        given(mpcWalletClient.generateKey()).willReturn(SOLANA_ADDRESS);
+        given(walletRepository.save(newWallet)).willReturn(savedWallet);
+
+        // when
+        var result = walletService.create(USER_ID);
+
+        // then
+        var expected = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(mpcWalletClient).should().generateKey();
+        then(walletRepository).should().save(newWallet);
+    }
+
+    @Test
+    void shouldFundWalletSuccessfully() {
+        // given
+        var existingWallet = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.valueOf(100))
+                .totalBalance(BigDecimal.valueOf(100))
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+        var fundedWallet = existingWallet.toBuilder()
+                .availableBalance(BigDecimal.valueOf(150))
+                .totalBalance(BigDecimal.valueOf(150))
+                .build();
+        var savedWallet = fundedWallet.toBuilder()
+                .updatedAt(Instant.parse("2026-04-03T11:00:00Z"))
+                .build();
+
+        given(walletRepository.findById(WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(walletRepository.save(fundedWallet)).willReturn(savedWallet);
+
+        // when
+        var result = walletService.fund(WALLET_ID, FUND_AMOUNT);
+
+        // then
+        var expected = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.valueOf(150))
+                .totalBalance(BigDecimal.valueOf(150))
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T11:00:00Z"))
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(treasuryService).should().transferFromTreasury(SOLANA_ADDRESS, FUND_AMOUNT);
+        then(walletRepository).should().save(fundedWallet);
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFoundOnFund() {
+        // given
+        given(walletRepository.findById(WALLET_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> walletService.fund(WALLET_ID, FUND_AMOUNT))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006");
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/service/WalletServiceImplTest.java
+++ b/backend/src/test/java/com/stablepay/domain/service/WalletServiceImplTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.exception.TreasuryDepletedException;
+import com.stablepay.domain.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.exception.WalletNotFoundException;
 import com.stablepay.domain.model.Wallet;
 import com.stablepay.domain.port.outbound.MpcWalletClient;
@@ -28,6 +30,7 @@ class WalletServiceImplTest {
     private static final String SOLANA_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
     private static final Long WALLET_ID = 1L;
     private static final BigDecimal FUND_AMOUNT = BigDecimal.valueOf(50);
+    private static final BigDecimal TREASURY_BALANCE = BigDecimal.valueOf(1_000_000);
 
     @Mock
     private WalletRepository walletRepository;
@@ -56,6 +59,7 @@ class WalletServiceImplTest {
                 .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
                 .build();
 
+        given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
         given(mpcWalletClient.generateKey()).willReturn(SOLANA_ADDRESS);
         given(walletRepository.save(newWallet)).willReturn(savedWallet);
 
@@ -102,6 +106,7 @@ class WalletServiceImplTest {
                 .build();
 
         given(walletRepository.findById(WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(treasuryService.getBalance()).willReturn(TREASURY_BALANCE);
         given(walletRepository.save(fundedWallet)).willReturn(savedWallet);
 
         // when
@@ -135,5 +140,50 @@ class WalletServiceImplTest {
         assertThatThrownBy(() -> walletService.fund(WALLET_ID, FUND_AMOUNT))
                 .isInstanceOf(WalletNotFoundException.class)
                 .hasMessageContaining("SP-0006");
+    }
+
+    @Test
+    void shouldThrowTreasuryDepletedWhenTreasuryBalanceLow() {
+        // given
+        var lowTreasuryBalance = BigDecimal.valueOf(10);
+        var requestedAmount = BigDecimal.valueOf(100);
+        var existingWallet = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.valueOf(200))
+                .totalBalance(BigDecimal.valueOf(200))
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        given(walletRepository.findById(WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(treasuryService.getBalance()).willReturn(lowTreasuryBalance);
+
+        // when / then
+        assertThatThrownBy(() -> walletService.fund(WALLET_ID, requestedAmount))
+                .isInstanceOf(TreasuryDepletedException.class)
+                .hasMessageContaining("SP-0007");
+    }
+
+    @Test
+    void shouldThrowWhenWalletAlreadyExistsForUserId() {
+        // given
+        var existingWallet = Wallet.builder()
+                .id(WALLET_ID)
+                .userId(USER_ID)
+                .solanaAddress(SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        given(walletRepository.findByUserId(USER_ID)).willReturn(Optional.of(existingWallet));
+
+        // when / then
+        assertThatThrownBy(() -> walletService.create(USER_ID))
+                .isInstanceOf(WalletAlreadyExistsException.class)
+                .hasMessageContaining("SP-0008");
     }
 }


### PR DESCRIPTION
## STA Issue
Closes #33

## Changes
- Add `POST /api/wallets` endpoint — triggers MPC keygen, creates wallet with zero balances, returns 201
- Add `POST /api/wallets/{id}/fund` endpoint — transfers USDC from treasury, updates wallet balances
- Implement `WalletServiceImpl` domain service with `create()` and `fund()` operations
- Add `TreasuryService` outbound port + stub adapter (real Solana integration deferred)
- Add `WalletNotFoundException` domain exception with `SP-0006` error code
- Add `GlobalExceptionHandler` — maps domain exceptions to HTTP status codes (404, 400)
- Add DTOs: `CreateWalletRequest`, `FundWalletRequest`, `WalletResponse`, `ErrorResponse`
- Add `WalletApiMapper` (MapStruct) for domain→response mapping
- Fix `installGitHooks` Gradle task to handle git worktrees

## Test plan
- [x] `./gradlew build` passes
- [x] 3 unit tests: `WalletServiceImplTest` (create, fund, not-found)
- [x] 4 controller tests: `WalletControllerTest` (create 201, fund 200, 404, validation 400)
- [x] ArchUnit rules pass (6 rules)
- [x] Spotless formatting applied

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — wallet endpoints are not deployed yet (hackathon scaffolding phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)