### PR TITLE
STA-55/56: Add test fixtures, integration tests, and WireMock

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,4 +6,4 @@ out/
 *.jar
 !gradle/wrapper/gradle-wrapper.jar
 *.war
-backend/.idea/
+.idea/

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 spotless {
     java {
         removeUnusedImports()
-        importOrder("java|javax", "jakarta", "org", "com", "")
+        importOrder("\\#", "java|javax", "jakarta", "org", "com", "")
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -95,6 +95,7 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     // Flyway
+    implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.flywaydb:flyway-core:12.1.1")
     implementation("org.flywaydb:flyway-database-postgresql:12.1.1")
 
@@ -119,4 +120,8 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:1.21.4")
     testImplementation("org.testcontainers:postgresql:1.21.4")
     testImplementation("io.temporal:temporal-testing:1.33.0")
+
+    // Integration test dependencies
+    "integrationTestImplementation"(testFixtures(project))
+    "integrationTestImplementation"("org.wiremock:wiremock-standalone:3.13.0")
 }

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.stablepay.infrastructure.db.wallet;
+
+import static com.stablepay.testutil.WalletFixtures.SOME_BALANCE;
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.test.PgTest;
+
+@PgTest
+@Transactional
+class WalletRepositoryIntegrationTest {
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Test
+    void shouldSaveAndFindWalletById() {
+        // given
+        var wallet = Wallet.builder()
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+
+        // when
+        var saved = walletRepository.save(wallet);
+        var found = walletRepository.findById(saved.id());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get())
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(saved);
+    }
+
+    @Test
+    void shouldFindWalletByUserId() {
+        // given
+        var wallet = Wallet.builder()
+                .userId("unique-user-" + System.nanoTime())
+                .solanaAddress("addr-" + System.nanoTime())
+                .availableBalance(SOME_BALANCE)
+                .totalBalance(SOME_BALANCE)
+                .build();
+        walletRepository.save(wallet);
+
+        // when
+        var found = walletRepository.findByUserId(wallet.userId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().userId()).isEqualTo(wallet.userId());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenWalletNotFound() {
+        // when
+        var found = walletRepository.findById(999999L);
+
+        // then
+        assertThat(found).isEmpty();
+    }
+}

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/fx/ExchangeRateApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/fx/ExchangeRateApiIntegrationTest.java
@@ -7,12 +7,15 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -41,6 +44,17 @@ class ExchangeRateApiIntegrationTest {
 
     @Autowired
     private FxRateProvider fxRateProvider;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void clearCaches() {
+        cacheManager.getCacheNames().stream()
+                .map(cacheManager::getCache)
+                .filter(Objects::nonNull)
+                .forEach(org.springframework.cache.Cache::clear);
+    }
 
     @Test
     void shouldReturnLiveRateFromApi() {

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/fx/ExchangeRateApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/fx/ExchangeRateApiIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.stablepay.infrastructure.fx;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.stablepay.domain.fx.port.FxRateProvider;
+import com.stablepay.test.IntegrationTestConfig;
+import com.stablepay.test.PostgresContainerExtension;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@ExtendWith(PostgresContainerExtension.class)
+@Import(IntegrationTestConfig.class)
+class ExchangeRateApiIntegrationTest {
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("stablepay.fx.api.base-url", wireMock::baseUrl);
+    }
+
+    @Autowired
+    private FxRateProvider fxRateProvider;
+
+    @Test
+    void shouldReturnLiveRateFromApi() {
+        // given
+        wireMock.stubFor(get(urlPathEqualTo("/v6/latest/USD"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "result": "success",
+                                    "rates": {
+                                        "INR": 83.25
+                                    }
+                                }
+                                """)));
+
+        // when
+        var quote = fxRateProvider.getRate("USD", "INR");
+
+        // then
+        assertThat(quote.rate()).isEqualByComparingTo(new BigDecimal("83.25"));
+        assertThat(quote.source()).isEqualTo("open.er-api.com");
+    }
+
+    @Test
+    void shouldReturnFallbackWhenApiReturns500() {
+        // given
+        wireMock.stubFor(get(urlPathEqualTo("/v6/latest/USD"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withBody("Internal Server Error")));
+
+        // when
+        var quote = fxRateProvider.getRate("USD", "INR");
+
+        // then
+        assertThat(quote.rate()).isEqualByComparingTo(new BigDecimal("84.50"));
+        assertThat(quote.source()).isEqualTo("fallback");
+    }
+
+    @Test
+    void shouldReturnFallbackWhenApiTimesOut() {
+        // given
+        wireMock.stubFor(get(urlPathEqualTo("/v6/latest/USD"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withFixedDelay(15000)
+                        .withBody("""
+                                {
+                                    "result": "success",
+                                    "rates": {
+                                        "INR": 83.25
+                                    }
+                                }
+                                """)));
+
+        // when
+        var quote = fxRateProvider.getRate("USD", "INR");
+
+        // then
+        assertThat(quote.rate()).isEqualByComparingTo(new BigDecimal("84.50"));
+        assertThat(quote.source()).isEqualTo("fallback");
+    }
+}

--- a/backend/src/integration-test/java/com/stablepay/test/IntegrationTestConfig.java
+++ b/backend/src/integration-test/java/com/stablepay/test/IntegrationTestConfig.java
@@ -2,6 +2,8 @@ package com.stablepay.test;
 
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 
 import com.stablepay.domain.common.port.SmsProvider;
@@ -18,5 +20,10 @@ public class IntegrationTestConfig {
     @Bean
     public SmsProvider smsProvider() {
         return Mockito.mock(SmsProvider.class);
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager();
     }
 }

--- a/backend/src/integration-test/java/com/stablepay/test/IntegrationTestConfig.java
+++ b/backend/src/integration-test/java/com/stablepay/test/IntegrationTestConfig.java
@@ -1,0 +1,22 @@
+package com.stablepay.test;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.stablepay.domain.common.port.SmsProvider;
+import com.stablepay.domain.wallet.port.MpcWalletClient;
+
+@TestConfiguration
+public class IntegrationTestConfig {
+
+    @Bean
+    public MpcWalletClient mpcWalletClient() {
+        return Mockito.mock(MpcWalletClient.class);
+    }
+
+    @Bean
+    public SmsProvider smsProvider() {
+        return Mockito.mock(SmsProvider.class);
+    }
+}

--- a/backend/src/integration-test/java/com/stablepay/test/PgTest.java
+++ b/backend/src/integration-test/java/com/stablepay/test/PgTest.java
@@ -1,0 +1,19 @@
+package com.stablepay.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@ActiveProfiles("test")
+@ExtendWith(PostgresContainerExtension.class)
+@Import(IntegrationTestConfig.class)
+public @interface PgTest {}

--- a/backend/src/integration-test/java/com/stablepay/test/PostgresContainerExtension.java
+++ b/backend/src/integration-test/java/com/stablepay/test/PostgresContainerExtension.java
@@ -1,0 +1,24 @@
+package com.stablepay.test;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgresContainerExtension implements BeforeAllCallback {
+
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("stablepay_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (!POSTGRES.isRunning()) {
+            POSTGRES.start();
+        }
+        System.setProperty("spring.datasource.url", POSTGRES.getJdbcUrl());
+        System.setProperty("spring.datasource.username", POSTGRES.getUsername());
+        System.setProperty("spring.datasource.password", POSTGRES.getPassword());
+    }
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,6 +1,15 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.data.redis.autoconfigure.RedisRepositoriesAutoConfiguration
+  cache:
+    type: none
   flyway:
     enabled: true
+    locations: classpath:db/migration
   jpa:
     hibernate:
       ddl-auto: validate

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,12 +1,8 @@
 spring:
   autoconfigure:
     exclude:
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
       - org.springframework.boot.data.redis.autoconfigure.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
       - org.springframework.boot.data.redis.autoconfigure.RedisRepositoriesAutoConfiguration
-  cache:
-    type: none
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
@@ -1,5 +1,9 @@
 package com.stablepay.application.controller.fx;
 
+import static com.stablepay.testutil.FxQuoteFixtures.SOME_EXPIRES_AT;
+import static com.stablepay.testutil.FxQuoteFixtures.SOME_RATE;
+import static com.stablepay.testutil.FxQuoteFixtures.SOME_TIMESTAMP;
+import static com.stablepay.testutil.FxQuoteFixtures.fxQuoteBuilder;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -17,7 +21,6 @@ import com.stablepay.application.controller.fx.mapper.FxRateApiMapper;
 import com.stablepay.application.dto.FxRateResponse;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.fx.handler.GetFxRateQueryHandler;
-import com.stablepay.testutil.FxQuoteFixtures;
 
 @WebMvcTest(FxRateController.class)
 class FxRateControllerTest {
@@ -34,14 +37,14 @@ class FxRateControllerTest {
     @Test
     void shouldReturnLiveFxRate() throws Exception {
         // given
-        var quote = FxQuoteFixtures.fxQuoteBuilder()
+        var quote = fxQuoteBuilder()
                 .source("open.er-api.com")
                 .build();
         var response = FxRateResponse.builder()
-                .rate(FxQuoteFixtures.SOME_RATE)
+                .rate(SOME_RATE)
                 .source("open.er-api.com")
-                .timestamp(FxQuoteFixtures.SOME_TIMESTAMP)
-                .expiresAt(FxQuoteFixtures.SOME_EXPIRES_AT)
+                .timestamp(SOME_TIMESTAMP)
+                .expiresAt(SOME_EXPIRES_AT)
                 .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
@@ -57,15 +60,15 @@ class FxRateControllerTest {
     @Test
     void shouldReturnFallbackFxRate() throws Exception {
         // given
-        var quote = FxQuoteFixtures.fxQuoteBuilder()
+        var quote = fxQuoteBuilder()
                 .rate(BigDecimal.valueOf(84.50))
                 .source("fallback")
                 .build();
         var response = FxRateResponse.builder()
                 .rate(BigDecimal.valueOf(84.50))
                 .source("fallback")
-                .timestamp(FxQuoteFixtures.SOME_TIMESTAMP)
-                .expiresAt(FxQuoteFixtures.SOME_EXPIRES_AT)
+                .timestamp(SOME_TIMESTAMP)
+                .expiresAt(SOME_EXPIRES_AT)
                 .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -1,5 +1,11 @@
 package com.stablepay.application.controller.wallet;
 
+import static com.stablepay.testutil.WalletFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_UPDATED_AT;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,7 +30,6 @@ import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
 import com.stablepay.domain.wallet.handler.FundWalletHandler;
-import com.stablepay.testutil.WalletFixtures;
 
 @WebMvcTest(WalletController.class)
 class WalletControllerTest {
@@ -48,26 +53,26 @@ class WalletControllerTest {
     @Test
     void shouldCreateWallet() throws Exception {
         // given
-        var wallet = WalletFixtures.walletBuilder()
+        var wallet = walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
         var response = WalletResponse.builder()
-                .id(WalletFixtures.SOME_WALLET_ID)
-                .userId(WalletFixtures.SOME_USER_ID)
-                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(WalletFixtures.SOME_CREATED_AT)
-                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
                 .build();
 
-        given(createWalletHandler.handle(WalletFixtures.SOME_USER_ID)).willReturn(wallet);
+        given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
         given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
         var request = CreateWalletRequest.builder()
-                .userId(WalletFixtures.SOME_USER_ID)
+                .userId(SOME_USER_ID)
                 .build();
 
         // when / then
@@ -75,54 +80,54 @@ class WalletControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(WalletFixtures.SOME_WALLET_ID))
-                .andExpect(jsonPath("$.userId").value(WalletFixtures.SOME_USER_ID))
-                .andExpect(jsonPath("$.solanaAddress").value(WalletFixtures.SOME_SOLANA_ADDRESS));
+                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
+                .andExpect(jsonPath("$.userId").value(SOME_USER_ID))
+                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
     }
 
     @Test
     void shouldFundWallet() throws Exception {
         // given
-        var wallet = WalletFixtures.walletBuilder()
+        var wallet = walletBuilder()
                 .availableBalance(SOME_FUND_AMOUNT)
                 .totalBalance(SOME_FUND_AMOUNT)
                 .build();
 
         var response = WalletResponse.builder()
-                .id(WalletFixtures.SOME_WALLET_ID)
-                .userId(WalletFixtures.SOME_USER_ID)
-                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(SOME_FUND_AMOUNT)
                 .totalBalance(SOME_FUND_AMOUNT)
-                .createdAt(WalletFixtures.SOME_CREATED_AT)
-                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
                 .build();
 
-        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
+        given(fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
                 .willReturn(wallet);
         given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
         var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(WalletFixtures.SOME_WALLET_ID))
+                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
                 .andExpect(jsonPath("$.availableBalance").value(500));
     }
 
     @Test
     void shouldReturn404WhenWalletNotFound() throws Exception {
         // given
-        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
-                .willThrow(WalletNotFoundException.byId(WalletFixtures.SOME_WALLET_ID));
+        given(fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
+                .willThrow(WalletNotFoundException.byId(SOME_WALLET_ID));
 
         var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -145,14 +150,14 @@ class WalletControllerTest {
     @Test
     void shouldReturn503WhenTreasuryDepleted() throws Exception {
         // given
-        given(fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
+        given(fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
                 .willThrow(TreasuryDepletedException.insufficientTreasury(
                         SOME_FUND_AMOUNT, BigDecimal.valueOf(100)));
 
         var request = FundWalletRequest.builder().amount(SOME_FUND_AMOUNT).build();
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", WalletFixtures.SOME_WALLET_ID)
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isServiceUnavailable())
@@ -162,11 +167,11 @@ class WalletControllerTest {
     @Test
     void shouldReturn409WhenWalletAlreadyExists() throws Exception {
         // given
-        given(createWalletHandler.handle(WalletFixtures.SOME_USER_ID))
-                .willThrow(WalletAlreadyExistsException.forUserId(WalletFixtures.SOME_USER_ID));
+        given(createWalletHandler.handle(SOME_USER_ID))
+                .willThrow(WalletAlreadyExistsException.forUserId(SOME_USER_ID));
 
         var request = CreateWalletRequest.builder()
-                .userId(WalletFixtures.SOME_USER_ID)
+                .userId(SOME_USER_ID)
                 .build();
 
         // when / then

--- a/backend/src/test/java/com/stablepay/domain/claim/model/ClaimTokenTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/model/ClaimTokenTest.java
@@ -1,5 +1,8 @@
 package com.stablepay.domain.claim.model;
 
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
+import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -7,17 +10,15 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
-import com.stablepay.testutil.ClaimTokenFixtures;
-
 class ClaimTokenTest {
 
     @Test
     void shouldCreateClaimTokenWithExpiry() {
         // given / when
-        var claimToken = ClaimTokenFixtures.claimTokenBuilder().build();
+        var claimToken = claimTokenBuilder().build();
 
         // then
-        var expected = ClaimTokenFixtures.claimTokenBuilder().build();
+        var expected = claimTokenBuilder().build();
 
         assertThat(claimToken)
                 .usingRecursiveComparison()
@@ -30,7 +31,7 @@ class ClaimTokenTest {
         var token = UUID.randomUUID().toString();
 
         // when
-        var claimToken = ClaimTokenFixtures.claimTokenBuilder()
+        var claimToken = claimTokenBuilder()
                 .token(token)
                 .build();
 
@@ -43,7 +44,7 @@ class ClaimTokenTest {
     void shouldThrowWhenRemittanceIdIsNull() {
         // when / then
         assertThatThrownBy(() -> ClaimToken.builder()
-                .token(ClaimTokenFixtures.SOME_TOKEN)
+                .token(SOME_TOKEN)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("remittanceId");
@@ -53,7 +54,7 @@ class ClaimTokenTest {
     void shouldThrowWhenTokenIsNull() {
         // when / then
         assertThatThrownBy(() -> ClaimToken.builder()
-                .remittanceId(ClaimTokenFixtures.SOME_REMITTANCE_ID)
+                .remittanceId(SOME_REMITTANCE_ID)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("token");

--- a/backend/src/test/java/com/stablepay/domain/fx/handler/GetFxRateQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/fx/handler/GetFxRateQueryHandlerTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.domain.fx.handler;
 
+import static com.stablepay.testutil.FxQuoteFixtures.fxQuoteBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -12,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.fx.port.FxRateProvider;
-import com.stablepay.testutil.FxQuoteFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class GetFxRateQueryHandlerTest {
@@ -26,7 +26,7 @@ class GetFxRateQueryHandlerTest {
     @Test
     void shouldReturnFxQuoteForSupportedCorridor() {
         // given
-        var expectedQuote = FxQuoteFixtures.fxQuoteBuilder()
+        var expectedQuote = fxQuoteBuilder()
                 .source("open.er-api.com")
                 .build();
         given(fxRateProvider.getRate("USD", "INR")).willReturn(expectedQuote);

--- a/backend/src/test/java/com/stablepay/domain/remittance/model/RemittanceTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/model/RemittanceTest.java
@@ -1,21 +1,24 @@
 package com.stablepay.domain.remittance.model;
 
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
-
-import com.stablepay.testutil.RemittanceFixtures;
 
 class RemittanceTest {
 
     @Test
     void shouldCreateRemittanceWithInitiatedStatus() {
         // given / when
-        var remittance = RemittanceFixtures.remittanceBuilder().build();
+        var remittance = remittanceBuilder().build();
 
         // then
-        var expected = RemittanceFixtures.remittanceBuilder().build();
+        var expected = remittanceBuilder().build();
 
         assertThat(remittance)
                 .usingRecursiveComparison()
@@ -25,7 +28,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromInitiatedToEscrowed() {
         // given
-        var remittance = RemittanceFixtures.remittanceBuilder().build();
+        var remittance = remittanceBuilder().build();
 
         // when
         var escrowed = remittance.toBuilder()
@@ -47,7 +50,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromEscrowedToClaimed() {
         // given
-        var remittance = RemittanceFixtures.remittanceBuilder()
+        var remittance = remittanceBuilder()
                 .status(RemittanceStatus.ESCROWED)
                 .build();
 
@@ -69,7 +72,7 @@ class RemittanceTest {
     @Test
     void shouldTransitionFromClaimedToDelivered() {
         // given
-        var remittance = RemittanceFixtures.remittanceBuilder()
+        var remittance = remittanceBuilder()
                 .status(RemittanceStatus.CLAIMED)
                 .build();
 
@@ -92,9 +95,9 @@ class RemittanceTest {
     void shouldThrowWhenRemittanceIdIsNull() {
         // when / then
         assertThatThrownBy(() -> Remittance.builder()
-                .senderId(RemittanceFixtures.SOME_SENDER_ID)
-                .recipientPhone(RemittanceFixtures.SOME_RECIPIENT_PHONE)
-                .amountUsdc(RemittanceFixtures.SOME_AMOUNT_USDC)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
                 .status(RemittanceStatus.INITIATED)
                 .build())
                 .isInstanceOf(NullPointerException.class)
@@ -105,10 +108,10 @@ class RemittanceTest {
     void shouldThrowWhenStatusIsNull() {
         // when / then
         assertThatThrownBy(() -> Remittance.builder()
-                .remittanceId(RemittanceFixtures.SOME_REMITTANCE_ID)
-                .senderId(RemittanceFixtures.SOME_SENDER_ID)
-                .recipientPhone(RemittanceFixtures.SOME_RECIPIENT_PHONE)
-                .amountUsdc(RemittanceFixtures.SOME_AMOUNT_USDC)
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
                 .build())
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("status");

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
@@ -1,5 +1,11 @@
 package com.stablepay.domain.wallet.handler;
 
+import static com.stablepay.testutil.WalletFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_UPDATED_AT;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -18,7 +24,6 @@ import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.domain.wallet.port.WalletRepository;
-import com.stablepay.testutil.WalletFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class CreateWalletHandlerTest {
@@ -35,36 +40,36 @@ class CreateWalletHandlerTest {
     @Test
     void shouldCreateWallet() {
         // given
-        given(walletRepository.findByUserId(WalletFixtures.SOME_USER_ID)).willReturn(Optional.empty());
-        given(mpcWalletClient.generateKey()).willReturn(WalletFixtures.SOME_SOLANA_ADDRESS);
+        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.empty());
+        given(mpcWalletClient.generateKey()).willReturn(SOME_SOLANA_ADDRESS);
 
         var walletToSave = Wallet.builder()
-                .userId(WalletFixtures.SOME_USER_ID)
-                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
         var savedWallet = walletToSave.toBuilder()
-                .id(WalletFixtures.SOME_WALLET_ID)
-                .createdAt(WalletFixtures.SOME_CREATED_AT)
-                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
+                .id(SOME_WALLET_ID)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
                 .build();
 
         given(walletRepository.save(walletToSave)).willReturn(savedWallet);
 
         // when
-        var result = createWalletHandler.handle(WalletFixtures.SOME_USER_ID);
+        var result = createWalletHandler.handle(SOME_USER_ID);
 
         // then
         var expected = Wallet.builder()
-                .id(WalletFixtures.SOME_WALLET_ID)
-                .userId(WalletFixtures.SOME_USER_ID)
-                .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                .id(SOME_WALLET_ID)
+                .userId(SOME_USER_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
-                .createdAt(WalletFixtures.SOME_CREATED_AT)
-                .updatedAt(WalletFixtures.SOME_UPDATED_AT)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
                 .build();
 
         assertThat(result)
@@ -78,18 +83,18 @@ class CreateWalletHandlerTest {
     @Test
     void shouldThrowWhenWalletAlreadyExists() {
         // given
-        var existingWallet = WalletFixtures.walletBuilder()
+        var existingWallet = walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        given(walletRepository.findByUserId(WalletFixtures.SOME_USER_ID))
+        given(walletRepository.findByUserId(SOME_USER_ID))
                 .willReturn(Optional.of(existingWallet));
 
         // when / then
-        assertThatThrownBy(() -> createWalletHandler.handle(WalletFixtures.SOME_USER_ID))
+        assertThatThrownBy(() -> createWalletHandler.handle(SOME_USER_ID))
                 .isInstanceOf(WalletAlreadyExistsException.class)
                 .hasMessageContaining("SP-0008")
-                .hasMessageContaining(WalletFixtures.SOME_USER_ID);
+                .hasMessageContaining(SOME_USER_ID);
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/FundWalletHandlerTest.java
@@ -1,5 +1,8 @@
 package com.stablepay.domain.wallet.handler;
 
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -18,7 +21,6 @@ import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.port.TreasuryService;
 import com.stablepay.domain.wallet.port.WalletRepository;
-import com.stablepay.testutil.WalletFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class FundWalletHandlerTest {
@@ -38,9 +40,9 @@ class FundWalletHandlerTest {
     @Test
     void shouldFundWallet() {
         // given
-        var existingWallet = WalletFixtures.walletBuilder().build();
+        var existingWallet = walletBuilder().build();
 
-        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID))
+        given(walletRepository.findById(SOME_WALLET_ID))
                 .willReturn(Optional.of(existingWallet));
         given(treasuryService.getBalance()).willReturn(SOME_TREASURY_BALANCE);
 
@@ -52,7 +54,7 @@ class FundWalletHandlerTest {
         given(walletRepository.save(fundedWallet)).willReturn(fundedWallet);
 
         // when
-        var result = fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT);
+        var result = fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT);
 
         // then
         var expected = existingWallet.toBuilder()
@@ -65,26 +67,26 @@ class FundWalletHandlerTest {
                 .isEqualTo(expected);
 
         then(treasuryService).should()
-                .transferFromTreasury(WalletFixtures.SOME_SOLANA_ADDRESS, SOME_FUND_AMOUNT);
+                .transferFromTreasury(SOME_SOLANA_ADDRESS, SOME_FUND_AMOUNT);
         then(walletRepository).should().save(fundedWallet);
     }
 
     @Test
     void shouldThrowWhenWalletNotFound() {
         // given
-        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID)).willReturn(Optional.empty());
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, SOME_FUND_AMOUNT))
+        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, SOME_FUND_AMOUNT))
                 .isInstanceOf(WalletNotFoundException.class)
                 .hasMessageContaining("SP-0006")
-                .hasMessageContaining(WalletFixtures.SOME_WALLET_ID.toString());
+                .hasMessageContaining(SOME_WALLET_ID.toString());
     }
 
     @Test
     void shouldThrowWhenTreasuryDepleted() {
         // given
-        var existingWallet = WalletFixtures.walletBuilder()
+        var existingWallet = walletBuilder()
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
                 .build();
@@ -92,12 +94,12 @@ class FundWalletHandlerTest {
         var lowTreasuryBalance = BigDecimal.valueOf(100);
         var requestedAmount = BigDecimal.valueOf(500);
 
-        given(walletRepository.findById(WalletFixtures.SOME_WALLET_ID))
+        given(walletRepository.findById(SOME_WALLET_ID))
                 .willReturn(Optional.of(existingWallet));
         given(treasuryService.getBalance()).willReturn(lowTreasuryBalance);
 
         // when / then
-        assertThatThrownBy(() -> fundWalletHandler.handle(WalletFixtures.SOME_WALLET_ID, requestedAmount))
+        assertThatThrownBy(() -> fundWalletHandler.handle(SOME_WALLET_ID, requestedAmount))
                 .isInstanceOf(TreasuryDepletedException.class)
                 .hasMessageContaining("SP-0007");
     }

--- a/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
@@ -1,5 +1,8 @@
 package com.stablepay.domain.wallet.model;
 
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -9,7 +12,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
-import com.stablepay.testutil.WalletFixtures;
 
 class WalletTest {
 
@@ -19,7 +21,7 @@ class WalletTest {
         @Test
         void shouldReserveBalanceSuccessfully() {
             // given
-            var wallet = WalletFixtures.walletBuilder().build();
+            var wallet = walletBuilder().build();
 
             // when
             var reserved = wallet.reserveBalance(BigDecimal.valueOf(60));
@@ -37,7 +39,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingMoreThanAvailable() {
             // given
-            var wallet = WalletFixtures.walletBuilder()
+            var wallet = walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -50,7 +52,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingNegativeAmount() {
             // given
-            var wallet = WalletFixtures.walletBuilder().build();
+            var wallet = walletBuilder().build();
 
             // when / then
             assertThatThrownBy(() -> wallet.reserveBalance(BigDecimal.valueOf(-10)))
@@ -61,7 +63,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReservingZeroAmount() {
             // given
-            var wallet = WalletFixtures.walletBuilder().build();
+            var wallet = walletBuilder().build();
 
             // when / then
             assertThatThrownBy(() -> wallet.reserveBalance(BigDecimal.ZERO))
@@ -76,7 +78,7 @@ class WalletTest {
         @Test
         void shouldReleaseBalanceSuccessfully() {
             // given
-            var wallet = WalletFixtures.walletBuilder()
+            var wallet = walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -96,7 +98,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReleasingExceedsTotalBalance() {
             // given
-            var wallet = WalletFixtures.walletBuilder()
+            var wallet = walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -109,7 +111,7 @@ class WalletTest {
         @Test
         void shouldThrowWhenReleasingNegativeAmount() {
             // given
-            var wallet = WalletFixtures.walletBuilder()
+            var wallet = walletBuilder()
                     .availableBalance(BigDecimal.valueOf(40))
                     .build();
 
@@ -127,7 +129,7 @@ class WalletTest {
         void shouldThrowWhenUserIdIsNull() {
             // when / then
             assertThatThrownBy(() -> Wallet.builder()
-                    .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                    .solanaAddress(SOME_SOLANA_ADDRESS)
                     .availableBalance(BigDecimal.ZERO)
                     .totalBalance(BigDecimal.ZERO)
                     .build())
@@ -139,8 +141,8 @@ class WalletTest {
         void shouldThrowWhenAvailableBalanceIsNull() {
             // when / then
             assertThatThrownBy(() -> Wallet.builder()
-                    .userId(WalletFixtures.SOME_USER_ID)
-                    .solanaAddress(WalletFixtures.SOME_SOLANA_ADDRESS)
+                    .userId(SOME_USER_ID)
+                    .solanaAddress(SOME_SOLANA_ADDRESS)
                     .totalBalance(BigDecimal.ZERO)
                     .build())
                     .isInstanceOf(NullPointerException.class)

--- a/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/fx/ExchangeRateApiAdapterTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.infrastructure.fx;
 
+import static com.stablepay.testutil.FxQuoteFixtures.SOME_RATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -16,7 +17,6 @@ import org.springframework.web.client.RestClient;
 
 import com.stablepay.domain.fx.model.FxQuote;
 import com.stablepay.infrastructure.fx.ExchangeRateApiAdapter.ExchangeRateResponse;
-import com.stablepay.testutil.FxQuoteFixtures;
 
 @ExtendWith(MockitoExtension.class)
 class ExchangeRateApiAdapterTest {
@@ -46,7 +46,7 @@ class ExchangeRateApiAdapterTest {
         // given
         var apiResponse = new ExchangeRateResponse(
                 "success",
-                Map.of("INR", FxQuoteFixtures.SOME_RATE));
+                Map.of("INR", SOME_RATE));
 
         given(fxRestClient.get()).willReturn(requestHeadersUriSpec);
         given(requestHeadersUriSpec.uri("/v6/latest/{from}", "USD")).willReturn(requestHeadersSpec);
@@ -58,7 +58,7 @@ class ExchangeRateApiAdapterTest {
 
         // then
         var expected = FxQuote.builder()
-                .rate(FxQuoteFixtures.SOME_RATE)
+                .rate(SOME_RATE)
                 .source("open.er-api.com")
                 .timestamp(result.timestamp())
                 .expiresAt(result.timestamp().plusSeconds(60))


### PR DESCRIPTION
## STA Issues
Closes #55, Closes #56

## Changes

### STA-55: Test Fixtures
- `WalletFixtures`, `RemittanceFixtures`, `ClaimTokenFixtures`, `FxQuoteFixtures` in `src/testFixtures/`
- `SOME_*` constants + builder factory methods per aggregate
- All 9 test files refactored to use explicit static imports (no wildcards)

### STA-56: Integration Test Infrastructure
- `PostgresContainerExtension`: shared PostgreSQL 16 container via Testcontainers
- `@PgTest` meta-annotation: `@SpringBootTest` + `@ActiveProfiles("test")` + `@ExtendWith`
- `WalletRepositoryIntegrationTest`: save/find/empty scenarios with real DB
- `ExchangeRateApiIntegrationTest`: WireMock stubs for live rate, 500 error, timeout → fallback
- WireMock + testFixtures dependencies for integration-test source set
- `application-test.yml`: disable Redis cache for tests

### Fixes
- Spotless `importOrder` with static import group prefix (`\\#`)
- `.gitignore` pattern for `.idea/`

## Test plan
- [x] `./gradlew build` passes (all unit tests green)
- [x] Integration test infrastructure compiles
- [x] Spotless formatting applied
- [ ] `./gradlew integrationTest` — requires Docker (Testcontainers)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — test infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)