### PR TITLE
STA-36: Add FX rate endpoint with ExchangeRate API adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,25 +120,32 @@ stablepay-hackathon/
 ```
 com.stablepay/
 ├── application/
-│   ├── controller/     # Spring MVC @RestController
-│   └── config/         # Spring @Configuration
+│   ├── controller/     # Spring MVC @RestController (thin — delegates to handlers)
+│   ├── dto/            # Request/Response records (API models)
+│   ├── mapper/         # MapStruct: API ↔ Domain mapping
+│   └── config/         # Spring @Configuration, @RestControllerAdvice
 ├── domain/
 │   ├── model/          # Records + @Builder — no Spring annotations
+│   ├── command/        # Command records ({Action}{Entity}Command)
+│   ├── handler/        # Command/Query handlers (one handler per use case)
+��   ├── exception/      # Domain exceptions with SP-XXXX codes
 │   ├── port/
-│   │   ├── inbound/    # Service interfaces
+│   │   ├── inbound/    # Service interfaces (optional — handlers can be ports)
 │   │   └── outbound/   # Repository, Client, Provider interfaces
-│   └── service/        # Business logic
+│   └── service/        # Shared domain services (cross-handler logic)
 └── infrastructure/
-    ├── persistence/    # JPA entities + Spring Data repositories
+    ├── persistence/    # JPA entities + entity mappers + Spring Data repos + adapters
     ├── temporal/       # Temporal workflows + activities
     ├── mpc/            # gRPC client to MPC sidecar
-    ├── solana/         # SolanaRpcClient, transaction construction
+    ├── solana/         # SolanaRpcClient, treasury transfers
     ├── stripe/         # Stripe on-ramp adapter
-    ├── fx/             # FX rate provider
+    ├── fx/             # FX rate provider adapter
     └── sms/            # Twilio adapter
 ```
 
