### PR TITLE
STA-34: Add remittance endpoints (create, get, list)

### DIFF
--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
@@ -65,6 +66,16 @@ public class GlobalExceptionHandler {
         log.warn("Unsupported corridor requested: {}", ex.getMessage());
         return ErrorResponse.builder()
                 .errorCode("SP-0009")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(RemittanceNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleRemittanceNotFound(RemittanceNotFoundException ex) {
+        log.warn("Remittance not found: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0010")
                 .message(ex.getMessage())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
@@ -1,0 +1,59 @@
+package com.stablepay.application.controller.remittance;
+
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.application.controller.remittance.mapper.RemittanceApiMapper;
+import com.stablepay.application.dto.CreateRemittanceRequest;
+import com.stablepay.application.dto.RemittanceResponse;
+import com.stablepay.domain.remittance.handler.CreateRemittanceHandler;
+import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
+import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/remittances")
+@RequiredArgsConstructor
+public class RemittanceController {
+
+    private final CreateRemittanceHandler createRemittanceHandler;
+    private final GetRemittanceQueryHandler getRemittanceQueryHandler;
+    private final ListRemittancesQueryHandler listRemittancesQueryHandler;
+    private final RemittanceApiMapper remittanceApiMapper;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public RemittanceResponse createRemittance(@Valid @RequestBody CreateRemittanceRequest request) {
+        var remittance = createRemittanceHandler.handle(
+                request.senderId(), request.recipientPhone(), request.amountUsdc());
+        return remittanceApiMapper.toResponse(remittance);
+    }
+
+    @GetMapping("/{remittanceId}")
+    public RemittanceResponse getRemittance(@PathVariable UUID remittanceId) {
+        var remittance = getRemittanceQueryHandler.handle(remittanceId);
+        return remittanceApiMapper.toResponse(remittance);
+    }
+
+    @GetMapping
+    public Page<RemittanceResponse> listRemittances(
+            @RequestParam String senderId,
+            Pageable pageable) {
+        return listRemittancesQueryHandler.handle(senderId, pageable)
+                .map(remittanceApiMapper::toResponse);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/remittance/mapper/RemittanceApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/remittance/mapper/RemittanceApiMapper.java
@@ -1,0 +1,11 @@
+package com.stablepay.application.controller.remittance.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.stablepay.application.dto.RemittanceResponse;
+import com.stablepay.domain.remittance.model.Remittance;
+
+@Mapper(componentModel = "spring")
+public interface RemittanceApiMapper {
+    RemittanceResponse toResponse(Remittance remittance);
+}

--- a/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
@@ -1,0 +1,16 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record CreateRemittanceRequest(
+    @NotBlank String senderId,
+    @NotBlank String recipientPhone,
+    @NotNull @Positive BigDecimal amountUsdc
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
@@ -1,0 +1,26 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record RemittanceResponse(
+    Long id,
+    UUID remittanceId,
+    String senderId,
+    String recipientPhone,
+    BigDecimal amountUsdc,
+    BigDecimal amountInr,
+    BigDecimal fxRate,
+    RemittanceStatus status,
+    String escrowPda,
+    boolean smsNotificationFailed,
+    Instant createdAt,
+    Instant updatedAt,
+    Instant expiresAt
+) {}

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/RemittanceNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/RemittanceNotFoundException.java
@@ -1,0 +1,15 @@
+package com.stablepay.domain.remittance.exception;
+
+import java.util.UUID;
+
+public class RemittanceNotFoundException extends RuntimeException {
+
+    public static RemittanceNotFoundException byId(UUID remittanceId) {
+        return new RemittanceNotFoundException(
+                "SP-0010: Remittance not found: " + remittanceId);
+    }
+
+    private RemittanceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
@@ -1,0 +1,62 @@
+package com.stablepay.domain.remittance.handler;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.fx.model.FxQuote;
+import com.stablepay.domain.fx.port.FxRateProvider;
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateRemittanceHandler {
+
+    private final RemittanceRepository remittanceRepository;
+    private final WalletRepository walletRepository;
+    private final FxRateProvider fxRateProvider;
+
+    public Remittance handle(String senderId, String recipientPhone, BigDecimal amountUsdc) {
+        var wallet = walletRepository.findByUserId(senderId)
+                .orElseThrow(() -> WalletNotFoundException.byUserId(senderId));
+
+        var reserved = wallet.reserveBalance(amountUsdc);
+        walletRepository.save(reserved);
+
+        var fxQuote = fxRateProvider.getRate("USD", "INR");
+        var amountInr = calculateInrAmount(amountUsdc, fxQuote);
+
+        var remittance = Remittance.builder()
+                .remittanceId(UUID.randomUUID())
+                .senderId(senderId)
+                .recipientPhone(recipientPhone)
+                .amountUsdc(amountUsdc)
+                .amountInr(amountInr)
+                .fxRate(fxQuote.rate())
+                .status(RemittanceStatus.INITIATED)
+                .smsNotificationFailed(false)
+                .build();
+
+        var saved = remittanceRepository.save(remittance);
+        log.info("Created remittance remittanceId={}, senderId={}, amountUsdc={}, fxRate={}",
+                saved.remittanceId(), senderId, amountUsdc, fxQuote.rate());
+
+        return saved;
+    }
+
+    private BigDecimal calculateInrAmount(BigDecimal amountUsdc, FxQuote fxQuote) {
+        return amountUsdc.multiply(fxQuote.rate()).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandler.java
@@ -1,0 +1,25 @@
+package com.stablepay.domain.remittance.handler;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetRemittanceQueryHandler {
+
+    private final RemittanceRepository remittanceRepository;
+
+    public Remittance handle(UUID remittanceId) {
+        return remittanceRepository.findByRemittanceId(remittanceId)
+                .orElseThrow(() -> RemittanceNotFoundException.byId(remittanceId));
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandler.java
@@ -1,0 +1,23 @@
+package com.stablepay.domain.remittance.handler;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ListRemittancesQueryHandler {
+
+    private final RemittanceRepository remittanceRepository;
+
+    public Page<Remittance> handle(String senderId, Pageable pageable) {
+        return remittanceRepository.findBySenderId(senderId, pageable);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceRepository.java
@@ -1,13 +1,15 @@
 package com.stablepay.domain.remittance.port;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import com.stablepay.domain.remittance.model.Remittance;
 
 public interface RemittanceRepository {
     Remittance save(Remittance remittance);
     Optional<Remittance> findByRemittanceId(UUID remittanceId);
-    List<Remittance> findBySenderId(String senderId);
+    Page<Remittance> findBySenderId(String senderId, Pageable pageable);
 }

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
@@ -6,6 +6,10 @@ public class WalletNotFoundException extends RuntimeException {
         return new WalletNotFoundException("SP-0006: Wallet not found: " + id);
     }
 
+    public static WalletNotFoundException byUserId(String userId) {
+        return new WalletNotFoundException("SP-0006: Wallet not found for user: " + userId);
+    }
+
     private WalletNotFoundException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceJpaRepository.java
@@ -1,12 +1,13 @@
 package com.stablepay.infrastructure.db.remittance;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 interface RemittanceJpaRepository extends JpaRepository<RemittanceEntity, Long> {
     Optional<RemittanceEntity> findByRemittanceId(UUID remittanceId);
-    List<RemittanceEntity> findBySenderId(String senderId);
+    Page<RemittanceEntity> findBySenderId(String senderId, Pageable pageable);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryAdapter.java
@@ -1,10 +1,11 @@
 package com.stablepay.infrastructure.db.remittance;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.stablepay.domain.remittance.model.Remittance;
@@ -37,7 +38,7 @@ class RemittanceRepositoryAdapter implements RemittanceRepository {
     }
 
     @Override
-    public List<Remittance> findBySenderId(String senderId) {
-        return jpaRepository.findBySenderId(senderId).stream().map(mapper::toDomain).toList();
+    public Page<Remittance> findBySenderId(String senderId, Pageable pageable) {
+        return jpaRepository.findBySenderId(senderId, pageable).map(mapper::toDomain);
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -1,0 +1,206 @@
+package com.stablepay.application.controller.remittance;
+
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_DB_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_UPDATED_AT;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stablepay.application.controller.remittance.mapper.RemittanceApiMapper;
+import com.stablepay.application.dto.CreateRemittanceRequest;
+import com.stablepay.application.dto.RemittanceResponse;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.handler.CreateRemittanceHandler;
+import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
+import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+
+@WebMvcTest(RemittanceController.class)
+class RemittanceControllerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreateRemittanceHandler createRemittanceHandler;
+
+    @MockitoBean
+    private GetRemittanceQueryHandler getRemittanceQueryHandler;
+
+    @MockitoBean
+    private ListRemittancesQueryHandler listRemittancesQueryHandler;
+
+    @MockitoBean
+    private RemittanceApiMapper remittanceApiMapper;
+
+    @Test
+    void shouldCreateRemittance() throws Exception {
+        // given
+        var domain = remittanceBuilder().build();
+        var response = RemittanceResponse.builder()
+                .id(SOME_REMITTANCE_DB_ID)
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(new BigDecimal("8325.00"))
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .smsNotificationFailed(false)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        given(createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
+                .willReturn(domain);
+        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
+
+        var request = CreateRemittanceRequest.builder()
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .build();
+
+        // when / then
+        mockMvc.perform(post("/api/remittances")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(SOME_REMITTANCE_DB_ID))
+                .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.recipientPhone").value(SOME_RECIPIENT_PHONE))
+                .andExpect(jsonPath("$.status").value("INITIATED"));
+    }
+
+    @Test
+    void shouldGetRemittanceById() throws Exception {
+        // given
+        var domain = remittanceBuilder().build();
+        var response = RemittanceResponse.builder()
+                .id(SOME_REMITTANCE_DB_ID)
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .smsNotificationFailed(false)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        given(getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID)).willReturn(domain);
+        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID));
+    }
+
+    @Test
+    void shouldListRemittancesBySenderId() throws Exception {
+        // given
+        var pageable = PageRequest.of(0, 20);
+        var domain = remittanceBuilder().build();
+        var page = new PageImpl<>(List.of(domain), pageable, 1);
+
+        var response = RemittanceResponse.builder()
+                .id(SOME_REMITTANCE_DB_ID)
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .status(RemittanceStatus.INITIATED)
+                .build();
+
+        given(listRemittancesQueryHandler.handle(SOME_SENDER_ID, pageable)).willReturn(page);
+        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/remittances")
+                        .param("senderId", SOME_SENDER_ID)
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].remittanceId").value(SOME_REMITTANCE_ID.toString()))
+                .andExpect(jsonPath("$.content[0].senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void shouldReturn404WhenRemittanceNotFound() throws Exception {
+        // given
+        var unknownId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        given(getRemittanceQueryHandler.handle(unknownId))
+                .willThrow(RemittanceNotFoundException.byId(unknownId));
+
+        // when / then
+        mockMvc.perform(get("/api/remittances/{remittanceId}", unknownId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0010"));
+    }
+
+    @Test
+    void shouldReturn400WhenInsufficientBalance() throws Exception {
+        // given
+        given(createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
+                .willThrow(InsufficientBalanceException.forAmount(SOME_AMOUNT_USDC, BigDecimal.valueOf(50)));
+
+        var request = CreateRemittanceRequest.builder()
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .build();
+
+        // when / then
+        mockMvc.perform(post("/api/remittances")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0002"));
+    }
+
+    @Test
+    void shouldReturn400WhenValidationFails() throws Exception {
+        // given
+        var request = CreateRemittanceRequest.builder()
+                .senderId("")
+                .recipientPhone("")
+                .amountUsdc(null)
+                .build();
+
+        // when / then
+        mockMvc.perform(post("/api/remittances")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0003"));
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.application.controller.remittance;
 
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_CREATED_AT;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
@@ -69,7 +70,7 @@ class RemittanceControllerTest {
                 .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
-                .amountInr(new BigDecimal("8325.00"))
+                .amountInr(SOME_AMOUNT_INR)
                 .fxRate(SOME_FX_RATE)
                 .status(RemittanceStatus.INITIATED)
                 .smsNotificationFailed(false)

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
@@ -1,0 +1,116 @@
+package com.stablepay.domain.remittance.handler;
+
+import static com.stablepay.testutil.FxQuoteFixtures.fxQuoteBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.fx.port.FxRateProvider;
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CreateRemittanceHandlerTest {
+
+    @Mock
+    private RemittanceRepository remittanceRepository;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private FxRateProvider fxRateProvider;
+
+    @InjectMocks
+    private CreateRemittanceHandler createRemittanceHandler;
+
+    @Test
+    void shouldCreateRemittanceWithLockedFxRate() {
+        // given
+        var wallet = walletBuilder()
+                .availableBalance(BigDecimal.valueOf(500))
+                .totalBalance(BigDecimal.valueOf(500))
+                .build();
+
+        var fxQuote = fxQuoteBuilder().build();
+
+        given(walletRepository.findByUserId(SOME_SENDER_ID)).willReturn(Optional.of(wallet));
+
+        var reservedWallet = wallet.reserveBalance(SOME_AMOUNT_USDC);
+        given(walletRepository.save(reservedWallet)).willReturn(reservedWallet);
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(fxQuote);
+
+        given(remittanceRepository.save(argThat(r ->
+                r.senderId().equals(SOME_SENDER_ID)
+                        && r.recipientPhone().equals(SOME_RECIPIENT_PHONE)
+                        && r.amountUsdc().compareTo(SOME_AMOUNT_USDC) == 0
+                        && r.status() == RemittanceStatus.INITIATED)))
+                .willAnswer(invocation -> {
+                    Remittance input = invocation.getArgument(0);
+                    return input.toBuilder().id(1L).build();
+                });
+
+        // when
+        var result = createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
+
+        // then
+        assertThat(result.senderId()).isEqualTo(SOME_SENDER_ID);
+        assertThat(result.recipientPhone()).isEqualTo(SOME_RECIPIENT_PHONE);
+        assertThat(result.amountUsdc()).isEqualByComparingTo(SOME_AMOUNT_USDC);
+        assertThat(result.amountInr()).isEqualByComparingTo(new BigDecimal("8325.00"));
+        assertThat(result.fxRate()).isEqualByComparingTo(fxQuote.rate());
+        assertThat(result.status()).isEqualTo(RemittanceStatus.INITIATED);
+        assertThat(result.remittanceId()).isNotNull();
+
+        then(walletRepository).should().save(reservedWallet);
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFound() {
+        // given
+        given(walletRepository.findByUserId(SOME_SENDER_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> createRemittanceHandler.handle(
+                SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006");
+    }
+
+    @Test
+    void shouldThrowWhenInsufficientBalance() {
+        // given
+        var wallet = walletBuilder()
+                .availableBalance(BigDecimal.valueOf(50))
+                .totalBalance(BigDecimal.valueOf(50))
+                .build();
+
+        given(walletRepository.findByUserId(SOME_SENDER_ID)).willReturn(Optional.of(wallet));
+
+        // when / then
+        assertThatThrownBy(() -> createRemittanceHandler.handle(
+                SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
+                .isInstanceOf(InsufficientBalanceException.class)
+                .hasMessageContaining("SP-0002");
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
@@ -1,8 +1,11 @@
 package com.stablepay.domain.remittance.handler;
 
 import static com.stablepay.testutil.FxQuoteFixtures.fxQuoteBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +19,8 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -40,6 +45,9 @@ class CreateRemittanceHandlerTest {
     @Mock
     private FxRateProvider fxRateProvider;
 
+    @Captor
+    private ArgumentCaptor<Remittance> remittanceCaptor;
+
     @InjectMocks
     private CreateRemittanceHandler createRemittanceHandler;
 
@@ -62,25 +70,30 @@ class CreateRemittanceHandlerTest {
 
         given(remittanceRepository.save(argThat(r ->
                 r.senderId().equals(SOME_SENDER_ID)
-                        && r.recipientPhone().equals(SOME_RECIPIENT_PHONE)
-                        && r.amountUsdc().compareTo(SOME_AMOUNT_USDC) == 0
                         && r.status() == RemittanceStatus.INITIATED)))
-                .willAnswer(invocation -> {
-                    Remittance input = invocation.getArgument(0);
-                    return input.toBuilder().id(1L).build();
-                });
+                .willAnswer(invocation -> invocation.<Remittance>getArgument(0).toBuilder().id(1L).build());
 
         // when
-        var result = createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
+        createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
 
         // then
-        assertThat(result.senderId()).isEqualTo(SOME_SENDER_ID);
-        assertThat(result.recipientPhone()).isEqualTo(SOME_RECIPIENT_PHONE);
-        assertThat(result.amountUsdc()).isEqualByComparingTo(SOME_AMOUNT_USDC);
-        assertThat(result.amountInr()).isEqualByComparingTo(new BigDecimal("8325.00"));
-        assertThat(result.fxRate()).isEqualByComparingTo(fxQuote.rate());
-        assertThat(result.status()).isEqualTo(RemittanceStatus.INITIATED);
-        assertThat(result.remittanceId()).isNotNull();
+        then(remittanceRepository).should().save(remittanceCaptor.capture());
+
+        var expected = Remittance.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .smsNotificationFailed(false)
+                .build();
+
+        assertThat(remittanceCaptor.getValue())
+                .usingRecursiveComparison()
+                .ignoringFields("remittanceId")
+                .isEqualTo(expected);
 
         then(walletRepository).should().save(reservedWallet);
     }

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandlerTest.java
@@ -1,0 +1,59 @@
+package com.stablepay.domain.remittance.handler;
+
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetRemittanceQueryHandlerTest {
+
+    @Mock
+    private RemittanceRepository remittanceRepository;
+
+    @InjectMocks
+    private GetRemittanceQueryHandler getRemittanceQueryHandler;
+
+    @Test
+    void shouldReturnRemittanceById() {
+        // given
+        var remittance = remittanceBuilder().build();
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID))
+                .willReturn(Optional.of(remittance));
+
+        // when
+        var result = getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID);
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(remittance);
+    }
+
+    @Test
+    void shouldThrowWhenRemittanceNotFound() {
+        // given
+        var unknownId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        given(remittanceRepository.findByRemittanceId(unknownId))
+                .willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> getRemittanceQueryHandler.handle(unknownId))
+                .isInstanceOf(RemittanceNotFoundException.class)
+                .hasMessageContaining("SP-0010")
+                .hasMessageContaining(unknownId.toString());
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandlerTest.java
@@ -1,0 +1,68 @@
+package com.stablepay.domain.remittance.handler;
+
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import com.stablepay.domain.remittance.model.Remittance;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ListRemittancesQueryHandlerTest {
+
+    @Mock
+    private RemittanceRepository remittanceRepository;
+
+    @InjectMocks
+    private ListRemittancesQueryHandler listRemittancesQueryHandler;
+
+    @Test
+    void shouldReturnPaginatedRemittancesForSender() {
+        // given
+        var pageable = PageRequest.of(0, 20);
+        var remittance1 = remittanceBuilder().build();
+        var remittance2 = remittanceBuilder()
+                .remittanceId(UUID.fromString("550e8400-e29b-41d4-a716-446655440001"))
+                .build();
+
+        var page = new PageImpl<>(List.of(remittance1, remittance2), pageable, 2);
+        given(remittanceRepository.findBySenderId(SOME_SENDER_ID, pageable)).willReturn(page);
+
+        // when
+        var result = listRemittancesQueryHandler.handle(SOME_SENDER_ID, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().getFirst())
+                .usingRecursiveComparison()
+                .isEqualTo(remittance1);
+    }
+
+    @Test
+    void shouldReturnEmptyPageWhenNoRemittances() {
+        // given
+        var pageable = PageRequest.of(0, 20);
+        var emptyPage = new PageImpl<Remittance>(List.of(), pageable, 0);
+        given(remittanceRepository.findBySenderId(SOME_SENDER_ID, pageable)).willReturn(emptyPage);
+
+        // when
+        var result = listRemittancesQueryHandler.handle(SOME_SENDER_ID, pageable);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
@@ -11,16 +11,19 @@ public final class RemittanceFixtures {
 
     private RemittanceFixtures() {}
 
+    public static final Long SOME_REMITTANCE_DB_ID = 1L;
     public static final UUID SOME_REMITTANCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
     public static final String SOME_SENDER_ID = "user-42";
     public static final String SOME_RECIPIENT_PHONE = "+919876543210";
     public static final BigDecimal SOME_AMOUNT_USDC = BigDecimal.valueOf(100);
-    public static final BigDecimal SOME_AMOUNT_INR = BigDecimal.valueOf(8450);
-    public static final BigDecimal SOME_FX_RATE = new BigDecimal("84.50");
+    public static final BigDecimal SOME_AMOUNT_INR = new BigDecimal("8325.00");
+    public static final BigDecimal SOME_FX_RATE = new BigDecimal("83.25");
     public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    public static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
 
     public static Remittance.RemittanceBuilder remittanceBuilder() {
         return Remittance.builder()
+                .id(SOME_REMITTANCE_DB_ID)
                 .remittanceId(SOME_REMITTANCE_ID)
                 .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
@@ -28,6 +31,8 @@ public final class RemittanceFixtures {
                 .amountInr(SOME_AMOUNT_INR)
                 .fxRate(SOME_FX_RATE)
                 .status(RemittanceStatus.INITIATED)
-                .createdAt(SOME_CREATED_AT);
+                .smsNotificationFailed(false)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT);
     }
 }


### PR DESCRIPTION
## STA Issue
Closes #34

## Changes
- Add `POST /api/remittances` endpoint — reserves wallet balance, locks FX rate, creates remittance with INITIATED status
- Add `GET /api/remittances/{remittanceId}` endpoint — fetch remittance by UUID
- Add `GET /api/remittances?senderId={id}&page=0&size=20` endpoint — paginated sender history
- Add `CreateRemittanceHandler` — orchestrates balance reservation, FX rate locking, and remittance creation within a single transaction
- Add `GetRemittanceQueryHandler` and `ListRemittancesQueryHandler` for read operations
- Add `RemittanceNotFoundException` with error code SP-0010
- Add `WalletNotFoundException.byUserId()` factory method
- Update `RemittanceRepository` port and infrastructure adapter with pagination support (`Page<Remittance>`)
- Add `RemittanceApiMapper` (MapStruct) and DTOs (`CreateRemittanceRequest`, `RemittanceResponse`)
- Register `RemittanceNotFoundException` in `GlobalExceptionHandler` (404)
- Enrich `RemittanceFixtures` with additional constants for handler tests

## Architecture
```
Controller → Handler → Outbound Port → Adapter
```
- Controller is thin — delegates to handlers
- `CreateRemittanceHandler` uses `WalletRepository` (pessimistic lock) + `FxRateProvider` + `RemittanceRepository`
- Balance reservation happens atomically within `@Transactional`

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (13 new tests: 6 controller + 3 create handler + 2 get handler + 2 list handler)
- [x] Spotless formatting applied
- [x] ArchUnit rules pass
- [x] Hexagonal architecture maintained (domain → nothing, application → domain, infrastructure → domain)
- [x] BDDMockito + AssertJ patterns followed
- [ ] Integration tests (deferred — will be covered in follow-up with Testcontainers)

## Note
Temporal workflow integration (`startWorkflow()` call in `CreateRemittanceHandler`) is deferred to STA-28/32. The handler currently creates and persists the remittance with INITIATED status — workflow orchestration will be wired when the Temporal infrastructure is ready.
Closes #5