### PR TITLE
STA-33: Add wallet endpoints with handler pattern

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-webmvc-test")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.4.1")
     testImplementation("org.testcontainers:junit-jupiter:1.21.4")
     testImplementation("org.testcontainers:postgresql:1.21.4")

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.stablepay.application.config;
+
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.stablepay.application.dto.ErrorResponse;
+import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(WalletNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleWalletNotFound(WalletNotFoundException ex) {
+        log.warn("Wallet not found: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0006")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(InsufficientBalanceException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInsufficientBalance(InsufficientBalanceException ex) {
+        log.warn("Insufficient balance: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0002")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(TreasuryDepletedException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ErrorResponse handleTreasuryDepleted(TreasuryDepletedException ex) {
+        log.warn("Treasury depleted: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0007")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(WalletAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleWalletAlreadyExists(WalletAlreadyExistsException ex) {
+        log.warn("Wallet already exists: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0008")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(MethodArgumentNotValidException ex) {
+        var message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", message);
+        return ErrorResponse.builder()
+                .errorCode("SP-0400")
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
@@ -1,0 +1,45 @@
+package com.stablepay.application.controller.wallet;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
+import com.stablepay.application.dto.CreateWalletRequest;
+import com.stablepay.application.dto.FundWalletRequest;
+import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.handler.FundWalletHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/wallets")
+@RequiredArgsConstructor
+public class WalletController {
+
+    private final CreateWalletHandler createWalletHandler;
+    private final FundWalletHandler fundWalletHandler;
+    private final WalletApiMapper walletApiMapper;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public WalletResponse createWallet(@Valid @RequestBody CreateWalletRequest request) {
+        var wallet = createWalletHandler.handle(request.userId());
+        return walletApiMapper.toResponse(wallet);
+    }
+
+    @PostMapping("/{id}/fund")
+    public WalletResponse fundWallet(
+            @PathVariable Long id,
+            @Valid @RequestBody FundWalletRequest request) {
+        var wallet = fundWalletHandler.handle(id, request.amount());
+        return walletApiMapper.toResponse(wallet);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
@@ -1,0 +1,11 @@
+package com.stablepay.application.controller.wallet.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.domain.wallet.model.Wallet;
+
+@Mapper(componentModel = "spring")
+public interface WalletApiMapper {
+    WalletResponse toResponse(Wallet wallet);
+}

--- a/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
@@ -1,0 +1,10 @@
+package com.stablepay.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record CreateWalletRequest(
+    @NotBlank String userId
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.stablepay.application.dto;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ErrorResponse(
+    String errorCode,
+    String message
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/FundWalletRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/FundWalletRequest.java
@@ -1,0 +1,13 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record FundWalletRequest(
+    @NotNull @Positive BigDecimal amount
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
@@ -1,0 +1,17 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record WalletResponse(
+    Long id,
+    String userId,
+    String solanaAddress,
+    BigDecimal availableBalance,
+    BigDecimal totalBalance,
+    Instant createdAt,
+    Instant updatedAt
+) {}

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/TreasuryDepletedException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/TreasuryDepletedException.java
@@ -1,0 +1,16 @@
+package com.stablepay.domain.wallet.exception;
+
+import java.math.BigDecimal;
+
+public class TreasuryDepletedException extends RuntimeException {
+
+    public static TreasuryDepletedException insufficientTreasury(
+            BigDecimal requested, BigDecimal available) {
+        return new TreasuryDepletedException(
+                "SP-0007: Treasury depleted. Requested: " + requested + ", Available: " + available);
+    }
+
+    private TreasuryDepletedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletAlreadyExistsException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.stablepay.domain.wallet.exception;
+
+public class WalletAlreadyExistsException extends RuntimeException {
+
+    public static WalletAlreadyExistsException forUserId(String userId) {
+        return new WalletAlreadyExistsException(
+                "SP-0008: Wallet already exists for userId: " + userId);
+    }
+
+    private WalletAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.wallet.exception;
+
+public class WalletNotFoundException extends RuntimeException {
+
+    public static WalletNotFoundException byId(Long id) {
+        return new WalletNotFoundException("SP-0006: Wallet not found: " + id);
+    }
+
+    private WalletNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/handler/CreateWalletHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/handler/CreateWalletHandler.java
@@ -1,0 +1,42 @@
+package com.stablepay.domain.wallet.handler;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.MpcWalletClient;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateWalletHandler {
+
+    private final WalletRepository walletRepository;
+    private final MpcWalletClient mpcWalletClient;
+
+    public Wallet handle(String userId) {
+        walletRepository.findByUserId(userId).ifPresent(existing -> {
+            throw WalletAlreadyExistsException.forUserId(userId);
+        });
+
+        var solanaAddress = mpcWalletClient.generateKey();
+        log.info("Generated MPC wallet for userId={}, solanaAddress={}", userId, solanaAddress);
+
+        var wallet = Wallet.builder()
+                .userId(userId)
+                .solanaAddress(solanaAddress)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+
+        return walletRepository.save(wallet);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/handler/FundWalletHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/handler/FundWalletHandler.java
@@ -1,0 +1,45 @@
+package com.stablepay.domain.wallet.handler;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.TreasuryService;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FundWalletHandler {
+
+    private final WalletRepository walletRepository;
+    private final TreasuryService treasuryService;
+
+    public Wallet handle(Long walletId, BigDecimal amount) {
+        var wallet = walletRepository.findById(walletId)
+                .orElseThrow(() -> WalletNotFoundException.byId(walletId));
+
+        var treasuryBalance = treasuryService.getBalance();
+        if (treasuryBalance.compareTo(amount) < 0) {
+            throw TreasuryDepletedException.insufficientTreasury(amount, treasuryBalance);
+        }
+
+        treasuryService.transferFromTreasury(wallet.solanaAddress(), amount);
+        log.info("Funded wallet id={} with amount={}", walletId, amount);
+
+        var funded = wallet.toBuilder()
+                .availableBalance(wallet.availableBalance().add(amount))
+                .totalBalance(wallet.totalBalance().add(amount))
+                .build();
+
+        return walletRepository.save(funded);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
@@ -1,0 +1,9 @@
+package com.stablepay.domain.wallet.port;
+
+import java.math.BigDecimal;
+
+public interface TreasuryService {
+    void transferFromTreasury(String destinationAddress, BigDecimal amount);
+
+    BigDecimal getBalance();
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -1,0 +1,25 @@
+package com.stablepay.infrastructure.solana;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.wallet.port.TreasuryService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class TreasuryServiceAdapter implements TreasuryService {
+
+    @Override
+    public void transferFromTreasury(String destinationAddress, BigDecimal amount) {
+        log.info("STUB: Transferring {} USDC from treasury to {}", amount, destinationAddress);
+    }
+
+    @Override
+    public BigDecimal getBalance() {
+        log.debug("STUB: Returning treasury balance of 1,000,000 USDC");
+        return BigDecimal.valueOf(1_000_000);
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -1,0 +1,193 @@
+package com.stablepay.application.controller.wallet;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
+import com.stablepay.application.dto.CreateWalletRequest;
+import com.stablepay.application.dto.FundWalletRequest;
+import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.handler.FundWalletHandler;
+import com.stablepay.domain.wallet.model.Wallet;
+
+@WebMvcTest(WalletController.class)
+class WalletControllerTest {
+
+    private static final String SOME_USER_ID = "user-123";
+    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
+    private static final Long SOME_WALLET_ID = 1L;
+    private static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    private static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateWalletHandler createWalletHandler;
+
+    @MockitoBean
+    private FundWalletHandler fundWalletHandler;
+
+    @MockitoBean
+    private WalletApiMapper walletApiMapper;
+
+    @Test
+    void shouldCreateWallet() throws Exception {
+        // given
+        var wallet = Wallet.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        var response = WalletResponse.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
+        given(walletApiMapper.toResponse(wallet)).willReturn(response);
+
+        var request = CreateWalletRequest.builder().userId(SOME_USER_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
+                .andExpect(jsonPath("$.userId").value(SOME_USER_ID))
+                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
+    }
+
+    @Test
+    void shouldFundWallet() throws Exception {
+        // given
+        var fundAmount = BigDecimal.valueOf(500);
+
+        var wallet = Wallet.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(fundAmount)
+                .totalBalance(fundAmount)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        var response = WalletResponse.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(fundAmount)
+                .totalBalance(fundAmount)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount)).willReturn(wallet);
+        given(walletApiMapper.toResponse(wallet)).willReturn(response);
+
+        var request = FundWalletRequest.builder().amount(fundAmount).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
+                .andExpect(jsonPath("$.availableBalance").value(500));
+    }
+
+    @Test
+    void shouldReturn404WhenWalletNotFound() throws Exception {
+        // given
+        var fundAmount = BigDecimal.valueOf(500);
+        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount))
+                .willThrow(WalletNotFoundException.byId(SOME_WALLET_ID));
+
+        var request = FundWalletRequest.builder().amount(fundAmount).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0006"));
+    }
+
+    @Test
+    void shouldReturn400WhenValidationFails() throws Exception {
+        // given
+        var request = CreateWalletRequest.builder().userId("").build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0400"));
+    }
+
+    @Test
+    void shouldReturn503WhenTreasuryDepleted() throws Exception {
+        // given
+        var fundAmount = BigDecimal.valueOf(500);
+        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount))
+                .willThrow(TreasuryDepletedException.insufficientTreasury(
+                        fundAmount, BigDecimal.valueOf(100)));
+
+        var request = FundWalletRequest.builder().amount(fundAmount).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.errorCode").value("SP-0007"));
+    }
+
+    @Test
+    void shouldReturn409WhenWalletAlreadyExists() throws Exception {
+        // given
+        given(createWalletHandler.handle(SOME_USER_ID))
+                .willThrow(WalletAlreadyExistsException.forUserId(SOME_USER_ID));
+
+        var request = CreateWalletRequest.builder().userId(SOME_USER_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0008"));
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
@@ -1,0 +1,100 @@
+package com.stablepay.domain.wallet.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.MpcWalletClient;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CreateWalletHandlerTest {
+
+    private static final String SOME_USER_ID = "user-123";
+    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private MpcWalletClient mpcWalletClient;
+
+    @InjectMocks
+    private CreateWalletHandler createWalletHandler;
+
+    @Test
+    void shouldCreateWallet() {
+        // given
+        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.empty());
+        given(mpcWalletClient.generateKey()).willReturn(SOME_SOLANA_ADDRESS);
+
+        var walletToSave = Wallet.builder()
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+
+        var savedWallet = walletToSave.toBuilder()
+                .id(1L)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        given(walletRepository.save(walletToSave)).willReturn(savedWallet);
+
+        // when
+        var result = createWalletHandler.handle(SOME_USER_ID);
+
+        // then
+        var expected = Wallet.builder()
+                .id(1L)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(mpcWalletClient).should().generateKey();
+        then(walletRepository).should().save(walletToSave);
+    }
+
+    @Test
+    void shouldThrowWhenWalletAlreadyExists() {
+        // given
+        var existingWallet = Wallet.builder()
+                .id(1L)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+
+        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.of(existingWallet));
+
+        // when / then
+        assertThatThrownBy(() -> createWalletHandler.handle(SOME_USER_ID))
+                .isInstanceOf(WalletAlreadyExistsException.class)
+                .hasMessageContaining("SP-0008")
+                .hasMessageContaining(SOME_USER_ID);
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
@@ -1,0 +1,118 @@
+package com.stablepay.domain.wallet.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.TreasuryService;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FundWalletHandlerTest {
+
+    private static final Long SOME_WALLET_ID = 1L;
+    private static final String SOME_USER_ID = "user-123";
+    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
+    private static final BigDecimal SOME_FUND_AMOUNT = BigDecimal.valueOf(500);
+    private static final BigDecimal SOME_TREASURY_BALANCE = BigDecimal.valueOf(1_000_000);
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private TreasuryService treasuryService;
+
+    @InjectMocks
+    private FundWalletHandler fundWalletHandler;
+
+    @Test
+    void shouldFundWallet() {
+        // given
+        var existingWallet = Wallet.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.valueOf(100))
+                .totalBalance(BigDecimal.valueOf(100))
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(treasuryService.getBalance()).willReturn(SOME_TREASURY_BALANCE);
+
+        var fundedWallet = existingWallet.toBuilder()
+                .availableBalance(BigDecimal.valueOf(600))
+                .totalBalance(BigDecimal.valueOf(600))
+                .build();
+
+        given(walletRepository.save(fundedWallet)).willReturn(fundedWallet);
+
+        // when
+        var result = fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT);
+
+        // then
+        var expected = existingWallet.toBuilder()
+                .availableBalance(BigDecimal.valueOf(600))
+                .totalBalance(BigDecimal.valueOf(600))
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(treasuryService).should().transferFromTreasury(SOME_SOLANA_ADDRESS, SOME_FUND_AMOUNT);
+        then(walletRepository).should().save(fundedWallet);
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFound() {
+        // given
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006")
+                .hasMessageContaining(SOME_WALLET_ID.toString());
+    }
+
+    @Test
+    void shouldThrowWhenTreasuryDepleted() {
+        // given
+        var existingWallet = Wallet.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .build();
+
+        var lowTreasuryBalance = BigDecimal.valueOf(100);
+        var requestedAmount = BigDecimal.valueOf(500);
+
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(treasuryService.getBalance()).willReturn(lowTreasuryBalance);
+
+        // when / then
+        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, requestedAmount))
+                .isInstanceOf(TreasuryDepletedException.class)
+                .hasMessageContaining("SP-0007");
+    }
+}


### PR DESCRIPTION
## STA Issue
Closes #33

## Changes
- `CreateWalletHandler`: MPC keygen + duplicate userId check (SP-0008 → 409)
- `FundWalletHandler`: treasury balance check (SP-0007 → 503) + transfer + balance update
- `TreasuryService` outbound port + stub adapter
- `WalletController` with co-located `WalletApiMapper`
- `GlobalExceptionHandler`: 404, 400, 503, 409
- Domain exceptions: `WalletNotFoundException`, `TreasuryDepletedException`, `WalletAlreadyExistsException`
- Follows subdomain package structure: `domain/wallet/{handler,port,exception}`

## Test plan
- [x] `./gradlew build` passes
- [x] 5 handler tests (CreateWalletHandler + FundWalletHandler)
- [x] 6 controller tests (MockMvc: create, fund, 404, 400, 503, 409)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — wallet endpoints not deployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)