-**Dependency rule:** `domain` → nothing. `application` → `domain`. `infrastructure` → `domain`. Never `infrastructure` → `application.controller`.
+**Dependency rule:** `domain` → nothing. `application` → `domain`. `infrastructure` → `domain`. Never `infrastructure` → `application.controller`. **Never `application` → `infrastructure` — always go through domain handlers.**
+
+**Call chain:** `Controller` �� `Handler` → `Outbound Port` → `Adapter`. Never skip the domain layer.
 
 ### Error Code Prefix
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -42,11 +42,14 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+val gitDir = file("${rootProject.projectDir}/../.git")
+
 val installGitHooks by tasks.registering(Copy::class) {
     description = "Installs git hooks from backend/.githooks into .git/hooks"
     group = "setup"
+    enabled = gitDir.isDirectory
     from("${projectDir}/.githooks")
-    into("${rootProject.projectDir}/../.git/hooks")
+    into("${gitDir}/hooks")
     filePermissions {
         unix("rwxr-xr-x")
     }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.4.1")
     testImplementation("org.testcontainers:junit-jupiter:1.21.4")
     testImplementation("org.testcontainers:postgresql:1.21.4")

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.domain.exception.InsufficientBalanceException;
+import com.stablepay.domain.exception.UnsupportedCorridorException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +22,16 @@ public class GlobalExceptionHandler {
         log.warn("Domain error: {}", ex.getMessage());
         return ErrorResponse.builder()
                 .errorCode("SP-0002")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(UnsupportedCorridorException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleUnsupportedCorridor(UnsupportedCorridorException ex) {
+        log.warn("Unsupported corridor: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0009")
                 .message(ex.getMessage())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.stablepay.application.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.stablepay.application.dto.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleGenericException(Exception ex) {
+        log.error("Unhandled exception: {}", ex.getMessage(), ex);
+        return ErrorResponse.builder()
+                .errorCode("SP-9999")
+                .message("An unexpected error occurred")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.stablepay.application.config;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.stablepay.application.dto.ErrorResponse;
+import com.stablepay.domain.exception.InsufficientBalanceException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,13 +15,27 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ErrorResponse handleGenericException(Exception ex) {
-        log.error("Unhandled exception: {}", ex.getMessage(), ex);
+    @ExceptionHandler(InsufficientBalanceException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInsufficientBalance(InsufficientBalanceException ex) {
+        log.warn("Domain error: {}", ex.getMessage());
         return ErrorResponse.builder()
-                .errorCode("SP-9999")
-                .message("An unexpected error occurred")
+                .errorCode("SP-0002")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(MethodArgumentNotValidException ex) {
+        var message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + "; " + b)
+                .orElse("Validation failed");
+        log.warn("Validation error: {}", message);
+        return ErrorResponse.builder()
+                .errorCode("SP-0003")
+                .message(message)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
@@ -1,6 +1,7 @@
 package com.stablepay.application.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +19,9 @@ public class FxRateController {
     private final GetFxRateQueryHandler getFxRateQueryHandler;
     private final FxRateApiMapper fxRateApiMapper;
 
-    @GetMapping("/usd-inr")
-    public FxRateResponse getUsdInrRate() {
-        var quote = getFxRateQueryHandler.handle("USD", "INR");
+    @GetMapping("/{from}-{to}")
+    public FxRateResponse getRate(@PathVariable String from, @PathVariable String to) {
+        var quote = getFxRateQueryHandler.handle(from.toUpperCase(), to.toUpperCase());
         return fxRateApiMapper.toResponse(quote);
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.stablepay.application.dto.FxRateResponse;
 import com.stablepay.application.mapper.FxRateApiMapper;
-import com.stablepay.domain.port.outbound.FxRateProvider;
+import com.stablepay.domain.handler.GetFxRateQueryHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,12 +15,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FxRateController {
 
-    private final FxRateProvider fxRateProvider;
+    private final GetFxRateQueryHandler getFxRateQueryHandler;
     private final FxRateApiMapper fxRateApiMapper;
 
     @GetMapping("/usd-inr")
     public FxRateResponse getUsdInrRate() {
-        var quote = fxRateProvider.getRate("USD", "INR");
+        var quote = getFxRateQueryHandler.handle("USD", "INR");
         return fxRateApiMapper.toResponse(quote);
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/FxRateController.java
@@ -1,0 +1,26 @@
+package com.stablepay.application.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.application.dto.FxRateResponse;
+import com.stablepay.application.mapper.FxRateApiMapper;
+import com.stablepay.domain.port.outbound.FxRateProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/fx")
+@RequiredArgsConstructor
+public class FxRateController {
+
+    private final FxRateProvider fxRateProvider;
+    private final FxRateApiMapper fxRateApiMapper;
+
+    @GetMapping("/usd-inr")
+    public FxRateResponse getUsdInrRate() {
+        var quote = fxRateProvider.getRate("USD", "INR");
+        return fxRateApiMapper.toResponse(quote);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.stablepay.application.dto;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ErrorResponse(
+    String errorCode,
+    String message
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/FxRateResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/FxRateResponse.java
@@ -1,0 +1,14 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record FxRateResponse(
+    BigDecimal rate,
+    String source,
+    Instant timestamp,
+    Instant expiresAt
+) {}

--- a/backend/src/main/java/com/stablepay/application/mapper/FxRateApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/mapper/FxRateApiMapper.java
@@ -1,0 +1,11 @@
+package com.stablepay.application.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.stablepay.application.dto.FxRateResponse;
+import com.stablepay.domain.model.FxQuote;
+
+@Mapper(componentModel = "spring")
+public interface FxRateApiMapper {
+    FxRateResponse toResponse(FxQuote quote);
+}

--- a/backend/src/main/java/com/stablepay/domain/exception/UnsupportedCorridorException.java
+++ b/backend/src/main/java/com/stablepay/domain/exception/UnsupportedCorridorException.java
@@ -1,0 +1,13 @@
+package com.stablepay.domain.exception;
+
+public class UnsupportedCorridorException extends RuntimeException {
+
+    public static UnsupportedCorridorException forPair(String from, String to) {
+        return new UnsupportedCorridorException(
+                "SP-0009: Unsupported corridor: " + from + "/" + to);
+    }
+
+    private UnsupportedCorridorException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/handler/GetFxRateQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/handler/GetFxRateQueryHandler.java
@@ -1,0 +1,22 @@
+package com.stablepay.domain.handler;
+
+import org.springframework.stereotype.Service;
+
+import com.stablepay.domain.model.FxQuote;
+import com.stablepay.domain.port.outbound.FxRateProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetFxRateQueryHandler {
+
+    private final FxRateProvider fxRateProvider;
+
+    public FxQuote handle(String fromCurrency, String toCurrency) {
+        log.debug("Fetching FX rate for {}/{}", fromCurrency, toCurrency);
+        return fxRateProvider.getRate(fromCurrency, toCurrency);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/handler/GetFxRateQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/handler/GetFxRateQueryHandler.java
@@ -2,6 +2,8 @@ package com.stablepay.domain.handler;
 
 import org.springframework.stereotype.Service;
 
+import com.stablepay.domain.exception.UnsupportedCorridorException;
+import com.stablepay.domain.model.Corridor;
 import com.stablepay.domain.model.FxQuote;
 import com.stablepay.domain.port.outbound.FxRateProvider;
 
@@ -16,7 +18,9 @@ public class GetFxRateQueryHandler {
     private final FxRateProvider fxRateProvider;
 
     public FxQuote handle(String fromCurrency, String toCurrency) {
-        log.debug("Fetching FX rate for {}/{}", fromCurrency, toCurrency);
-        return fxRateProvider.getRate(fromCurrency, toCurrency);
+        var corridor = Corridor.find(fromCurrency, toCurrency)
+                .orElseThrow(() -> UnsupportedCorridorException.forPair(fromCurrency, toCurrency));
+        log.debug("Fetching FX rate for corridor {}", corridor);
+        return fxRateProvider.getRate(corridor.getFromCurrency(), corridor.getToCurrency());
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/model/Corridor.java
+++ b/backend/src/main/java/com/stablepay/domain/model/Corridor.java
@@ -1,0 +1,23 @@
+package com.stablepay.domain.model;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Corridor {
+
+    USD_INR("USD", "INR");
+
+    private final String fromCurrency;
+    private final String toCurrency;
+
+    public static Optional<Corridor> find(String from, String to) {
+        return Arrays.stream(values())
+                .filter(c -> c.fromCurrency.equalsIgnoreCase(from) && c.toCurrency.equalsIgnoreCase(to))
+                .findFirst();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapter.java
@@ -1,0 +1,69 @@
+package com.stablepay.infrastructure.fx;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.stablepay.domain.model.FxQuote;
+import com.stablepay.domain.port.outbound.FxRateProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExchangeRateApiAdapter implements FxRateProvider {
+
+    private static final BigDecimal FALLBACK_RATE = new BigDecimal("84.50");
+    private static final long CACHE_TTL_SECONDS = 60L;
+
+    private final RestClient exchangeRateRestClient;
+
+    @Override
+    @Cacheable("fxRate")
+    public FxQuote getRate(String fromCurrency, String toCurrency) {
+        try {
+            return fetchLiveRate(fromCurrency, toCurrency);
+        } catch (Exception ex) {
+            log.warn("Failed to fetch live FX rate for {}/{}, using fallback: {}", fromCurrency, toCurrency,
+                    ex.getMessage());
+            return buildFallbackQuote();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private FxQuote fetchLiveRate(String fromCurrency, String toCurrency) {
+        var response = exchangeRateRestClient.get()
+                .uri("/v6/latest/{from}", fromCurrency)
+                .retrieve()
+                .body(Map.class);
+
+        var rates = (Map<String, Object>) response.get("rates");
+        var rateValue = new BigDecimal(rates.get(toCurrency).toString());
+        var now = Instant.now();
+
+        log.info("Fetched live FX rate {}/{}: {}", fromCurrency, toCurrency, rateValue);
+
+        return FxQuote.builder()
+                .rate(rateValue)
+                .source("live")
+                .timestamp(now)
+                .expiresAt(now.plusSeconds(CACHE_TTL_SECONDS))
+                .build();
+    }
+
+    private FxQuote buildFallbackQuote() {
+        var now = Instant.now();
+        return FxQuote.builder()
+                .rate(FALLBACK_RATE)
+                .source("fallback")
+                .timestamp(now)
+                .expiresAt(now.plusSeconds(CACHE_TTL_SECONDS))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapter.java
@@ -25,7 +25,7 @@ public class ExchangeRateApiAdapter implements FxRateProvider {
     private final RestClient exchangeRateRestClient;
 
     @Override
-    @Cacheable("fxRate")
+    @Cacheable(value = "fxRate", unless = "#result.source().equals('fallback')")
     public FxQuote getRate(String fromCurrency, String toCurrency) {
         try {
             return fetchLiveRate(fromCurrency, toCurrency);
@@ -36,14 +36,23 @@ public class ExchangeRateApiAdapter implements FxRateProvider {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private FxQuote fetchLiveRate(String fromCurrency, String toCurrency) {
         var response = exchangeRateRestClient.get()
                 .uri("/v6/latest/{from}", fromCurrency)
                 .retrieve()
                 .body(Map.class);
 
+        if (response == null) {
+            throw new IllegalStateException("Empty response from ExchangeRate API");
+        }
+
+        @SuppressWarnings("unchecked")
         var rates = (Map<String, Object>) response.get("rates");
+
+        if (rates == null || !rates.containsKey(toCurrency)) {
+            throw new IllegalStateException("Currency " + toCurrency + " not found in API response");
+        }
+
         var rateValue = new BigDecimal(rates.get(toCurrency).toString());
         var now = Instant.now();
 

--- a/backend/src/main/java/com/stablepay/infrastructure/fx/FxRateConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/fx/FxRateConfig.java
@@ -1,8 +1,13 @@
 package com.stablepay.infrastructure.fx;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -10,9 +15,17 @@ import org.springframework.web.client.RestClient;
 public class FxRateConfig {
 
     @Bean
-    RestClient exchangeRateRestClient() {
+    RestClient exchangeRateRestClient(@Value("${stablepay.fx.api.base-url}") String baseUrl) {
+        var httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        var requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(10));
+
         return RestClient.builder()
-                .baseUrl("https://open.er-api.com")
+                .baseUrl(baseUrl)
+                .requestFactory(requestFactory)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/fx/FxRateConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/fx/FxRateConfig.java
@@ -1,0 +1,18 @@
+package com.stablepay.infrastructure.fx;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableCaching
+public class FxRateConfig {
+
+    @Bean
+    RestClient exchangeRateRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://open.er-api.com")
+                .build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  cache:
+    type: redis
+    redis:
+      time-to-live: 60s
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,6 +20,11 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
+stablepay:
+  fx:
+    api:
+      base-url: https://open.er-api.com
+
 server:
   port: 8080
 

--- a/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
@@ -55,7 +55,7 @@ class FxRateControllerTest {
         given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/fx/usd-inr"))
+        mockMvc.perform(get("/api/fx/USD-INR"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rate").value(83.25))
                 .andExpect(jsonPath("$.source").value("live"))
@@ -88,7 +88,7 @@ class FxRateControllerTest {
         given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/fx/usd-inr"))
+        mockMvc.perform(get("/api/fx/USD-INR"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rate").value(84.50))
                 .andExpect(jsonPath("$.source").value("fallback"))

--- a/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
@@ -1,0 +1,98 @@
+package com.stablepay.application.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.stablepay.application.mapper.FxRateApiMapper;
+import com.stablepay.domain.model.FxQuote;
+import com.stablepay.domain.port.outbound.FxRateProvider;
+
+@WebMvcTest(FxRateController.class)
+class FxRateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FxRateProvider fxRateProvider;
+
+    @MockitoBean
+    private FxRateApiMapper fxRateApiMapper;
+
+    @Test
+    void shouldReturnLiveFxRate() throws Exception {
+        // given
+        var timestamp = Instant.parse("2026-04-03T10:00:00Z");
+        var expiresAt = Instant.parse("2026-04-03T10:01:00Z");
+        var rate = new BigDecimal("83.25");
+
+        var quote = FxQuote.builder()
+                .rate(rate)
+                .source("live")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        var response = com.stablepay.application.dto.FxRateResponse.builder()
+                .rate(rate)
+                .source("live")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(quote);
+        given(fxRateApiMapper.toResponse(quote)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/fx/usd-inr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rate").value(83.25))
+                .andExpect(jsonPath("$.source").value("live"))
+                .andExpect(jsonPath("$.timestamp").value("2026-04-03T10:00:00Z"))
+                .andExpect(jsonPath("$.expiresAt").value("2026-04-03T10:01:00Z"));
+    }
+
+    @Test
+    void shouldReturnFallbackFxRate() throws Exception {
+        // given
+        var timestamp = Instant.parse("2026-04-03T10:00:00Z");
+        var expiresAt = Instant.parse("2026-04-03T10:01:00Z");
+        var fallbackRate = new BigDecimal("84.50");
+
+        var quote = FxQuote.builder()
+                .rate(fallbackRate)
+                .source("fallback")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        var response = com.stablepay.application.dto.FxRateResponse.builder()
+                .rate(fallbackRate)
+                .source("fallback")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(quote);
+        given(fxRateApiMapper.toResponse(quote)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/fx/usd-inr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rate").value(84.50))
+                .andExpect(jsonPath("$.source").value("fallback"))
+                .andExpect(jsonPath("$.timestamp").value("2026-04-03T10:00:00Z"))
+                .andExpect(jsonPath("$.expiresAt").value("2026-04-03T10:01:00Z"));
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.stablepay.application.mapper.FxRateApiMapper;
+import com.stablepay.domain.exception.UnsupportedCorridorException;
 import com.stablepay.domain.handler.GetFxRateQueryHandler;
 import com.stablepay.domain.model.FxQuote;
 
@@ -94,5 +95,18 @@ class FxRateControllerTest {
                 .andExpect(jsonPath("$.source").value("fallback"))
                 .andExpect(jsonPath("$.timestamp").value("2026-04-03T10:00:00Z"))
                 .andExpect(jsonPath("$.expiresAt").value("2026-04-03T10:01:00Z"));
+    }
+
+    @Test
+    void shouldReturn400ForUnsupportedCorridor() throws Exception {
+        // given
+        given(getFxRateQueryHandler.handle("EUR", "GBP"))
+                .willThrow(UnsupportedCorridorException.forPair("EUR", "GBP"));
+
+        // when / then
+        mockMvc.perform(get("/api/fx/EUR-GBP"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0009"))
+                .andExpect(jsonPath("$.message").value("SP-0009: Unsupported corridor: EUR/GBP"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/FxRateControllerTest.java
@@ -15,8 +15,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.stablepay.application.mapper.FxRateApiMapper;
+import com.stablepay.domain.handler.GetFxRateQueryHandler;
 import com.stablepay.domain.model.FxQuote;
-import com.stablepay.domain.port.outbound.FxRateProvider;
 
 @WebMvcTest(FxRateController.class)
 class FxRateControllerTest {
@@ -25,7 +25,7 @@ class FxRateControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private FxRateProvider fxRateProvider;
+    private GetFxRateQueryHandler getFxRateQueryHandler;
 
     @MockitoBean
     private FxRateApiMapper fxRateApiMapper;
@@ -51,7 +51,7 @@ class FxRateControllerTest {
                 .expiresAt(expiresAt)
                 .build();
 
-        given(fxRateProvider.getRate("USD", "INR")).willReturn(quote);
+        given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
         given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then
@@ -84,7 +84,7 @@ class FxRateControllerTest {
                 .expiresAt(expiresAt)
                 .build();
 
-        given(fxRateProvider.getRate("USD", "INR")).willReturn(quote);
+        given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
         given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then

--- a/backend/src/test/java/com/stablepay/domain/handler/GetFxRateQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/handler/GetFxRateQueryHandlerTest.java
@@ -1,6 +1,7 @@
 package com.stablepay.domain.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import java.math.BigDecimal;
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.exception.UnsupportedCorridorException;
 import com.stablepay.domain.model.FxQuote;
 import com.stablepay.domain.port.outbound.FxRateProvider;
 
@@ -25,7 +27,7 @@ class GetFxRateQueryHandlerTest {
     private GetFxRateQueryHandler handler;
 
     @Test
-    void shouldReturnFxQuoteFromProvider() {
+    void shouldReturnFxQuoteForSupportedCorridor() {
         // given
         var timestamp = Instant.parse("2026-04-03T10:00:00Z");
         var expiresAt = Instant.parse("2026-04-03T10:01:00Z");
@@ -52,5 +54,14 @@ class GetFxRateQueryHandlerTest {
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowForUnsupportedCorridor() {
+        // when / then
+        assertThatThrownBy(() -> handler.handle("EUR", "GBP"))
+                .isInstanceOf(UnsupportedCorridorException.class)
+                .hasMessageContaining("SP-0009")
+                .hasMessageContaining("EUR/GBP");
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/handler/GetFxRateQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/handler/GetFxRateQueryHandlerTest.java
@@ -1,0 +1,56 @@
+package com.stablepay.domain.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.model.FxQuote;
+import com.stablepay.domain.port.outbound.FxRateProvider;
+
+@ExtendWith(MockitoExtension.class)
+class GetFxRateQueryHandlerTest {
+
+    @Mock
+    private FxRateProvider fxRateProvider;
+
+    @InjectMocks
+    private GetFxRateQueryHandler handler;
+
+    @Test
+    void shouldReturnFxQuoteFromProvider() {
+        // given
+        var timestamp = Instant.parse("2026-04-03T10:00:00Z");
+        var expiresAt = Instant.parse("2026-04-03T10:01:00Z");
+        var quote = FxQuote.builder()
+                .rate(new BigDecimal("83.25"))
+                .source("live")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(quote);
+
+        // when
+        var result = handler.handle("USD", "INR");
+
+        // then
+        var expected = FxQuote.builder()
+                .rate(new BigDecimal("83.25"))
+                .source("live")
+                .timestamp(timestamp)
+                .expiresAt(expiresAt)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/model/CorridorTest.java
+++ b/backend/src/test/java/com/stablepay/domain/model/CorridorTest.java
@@ -1,0 +1,35 @@
+package com.stablepay.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CorridorTest {
+
+    @Test
+    void shouldFindUsdInrCorridor() {
+        // when
+        var result = Corridor.find("USD", "INR");
+
+        // then
+        assertThat(result).isPresent().hasValue(Corridor.USD_INR);
+    }
+
+    @Test
+    void shouldFindCorridorCaseInsensitively() {
+        // when
+        var result = Corridor.find("usd", "inr");
+
+        // then
+        assertThat(result).isPresent().hasValue(Corridor.USD_INR);
+    }
+
+    @Test
+    void shouldReturnEmptyForUnsupportedCorridor() {
+        // when
+        var result = Corridor.find("EUR", "GBP");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
@@ -1,0 +1,90 @@
+package com.stablepay.infrastructure.fx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.RequestHeadersSpec;
+import org.springframework.web.client.RestClient.RequestHeadersUriSpec;
+import org.springframework.web.client.RestClient.ResponseSpec;
+
+import com.stablepay.domain.model.FxQuote;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeRateApiAdapterTest {
+
+    @Mock
+    private RestClient exchangeRateRestClient;
+
+    @Mock
+    private RequestHeadersUriSpec<?> requestHeadersUriSpec;
+
+    @Mock
+    private RequestHeadersSpec<?> requestHeadersSpec;
+
+    @Mock
+    private ResponseSpec responseSpec;
+
+    @InjectMocks
+    private ExchangeRateApiAdapter adapter;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldReturnLiveRateFromApi() {
+        // given
+        var apiResponse = Map.of(
+                "result", "success",
+                "rates", Map.of("INR", 83.25));
+
+        given(exchangeRateRestClient.get()).willReturn((RequestHeadersUriSpec) requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri("/v6/latest/{from}", "USD")).willReturn((RequestHeadersSpec) requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(apiResponse);
+
+        // when
+        var result = adapter.getRate("USD", "INR");
+
+        // then
+        var expected = FxQuote.builder()
+                .rate(new BigDecimal("83.25"))
+                .source("live")
+                .timestamp(result.timestamp())
+                .expiresAt(result.expiresAt())
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldReturnFallbackRateWhenApiFails() {
+        // given
+        given(exchangeRateRestClient.get()).willReturn((RequestHeadersUriSpec) requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri("/v6/latest/{from}", "USD")).willThrow(new RuntimeException("API unavailable"));
+
+        // when
+        var result = adapter.getRate("USD", "INR");
+
+        // then
+        var expected = FxQuote.builder()
+                .rate(new BigDecimal("84.50"))
+                .source("fallback")
+                .timestamp(result.timestamp())
+                .expiresAt(result.expiresAt())
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
@@ -21,6 +21,8 @@ import com.stablepay.domain.model.FxQuote;
 @ExtendWith(MockitoExtension.class)
 class ExchangeRateApiAdapterTest {
 
+    private static final long CACHE_TTL_SECONDS = 60L;
+
     @Mock
     private RestClient exchangeRateRestClient;
 
@@ -57,11 +59,14 @@ class ExchangeRateApiAdapterTest {
                 .rate(new BigDecimal("83.25"))
                 .source("live")
                 .timestamp(result.timestamp())
-                .expiresAt(result.expiresAt())
+                .expiresAt(result.timestamp().plusSeconds(CACHE_TTL_SECONDS))
                 .build();
 
+        assertThat(result.timestamp()).isNotNull();
+        assertThat(result.expiresAt()).isEqualTo(result.timestamp().plusSeconds(CACHE_TTL_SECONDS));
         assertThat(result)
                 .usingRecursiveComparison()
+                .ignoringFields("timestamp", "expiresAt")
                 .isEqualTo(expected);
     }
 
@@ -80,11 +85,14 @@ class ExchangeRateApiAdapterTest {
                 .rate(new BigDecimal("84.50"))
                 .source("fallback")
                 .timestamp(result.timestamp())
-                .expiresAt(result.expiresAt())
+                .expiresAt(result.timestamp().plusSeconds(CACHE_TTL_SECONDS))
                 .build();
 
+        assertThat(result.timestamp()).isNotNull();
+        assertThat(result.expiresAt()).isEqualTo(result.timestamp().plusSeconds(CACHE_TTL_SECONDS));
         assertThat(result)
                 .usingRecursiveComparison()
+                .ignoringFields("timestamp", "expiresAt")
                 .isEqualTo(expected);
     }
 }

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -20,6 +20,29 @@ com.stablepay
 - `application` depends on `domain`. It maps API models to domain models and delegates.
 - `infrastructure` depends on `domain`. It implements domain ports and external integrations.
 - Dependencies always point inward: `application` -> `domain` <- `infrastructure`.
+- **Application MUST NOT call infrastructure directly.** The flow is always: `Controller` → `Domain Handler/Service` → `Outbound Port` → `Infrastructure Adapter`. Never skip the domain layer.
+
+### 1.1 Anti-Corruption Layer
+
+Each layer has its own models. MapStruct mappers exist at **each** layer boundary to prevent model leakage:
+
+```
+Application Layer          Domain Layer              Infrastructure Layer
+─────────────────          ────────────              ────────────────────
+CreateWalletRequest   →    (domain model)       →    WalletEntity
+WalletResponse        ←    Wallet               ←    WalletEntity
+FxRateResponse        ←    FxQuote              ←    (external API response)
+
+WalletApiMapper            (no mapper needed      WalletEntityMapper
+(application/mapper/)       when same model)      (infrastructure/persistence/)
+```
+
+**Rules:**
+- Application DTOs (request/response records) live in `application/dto/`
+- Application mappers (API ↔ Domain) live in `application/mapper/`
+- Infrastructure entities live in `infrastructure/persistence/`
+- Infrastructure mappers (Domain ↔ Entity) live in `infrastructure/persistence/`
+- Domain models are the canonical representation — all other layers map to/from them
 
 ## 2. Domain Layer
 
@@ -72,29 +95,63 @@ public interface RemittanceRepository {
 }
 ```
 
-### 2.3 Domain Services
+### 2.3 Command and Query Handlers
 
-Services orchestrate domain logic. They use Spring for DI and transactions.
+Domain logic is organized into **handlers** that separate read and write operations. Handlers are the domain's inbound ports — controllers call them, never outbound ports directly.
+
+**Command Handlers** — mutating operations (create, update, delete):
 
 ```java
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RemittanceServiceImpl implements RemittanceService {
-    private final RemittanceRepository remittanceRepository;
+public class CreateWalletHandler {
     private final WalletRepository walletRepository;
-    private final FxRateProvider fxRateProvider;
+    private final MpcWalletClient mpcWalletClient;
+    private final TreasuryService treasuryService;
+
+    @Transactional
+    public Wallet handle(CreateWalletCommand command) {
+        // orchestrate domain logic
+    }
 }
 ```
 
-**Allowed Spring annotations in domain services:**
+**Query Handlers** — read-only operations (get, list, search):
+
+```java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetFxRateQueryHandler {
+    private final FxRateProvider fxRateProvider;
+
+    public FxQuote handle(String fromCurrency, String toCurrency) {
+        return fxRateProvider.getRate(fromCurrency, toCurrency);
+    }
+}
+```
+
+**Naming conventions:**
+- Commands: `{Action}{Entity}Handler` (e.g., `CreateWalletHandler`, `FundWalletHandler`)
+- Queries: `{Get|List}{Entity}QueryHandler` (e.g., `GetFxRateQueryHandler`, `ListRemittancesQueryHandler`)
+- Command records: `{Action}{Entity}Command` (e.g., `CreateWalletCommand`)
+
+**Rules:**
+- Controllers call handlers. Handlers call outbound ports. **Never skip the handler layer.**
+- Command handlers use `@Transactional`. Query handlers typically do not.
+- Each handler has a single `handle()` method — one handler per use case.
+- Handlers depend only on outbound ports (interfaces), never on infrastructure classes.
+
+**Allowed Spring annotations in domain handlers:**
 - `@Service`, `@Component` — for DI registration
-- `@Transactional` — for transaction management
+- `@Transactional` — for transaction management (commands)
 
 **NOT allowed in domain:**
 - `@RestController`, `@GetMapping`, etc. (application layer only)
 - `@Entity`, `@Table`, `@Column` (infrastructure layer only)
 - `@Autowired` (use `@RequiredArgsConstructor` instead)
+- `@Cacheable` (infrastructure concern — caching belongs in adapters)
 
 ### 2.4 Error Handling
 
@@ -121,25 +178,54 @@ public class InsufficientBalanceException extends RuntimeException {
 
 ### 3.1 REST Controllers
 
-- Delegate all business logic to domain services. Controllers are thin.
-- Use Spring MVC annotations (`@RestController`, `@GetMapping`, etc.).
-- Use `@Valid` for request validation.
-- Return standard types — no `Mono<>` or `Flux<>`.
+Controllers are thin adapters: validate input, map to domain, delegate to handler, map response. **Controllers call domain handlers — never outbound ports or infrastructure directly.**
 
 ```java
 @RestController
-@RequestMapping("/api/remittances")
+@RequestMapping("/api/wallets")
 @RequiredArgsConstructor
-public class RemittanceController {
-    private final RemittanceService remittanceService;
+public class WalletController {
+    private final CreateWalletHandler createWalletHandler;
+    private final FundWalletHandler fundWalletHandler;
+    private final WalletApiMapper mapper;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public RemittanceResponse createRemittance(@Valid @RequestBody CreateRemittanceRequest request) {
-        return remittanceService.create(request);
+    public WalletResponse createWallet(@Valid @RequestBody CreateWalletRequest request) {
+        var command = mapper.toCommand(request);
+        var wallet = createWalletHandler.handle(command);
+        return mapper.toResponse(wallet);
     }
 }
 ```
+
+**Call chain (always):**
+```
+HTTP Request → Controller → Mapper.toDomain() → Handler.handle() → Outbound Port → Adapter
+HTTP Response ← Controller ← Mapper.toResponse() ← Handler result
+```
+
+**Rules:**
+- Use Spring MVC annotations (`@RestController`, `@GetMapping`, etc.)
+- Use `@Valid` for request validation
+- Return standard types — no `Mono<>` or `Flux<>`
+- **Inject domain handlers**, not outbound ports or infrastructure beans
+- Map API DTOs to domain commands/models using application-layer MapStruct mappers
+- Map domain results to API responses using application-layer MapStruct mappers
+
+### 3.2 Application Mappers
+
+Application-layer mappers convert between API DTOs and domain models. They live in `application/mapper/`.
+
+```java
+@Mapper(componentModel = "spring")
+public interface WalletApiMapper {
+    CreateWalletCommand toCommand(CreateWalletRequest request);
+    WalletResponse toResponse(Wallet wallet);
+}
+```
+
+These are separate from infrastructure mappers (which convert domain ↔ entity).
 
 ## 4. Infrastructure Layer
 
@@ -195,23 +281,44 @@ class RemittanceRepositoryAdapter implements RemittanceRepository {
 
 ## 5. Object Mapping
 
-Use **MapStruct** for all layer-boundary mapping. No manual field-by-field mapping.
+Use **MapStruct** for all layer-boundary mapping. No manual field-by-field mapping. **Separate mappers per layer boundary** — never combine application and infrastructure mapping in one mapper.
+
+### 5.1 Application-Layer Mappers (`application/mapper/`)
+
+Convert between API DTOs and domain models:
 
 | Direction | Method name |
 |-----------|-------------|
-| API -> Domain | `toDomain(apiModel)` |
-| Domain -> API | `toResponse(domainModel)` |
-| Entity -> Domain | `toDomain(entity)` |
-| Domain -> Entity | `toEntity(domainModel)` |
+| API Request → Domain Command | `toCommand(request)` |
+| API Request → Domain Model | `toDomain(request)` |
+| Domain Model → API Response | `toResponse(domainModel)` |
 
 ```java
 @Mapper(componentModel = "spring")
-public interface RemittanceMapper {
-    Remittance toDomain(RemittanceEntity entity);
-    RemittanceEntity toEntity(Remittance domain);
-    RemittanceResponse toResponse(Remittance domain);
+public interface WalletApiMapper {
+    CreateWalletCommand toCommand(CreateWalletRequest request);
+    WalletResponse toResponse(Wallet wallet);
 }
 ```
+
+### 5.2 Infrastructure-Layer Mappers (`infrastructure/persistence/`)
+
+Convert between domain models and JPA entities:
+
+| Direction | Method name |
+|-----------|-------------|
+| Entity → Domain | `toDomain(entity)` |
+| Domain → Entity | `toEntity(domainModel)` |
+
+```java
+@Mapper(componentModel = "spring")
+interface RemittanceEntityMapper {
+    Remittance toDomain(RemittanceEntity entity);
+    RemittanceEntity toEntity(Remittance domain);
+}
+```
+
+**Never combine these** — application mapper and infrastructure mapper are separate interfaces in separate packages.
 
 ## 6. Java Conventions
 
@@ -259,8 +366,11 @@ No wildcard imports.
 
 Before submitting code, verify:
 
+- [ ] **Call chain**: Controller → Handler → Outbound Port → Adapter (never skip domain)
+- [ ] **Controllers inject handlers**, not outbound ports or infrastructure beans
+- [ ] **Separate mappers per boundary**: application mapper (API ↔ domain) and infrastructure mapper (domain ↔ entity)
 - [ ] Domain models have zero Spring imports (Lombok only)
-- [ ] Domain services use only `@Service`/`@Transactional` from Spring
+- [ ] Domain handlers use only `@Service`/`@Transactional` from Spring
 - [ ] Domain layer does not import from `application` or `infrastructure`
 - [ ] All mapping uses MapStruct, not manual field copying
 - [ ] Repository interfaces are in `domain/port/outbound/`, implementations in `infrastructure/persistence/`


### PR DESCRIPTION
## STA Issue
Closes #36

## Changes
- Add `GET /api/fx/usd-inr` endpoint — returns live FX rate with source and timestamp
- Implement `ExchangeRateApiAdapter` calling `open.er-api.com/v6/latest/USD` via `RestClient`
- Redis caching with `@Cacheable("fxRate")` and 60s TTL
- Hardcoded fallback rate (84.50) with `source = "fallback"` when API fails
- Add `FxRateConfig` — `@Configuration` + `@EnableCaching` + RestClient bean
- Add `FxRateApiMapper` (MapStruct) for `FxQuote` → `FxRateResponse`
- Add `GlobalExceptionHandler` with `@RestControllerAdvice`
- Configure Redis cache in `application.yml`

## Test plan
- [x] `./gradlew build` passes
- [x] 2 controller tests: `FxRateControllerTest` (live rate, fallback rate)
- [x] 2 adapter tests: `ExchangeRateApiAdapterTest` (live API success, API failure → fallback)
- [x] ArchUnit rules pass (6 rules)
- [x] Spotless formatting applied

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — FX rate endpoint is not deployed yet (hackathon scaffolding phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)