### PR TITLE
STA-55: Add shared test fixtures and refactor existing tests

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,3 +6,4 @@ out/
 *.jar
 !gradle/wrapper/gradle-wrapper.jar
 *.war
+backend/.idea/

--- a/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,7 @@ import com.stablepay.application.controller.fx.mapper.FxRateApiMapper;
 import com.stablepay.application.dto.FxRateResponse;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.fx.handler.GetFxRateQueryHandler;
-import com.stablepay.domain.fx.model.FxQuote;
+import com.stablepay.testutil.FxQuoteFixtures;
 
 @WebMvcTest(FxRateController.class)
 class FxRateControllerTest {
@@ -35,19 +34,14 @@ class FxRateControllerTest {
     @Test
     void shouldReturnLiveFxRate() throws Exception {
         // given
-        var now = Instant.parse("2026-04-03T10:00:00Z");
-        var expiresAt = now.plusSeconds(60);
-        var quote = FxQuote.builder()
-                .rate(BigDecimal.valueOf(83.25))
+        var quote = FxQuoteFixtures.fxQuoteBuilder()
                 .source("open.er-api.com")
-                .timestamp(now)
-                .expiresAt(expiresAt)
                 .build();
         var response = FxRateResponse.builder()
-                .rate(BigDecimal.valueOf(83.25))
+                .rate(FxQuoteFixtures.SOME_RATE)
                 .source("open.er-api.com")
-                .timestamp(now)
-                .expiresAt(expiresAt)
+                .timestamp(FxQuoteFixtures.SOME_TIMESTAMP)
+                .expiresAt(FxQuoteFixtures.SOME_EXPIRES_AT)
                 .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
@@ -63,19 +57,15 @@ class FxRateControllerTest {
     @Test
     void shouldReturnFallbackFxRate() throws Exception {
         // given
-        var now = Instant.parse("2026-04-03T10:00:00Z");
-        var expiresAt = now.plusSeconds(60);
-        var quote = FxQuote.builder()
+        var quote = FxQuoteFixtures.fxQuoteBuilder()
                 .rate(BigDecimal.valueOf(84.50))
                 .source("fallback")
-                .timestamp(now)
-                .expiresAt(expiresAt)
                 .build();
         var response = FxRateResponse.builder()
                 .rate(BigDecimal.valueOf(84.50))
                 .source("fallback")
-                .timestamp(now)
-                .expiresAt(expiresAt)
+                .timestamp(FxQuoteFixtures.SOME_TIMESTAMP)
+                .expiresAt(FxQuoteFixtures.SOME_EXPIRES_AT)
                 .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,16 +24,12 @@ import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
 import com.stablepay.domain.wallet.handler.FundWalletHandler;
-import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.testutil.WalletFixtures;
 
 @WebMvcTest(WalletController.class)
 class WalletControllerTest {
 
-    private static final String SOME_USER_ID = "user-123";
-    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
-    private static final Long SOME_WALLET_ID = 1L;
-    private static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
-    private static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    private static final BigDecimal SOME_FUND_AMOUNT = BigDecimal.valueOf(500);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -53,91 +48,81 @@ class WalletControllerTest {
     @Test
     void shouldCreateWallet() throws Exception {
         // given
-        var wallet = Wallet.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+        var wallet = WalletFixtures.walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
                 .build();
 
         var response = WalletResponse.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .id(WalletFixtures.SOME_WALLET_ID)
+                .userId(WalletFixtures.SOME_USER_ID)
+                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
+                .createdAt(WalletFixtures.SOME_CREATED_AT)
+                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
                 .build();
 
-        given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
+        given(createWalletHandler.handle(WalletFixtures.SOME_USER_ID)).willReturn(wallet);
         given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
-        var request = CreateWalletRequest.builder().userId(SOME_USER_ID).build();
+        var request = CreateWalletRequest.builder()
+                .userId(WalletFixtures.SOME_USER_ID)
+                .build();
 
         // when / then
         mockMvc.perform(post("/api/wallets")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.userId").value(SOME_USER_ID))
-                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
+                .andExpect(jsonPath("$.id").value(WalletFixtures.SOME_WALLET_ID))
+                .andExpect(jsonPath("$.userId").value(WalletFixtures.SOME_USER_ID))
+                .andExpect(jsonPath("$.solanaAddress").value(WalletFixtures.SOME_SOLANA_ADDRESS));
     }
 
     @Test
     void shouldFundWallet() throws Exception {
         // given
-        var fundAmount = BigDecimal.valueOf(500);
-
-        var wallet = Wallet.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(fundAmount)
-                .totalBalance(fundAmount)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
+        var wallet = WalletFixtures.walletBuilder()
+                .availableBalance(SOME_FUND_AMOUNT)
+                .totalBalance(SOME_FUND_AMOUNT)
                 .build();
 
         var response = WalletResponse.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(fundAmount)
-                .totalBalance(fundAmount)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
+                .id(WalletFixtures.SOME_WALLET_ID)
+                .userId(WalletFixtures.SOME_USER_ID)
+                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                .availableBalance(SOME_FUND_AMOUNT)
+                .totalBalance(SOME_FUND_AMOUNT)
+                .createdAt(WalletFixtures.SOME_CREATED_AT)
+                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
                 .build();
 
-        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount)).willReturn(wallet);
+        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
+                .willReturn(wallet);
         given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
-        var request = FundWalletRequest.builder().amount(fundAmount).build();
+        var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
+                .andExpect(jsonPath("$.id").value(WalletFixtures.SOME_WALLET_ID))
                 .andExpect(jsonPath("$.availableBalance").value(500));
     }
 
     @Test
     void shouldReturn404WhenWalletNotFound() throws Exception {
         // given
-        var fundAmount = BigDecimal.valueOf(500);
-        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount))
-                .willThrow(WalletNotFoundException.byId(SOME_WALLET_ID));
+        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
+                .willThrow(WalletNotFoundException.byId(WalletFixtures.SOME_WALLET_ID));
 
-        var request = FundWalletRequest.builder().amount(fundAmount).build();
+        var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -160,15 +145,14 @@ class WalletControllerTest {
     @Test
     void shouldReturn503WhenTreasuryDepleted() throws Exception {
         // given
-        var fundAmount = BigDecimal.valueOf(500);
-        given(fundWalletHandler.handle(SOME_WALLET_ID, fundAmount))
+        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
                 .willThrow(TreasuryDepletedException.insufficientTreasury(
-                        fundAmount, BigDecimal.valueOf(100)));
+                        SOME_FUND_AMOUNT, BigDecimal.valueOf(100)));
 
-        var request = FundWalletRequest.builder().amount(fundAmount).build();
+        var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isServiceUnavailable())
@@ -178,10 +162,12 @@ class WalletControllerTest {
     @Test
     void shouldReturn409WhenWalletAlreadyExists() throws Exception {
         // given
-        given(createWalletHandler.handle(SOME_USER_ID))
-                .willThrow(WalletAlreadyExistsException.forUserId(SOME_USER_ID));
+        given(createWalletHandler.handle(WalletFixtures.SOME_USER_ID))
+                .willThrow(WalletAlreadyExistsException.forUserId(WalletFixtures.SOME_USER_ID));
 
-        var request = CreateWalletRequest.builder().userId(SOME_USER_ID).build();
+        var request = CreateWalletRequest.builder()
+                .userId(WalletFixtures.SOME_USER_ID)
+                .build();
 
         // when / then
         mockMvc.perform(post("/api/wallets")

--- a/backend/src/test/java/com/stablepay/domain/claim/model/ClaimTokenTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/model/ClaimTokenTest.java
@@ -3,39 +3,21 @@ package com.stablepay.domain.claim.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+
+import com.stablepay.testutil.ClaimTokenFixtures;
 
 class ClaimTokenTest {
 
     @Test
     void shouldCreateClaimTokenWithExpiry() {
-        // given
-        var token = UUID.randomUUID().toString();
-        var remittanceId = UUID.randomUUID();
-        var now = Instant.now();
-        var expiresAt = now.plus(48, ChronoUnit.HOURS);
-
-        // when
-        var claimToken = ClaimToken.builder()
-                .remittanceId(remittanceId)
-                .token(token)
-                .claimed(false)
-                .createdAt(now)
-                .expiresAt(expiresAt)
-                .build();
+        // given / when
+        var claimToken = ClaimTokenFixtures.claimTokenBuilder().build();
 
         // then
-        var expected = ClaimToken.builder()
-                .remittanceId(remittanceId)
-                .token(token)
-                .claimed(false)
-                .createdAt(now)
-                .expiresAt(expiresAt)
-                .build();
+        var expected = ClaimTokenFixtures.claimTokenBuilder().build();
 
         assertThat(claimToken)
                 .usingRecursiveComparison()
@@ -48,8 +30,7 @@ class ClaimTokenTest {
         var token = UUID.randomUUID().toString();
 
         // when
-        var claimToken = ClaimToken.builder()
-                .remittanceId(UUID.randomUUID())
+        var claimToken = ClaimTokenFixtures.claimTokenBuilder()
                 .token(token)
                 .build();
 
@@ -62,7 +43,7 @@ class ClaimTokenTest {
     void shouldThrowWhenRemittanceIdIsNull() {
         // when / then
         assertThatThrownBy(() -> ClaimToken.builder()
-                .token("some-token")
+                .token(ClaimTokenFixtures.SOME_TOKEN)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("remittanceId");
@@ -72,7 +53,7 @@ class ClaimTokenTest {
     void shouldThrowWhenTokenIsNull() {
         // when / then
         assertThatThrownBy(() -> ClaimToken.builder()
-                .remittanceId(UUID.randomUUID())
+                .remittanceId(ClaimTokenFixtures.SOME_REMITTANCE_ID)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("token");

--- a/backend/src/test/java/com/stablepay/domain/fx/handler/GetFxRateQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/fx/handler/GetFxRateQueryHandlerTest.java
@@ -4,9 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
-import java.math.BigDecimal;
-import java.time.Instant;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,8 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
-import com.stablepay.domain.fx.model.FxQuote;
 import com.stablepay.domain.fx.port.FxRateProvider;
+import com.stablepay.testutil.FxQuoteFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class GetFxRateQueryHandlerTest {
@@ -29,12 +26,8 @@ class GetFxRateQueryHandlerTest {
     @Test
     void shouldReturnFxQuoteForSupportedCorridor() {
         // given
-        var now = Instant.now();
-        var expectedQuote = FxQuote.builder()
-                .rate(BigDecimal.valueOf(83.25))
+        var expectedQuote = FxQuoteFixtures.fxQuoteBuilder()
                 .source("open.er-api.com")
-                .timestamp(now)
-                .expiresAt(now.plusSeconds(60))
                 .build();
         given(fxRateProvider.getRate("USD", "INR")).willReturn(expectedQuote);
 

--- a/backend/src/test/java/com/stablepay/domain/remittance/model/RemittanceTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/model/RemittanceTest.java
@@ -3,45 +3,19 @@ package com.stablepay.domain.remittance.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
+
+import com.stablepay.testutil.RemittanceFixtures;
 
 class RemittanceTest {
 
     @Test
     void shouldCreateRemittanceWithInitiatedStatus() {
-        // given
-        var remittanceId = UUID.randomUUID();
-        var now = Instant.now();
-
-        // when
-        var remittance = Remittance.builder()
-                .remittanceId(remittanceId)
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
-                .amountInr(BigDecimal.valueOf(8450))
-                .fxRate(BigDecimal.valueOf(84.50))
-                .status(RemittanceStatus.INITIATED)
-                .smsNotificationFailed(false)
-                .createdAt(now)
-                .build();
+        // given / when
+        var remittance = RemittanceFixtures.remittanceBuilder().build();
 
         // then
-        var expected = Remittance.builder()
-                .remittanceId(remittanceId)
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
-                .amountInr(BigDecimal.valueOf(8450))
-                .fxRate(BigDecimal.valueOf(84.50))
-                .status(RemittanceStatus.INITIATED)
-                .smsNotificationFailed(false)
-                .createdAt(now)
-                .build();
+        var expected = RemittanceFixtures.remittanceBuilder().build();
 
         assertThat(remittance)
                 .usingRecursiveComparison()
@@ -51,13 +25,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromInitiatedToEscrowed() {
         // given
-        var remittance = Remittance.builder()
-                .remittanceId(UUID.randomUUID())
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
-                .status(RemittanceStatus.INITIATED)
-                .build();
+        var remittance = RemittanceFixtures.remittanceBuilder().build();
 
         // when
         var escrowed = remittance.toBuilder()
@@ -79,11 +47,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromEscrowedToClaimed() {
         // given
-        var remittance = Remittance.builder()
-                .remittanceId(UUID.randomUUID())
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
+        var remittance = RemittanceFixtures.remittanceBuilder()
                 .status(RemittanceStatus.ESCROWED)
                 .build();
 
@@ -105,11 +69,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromClaimedToDelivered() {
         // given
-        var remittance = Remittance.builder()
-                .remittanceId(UUID.randomUUID())
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
+        var remittance = RemittanceFixtures.remittanceBuilder()
                 .status(RemittanceStatus.CLAIMED)
                 .build();
 
@@ -132,9 +92,9 @@ class RemittanceTest {
     void shouldThrowWhenRemittanceIdIsNull() {
         // when / then
         assertThatThrownBy(() -> Remittance.builder()
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
+                .senderId(RemittanceFixtures.SOME_SENDER_ID)
+                .recipientPhone(RemittanceFixtures.SOME_RECIPIENT_PHONE)
+                .amountUsdc(RemittanceFixtures.SOME_AMOUNT_USDC)
                 .status(RemittanceStatus.INITIATED)
                 .build())
                 .isInstanceOf(NullPointerException.class)
@@ -145,10 +105,10 @@ class RemittanceTest {
     void shouldThrowWhenStatusIsNull() {
         // when / then
         assertThatThrownBy(() -> Remittance.builder()
-                .remittanceId(UUID.randomUUID())
-                .senderId("user-1")
-                .recipientPhone("+919876543210")
-                .amountUsdc(BigDecimal.valueOf(100))
+                .remittanceId(RemittanceFixtures.SOME_REMITTANCE_ID)
+                .senderId(RemittanceFixtures.SOME_SENDER_ID)
+                .recipientPhone(RemittanceFixtures.SOME_RECIPIENT_PHONE)
+                .amountUsdc(RemittanceFixtures.SOME_AMOUNT_USDC)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("status");

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -19,12 +18,10 @@ import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.testutil.WalletFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class CreateWalletHandlerTest {
-
-    private static final String SOME_USER_ID = "user-123";
-    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
 
     @Mock
     private WalletRepository walletRepository;
@@ -38,36 +35,36 @@ class CreateWalletHandlerTest {
     @Test
     void shouldCreateWallet() {
         // given
-        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.empty());
-        given(mpcWalletClient.generateKey()).willReturn(SOME_SOLANA_ADDRESS);
+        given(walletRepository.findByUserId(WalletFixtures.SOME_USER_ID)).willReturn(Optional.empty());
+        given(mpcWalletClient.generateKey()).willReturn(WalletFixtures.SOME_SOLANA_ADDRESS);
 
         var walletToSave = Wallet.builder()
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .userId(WalletFixtures.SOME_USER_ID)
+                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
         var savedWallet = walletToSave.toBuilder()
-                .id(1L)
-                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
-                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .id(WalletFixtures.SOME_WALLET_ID)
+                .createdAt(WalletFixtures.SOME_CREATED_AT)
+                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
                 .build();
 
         given(walletRepository.save(walletToSave)).willReturn(savedWallet);
 
         // when
-        var result = createWalletHandler.handle(SOME_USER_ID);
+        var result = createWalletHandler.handle(WalletFixtures.SOME_USER_ID);
 
         // then
         var expected = Wallet.builder()
-                .id(1L)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .id(WalletFixtures.SOME_WALLET_ID)
+                .userId(WalletFixtures.SOME_USER_ID)
+                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
-                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                .createdAt(WalletFixtures.SOME_CREATED_AT)
+                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
                 .build();
 
         assertThat(result)
@@ -81,20 +78,18 @@ class CreateWalletHandlerTest {
     @Test
     void shouldThrowWhenWalletAlreadyExists() {
         // given
-        var existingWallet = Wallet.builder()
-                .id(1L)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+        var existingWallet = WalletFixtures.walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.of(existingWallet));
+        given(walletRepository.findByUserId(WalletFixtures.SOME_USER_ID))
+                .willReturn(Optional.of(existingWallet));
 
         // when / then
-        assertThatThrownBy(() -> createWalletHandler.handle(SOME_USER_ID))
+        assertThatThrownBy(() -> createWalletHandler.handle(WalletFixtures.SOME_USER_ID))
                 .isInstanceOf(WalletAlreadyExistsException.class)
                 .hasMessageContaining("SP-0008")
-                .hasMessageContaining(SOME_USER_ID);
+                .hasMessageContaining(WalletFixtures.SOME_USER_ID);
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -17,16 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
-import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.TreasuryService;
 import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.testutil.WalletFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class FundWalletHandlerTest {
 
-    private static final Long SOME_WALLET_ID = 1L;
-    private static final String SOME_USER_ID = "user-123";
-    private static final String SOME_SOLANA_ADDRESS = "SoLaNaAdDrEsS123456789";
     private static final BigDecimal SOME_FUND_AMOUNT = BigDecimal.valueOf(500);
     private static final BigDecimal SOME_TREASURY_BALANCE = BigDecimal.valueOf(1_000_000);
 
@@ -42,17 +38,10 @@ class FundWalletHandlerTest {
     @Test
     void shouldFundWallet() {
         // given
-        var existingWallet = Wallet.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(BigDecimal.valueOf(100))
-                .totalBalance(BigDecimal.valueOf(100))
-                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
-                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
-                .build();
+        var existingWallet = WalletFixtures.walletBuilder().build();
 
-        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID))
+                .willReturn(Optional.of(existingWallet));
         given(treasuryService.getBalance()).willReturn(SOME_TREASURY_BALANCE);
 
         var fundedWallet = existingWallet.toBuilder()
@@ -63,7 +52,7 @@ class FundWalletHandlerTest {
         given(walletRepository.save(fundedWallet)).willReturn(fundedWallet);
 
         // when
-        var result = fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT);
+        var result = fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT);
 
         // then
         var expected = existingWallet.toBuilder()
@@ -75,43 +64,40 @@ class FundWalletHandlerTest {
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
 
-        then(treasuryService).should().transferFromTreasury(SOME_SOLANA_ADDRESS, SOME_FUND_AMOUNT);
+        then(treasuryService).should()
+                .transferFromTreasury(WalletFixtures.SOME_SOLANA_ADDRESS, SOME_FUND_AMOUNT);
         then(walletRepository).should().save(fundedWallet);
     }
 
     @Test
     void shouldThrowWhenWalletNotFound() {
         // given
-        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
+        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
+        assertThatThrownBy(() -> fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
                 .isInstanceOf(WalletNotFoundException.class)
                 .hasMessageContaining("SP-0006")
-                .hasMessageContaining(SOME_WALLET_ID.toString());
+                .hasMessageContaining(WalletFixtures.SOME_WALLET_ID.toString());
     }
 
     @Test
     void shouldThrowWhenTreasuryDepleted() {
         // given
-        var existingWallet = Wallet.builder()
-                .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
+        var existingWallet = WalletFixtures.walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(Instant.parse("2026-04-03T10:00:00Z"))
-                .updatedAt(Instant.parse("2026-04-03T10:00:00Z"))
                 .build();
 
         var lowTreasuryBalance = BigDecimal.valueOf(100);
         var requestedAmount = BigDecimal.valueOf(500);
 
-        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(existingWallet));
+        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID))
+                .willReturn(Optional.of(existingWallet));
         given(treasuryService.getBalance()).willReturn(lowTreasuryBalance);
 
         // when / then
-        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, requestedAmount))
+        assertThatThrownBy(() -> fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, requestedAmount))
                 .isInstanceOf(TreasuryDepletedException.class)
                 .hasMessageContaining("SP-0007");
     }

--- a/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+import com.stablepay.testutil.WalletFixtures;
 
 class WalletTest {
 
@@ -18,12 +19,7 @@ class WalletTest {
         @Test
         void shouldReserveBalanceSuccessfully() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
-                    .availableBalance(BigDecimal.valueOf(100))
-                    .build();
+            var wallet = WalletFixtures.walletBuilder().build();
 
             // when
             var reserved = wallet.reserveBalance(BigDecimal.valueOf(60));
@@ -41,10 +37,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingMoreThanAvailable() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
+            var wallet = WalletFixtures.walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -57,12 +50,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingNegativeAmount() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
-                    .availableBalance(BigDecimal.valueOf(100))
-                    .build();
+            var wallet = WalletFixtures.walletBuilder().build();
 
             // when / then
             assertThatThrownBy(() -> wallet.reserveBalance(BigDecimal.valueOf(-10)))
@@ -73,12 +61,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingZeroAmount() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
-                    .availableBalance(BigDecimal.valueOf(100))
-                    .build();
+            var wallet = WalletFixtures.walletBuilder().build();
 
             // when / then
             assertThatThrownBy(() -> wallet.reserveBalance(BigDecimal.ZERO))
@@ -93,10 +76,7 @@ class WalletTest {
         @Test
         void shouldReleaseBalanceSuccessfully() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
+            var wallet = WalletFixtures.walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -116,10 +96,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReleasingExceedsTotalBalance() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
+            var wallet = WalletFixtures.walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -132,10 +109,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReleasingNegativeAmount() {
             // given
-            var wallet = Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
-                    .totalBalance(BigDecimal.valueOf(100))
+            var wallet = WalletFixtures.walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -153,7 +127,7 @@ class WalletTest {
         void shouldThrowWhenUserIdIsNull() {
             // when / then
             assertThatThrownBy(() -> Wallet.builder()
-                    .solanaAddress("SomeAddress123")
+                    .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
                     .availableBalance(BigDecimal.ZERO)
                     .totalBalance(BigDecimal.ZERO)
                     .build())
@@ -165,8 +139,8 @@ class WalletTest {
         void shouldThrowWhenAvailableBalanceIsNull() {
             // when / then
             assertThatThrownBy(() -> Wallet.builder()
-                    .userId("user-1")
-                    .solanaAddress("SomeAddress123")
+                    .userId(WalletFixtures.SOME_USER_ID)
+                    .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
                     .totalBalance(BigDecimal.ZERO)
                     .build())
                     .isInstanceOf(NullPointerException.class)

--- a/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
@@ -16,6 +16,7 @@ import org.springframework.web.client.RestClient;
 
 import com.stablepay.domain.fx.model.FxQuote;
 import com.stablepay.infrastructure.fx.ExchangeRateApiAdapter.ExchangeRateResponse;
+import com.stablepay.testutil.FxQuoteFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class ExchangeRateApiAdapterTest {
@@ -45,7 +46,7 @@ class ExchangeRateApiAdapterTest {
         // given
         var apiResponse = new ExchangeRateResponse(
                 "success",
-                Map.of("INR", BigDecimal.valueOf(83.25)));
+                Map.of("INR", FxQuoteFixtures.SOME_RATE));
 
         given(fxRestClient.get()).willReturn(requestHeadersUriSpec);
         given(requestHeadersUriSpec.uri("/v6/latest/{from}", "USD")).willReturn(requestHeadersSpec);
@@ -57,7 +58,7 @@ class ExchangeRateApiAdapterTest {
 
         // then
         var expected = FxQuote.builder()
-                .rate(BigDecimal.valueOf(83.25))
+                .rate(FxQuoteFixtures.SOME_RATE)
                 .source("open.er-api.com")
                 .timestamp(result.timestamp())
                 .expiresAt(result.timestamp().plusSeconds(60))

--- a/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
@@ -1,0 +1,25 @@
+package com.stablepay.testutil;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.claim.model.ClaimToken;
+
+public final class ClaimTokenFixtures {
+
+    private ClaimTokenFixtures() {}
+
+    public static final UUID SOME_REMITTANCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    public static final String SOME_TOKEN = "claim-token-abc-123";
+    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-04-05T10:00:00Z");
+
+    public static ClaimToken.ClaimTokenBuilder claimTokenBuilder() {
+        return ClaimToken.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .token(SOME_TOKEN)
+                .claimed(false)
+                .createdAt(SOME_CREATED_AT)
+                .expiresAt(SOME_EXPIRES_AT);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/FxQuoteFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/FxQuoteFixtures.java
@@ -1,0 +1,24 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import com.stablepay.domain.fx.model.FxQuote;
+
+public final class FxQuoteFixtures {
+
+    private FxQuoteFixtures() {}
+
+    public static final BigDecimal SOME_RATE = new BigDecimal("83.25");
+    public static final String SOME_SOURCE = "live";
+    public static final Instant SOME_TIMESTAMP = Instant.parse("2026-04-03T10:00:00Z");
+    public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-04-03T10:01:00Z");
+
+    public static FxQuote.FxQuoteBuilder fxQuoteBuilder() {
+        return FxQuote.builder()
+                .rate(SOME_RATE)
+                .source(SOME_SOURCE)
+                .timestamp(SOME_TIMESTAMP)
+                .expiresAt(SOME_EXPIRES_AT);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
@@ -1,0 +1,33 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+public final class RemittanceFixtures {
+
+    private RemittanceFixtures() {}
+
+    public static final UUID SOME_REMITTANCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    public static final String SOME_SENDER_ID = "user-42";
+    public static final String SOME_RECIPIENT_PHONE = "+919876543210";
+    public static final BigDecimal SOME_AMOUNT_USDC = BigDecimal.valueOf(100);
+    public static final BigDecimal SOME_AMOUNT_INR = BigDecimal.valueOf(8450);
+    public static final BigDecimal SOME_FX_RATE = new BigDecimal("84.50");
+    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+
+    public static Remittance.RemittanceBuilder remittanceBuilder() {
+        return Remittance.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .createdAt(SOME_CREATED_AT);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
@@ -1,0 +1,29 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import com.stablepay.domain.wallet.model.Wallet;
+
+public final class WalletFixtures {
+
+    private WalletFixtures() {}
+
+    public static final Long SOME_WALLET_ID = 1L;
+    public static final String SOME_USER_ID = "user-42";
+    public static final String SOME_SOLANA_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
+    public static final BigDecimal SOME_BALANCE = BigDecimal.valueOf(100);
+    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    public static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+
+    public static Wallet.WalletBuilder walletBuilder() {
+        return Wallet.builder()
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(SOME_BALANCE)
+                .totalBalance(SOME_BALANCE)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT);
+    }
+}


### PR DESCRIPTION
## STA Issue
Closes #55

## Changes
- `WalletFixtures`, `RemittanceFixtures`, `ClaimTokenFixtures`, `FxQuoteFixtures` in `src/testFixtures/`
- `SOME_*` constants + builder factory methods per aggregate
- Refactored all 9 existing test files to use shared fixtures (net -22 lines)
- Added `.idea/` to `.gitignore`

## Test plan
- [x] `./gradlew build` passes (all tests green)
- [x] testFixtures source set compiles and is importable from test/
- [x] Spotless formatting applied

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — test infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)