### PR TITLE
STA-35: Add claim endpoints (get + submit)

### DIFF
--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.stablepay.application.dto.ErrorResponse;
+import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
+import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
@@ -66,6 +69,36 @@ public class GlobalExceptionHandler {
         log.warn("Unsupported corridor requested: {}", ex.getMessage());
         return ErrorResponse.builder()
                 .errorCode("SP-0009")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(ClaimTokenNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleClaimTokenNotFound(ClaimTokenNotFoundException ex) {
+        log.warn("Claim token not found: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0011")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(ClaimAlreadyClaimedException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleClaimAlreadyClaimed(ClaimAlreadyClaimedException ex) {
+        log.warn("Claim already submitted: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0012")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(ClaimTokenExpiredException.class)
+    @ResponseStatus(HttpStatus.GONE)
+    public ErrorResponse handleClaimTokenExpired(ClaimTokenExpiredException ex) {
+        log.warn("Claim token expired: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0013")
                 .message(ex.getMessage())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
 import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
+import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
@@ -99,6 +100,16 @@ public class GlobalExceptionHandler {
         log.warn("Claim token expired: {}", ex.getMessage());
         return ErrorResponse.builder()
                 .errorCode("SP-0013")
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ExceptionHandler(InvalidRemittanceStateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleInvalidRemittanceState(InvalidRemittanceStateException ex) {
+        log.warn("Invalid remittance state: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .errorCode("SP-0014")
                 .message(ex.getMessage())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/application/controller/claim/ClaimController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/claim/ClaimController.java
@@ -1,0 +1,42 @@
+package com.stablepay.application.controller.claim;
+
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.application.controller.claim.mapper.ClaimApiMapper;
+import com.stablepay.application.dto.ClaimResponse;
+import com.stablepay.application.dto.SubmitClaimRequest;
+import com.stablepay.domain.claim.handler.GetClaimQueryHandler;
+import com.stablepay.domain.claim.handler.SubmitClaimHandler;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/claims")
+@RequiredArgsConstructor
+public class ClaimController {
+
+    private final GetClaimQueryHandler getClaimQueryHandler;
+    private final SubmitClaimHandler submitClaimHandler;
+    private final ClaimApiMapper claimApiMapper;
+
+    @GetMapping("/{token}")
+    public ClaimResponse getClaim(@PathVariable String token) {
+        var claimDetails = getClaimQueryHandler.handle(token);
+        return claimApiMapper.toResponse(claimDetails);
+    }
+
+    @PostMapping("/{token}")
+    public ClaimResponse submitClaim(
+            @PathVariable String token,
+            @Valid @RequestBody SubmitClaimRequest request) {
+        var claimDetails = submitClaimHandler.handle(token, request.upiId());
+        return claimApiMapper.toResponse(claimDetails);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapper.java
@@ -1,0 +1,21 @@
+package com.stablepay.application.controller.claim.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.stablepay.application.dto.ClaimResponse;
+import com.stablepay.domain.claim.model.ClaimDetails;
+
+@Mapper
+public interface ClaimApiMapper {
+
+    @Mapping(source = "remittance.remittanceId", target = "remittanceId")
+    @Mapping(source = "remittance.senderId", target = "senderId")
+    @Mapping(source = "remittance.amountUsdc", target = "amountUsdc")
+    @Mapping(source = "remittance.amountInr", target = "amountInr")
+    @Mapping(source = "remittance.fxRate", target = "fxRate")
+    @Mapping(source = "remittance.status", target = "status")
+    @Mapping(source = "claimToken.claimed", target = "claimed")
+    @Mapping(source = "claimToken.expiresAt", target = "expiresAt")
+    ClaimResponse toResponse(ClaimDetails claimDetails);
+}

--- a/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
@@ -1,0 +1,21 @@
+package com.stablepay.application.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ClaimResponse(
+    UUID remittanceId,
+    String senderId,
+    BigDecimal amountUsdc,
+    BigDecimal amountInr,
+    BigDecimal fxRate,
+    RemittanceStatus status,
+    boolean claimed,
+    Instant expiresAt
+) {}

--- a/backend/src/main/java/com/stablepay/application/dto/SubmitClaimRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/SubmitClaimRequest.java
@@ -1,0 +1,15 @@
+package com.stablepay.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SubmitClaimRequest(
+    @NotBlank
+    @Size(max = 100)
+    @Pattern(regexp = ".*@.*", message = "must be a valid UPI ID (e.g., name@bank)")
+    String upiId
+) {}

--- a/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimAlreadyClaimedException.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimAlreadyClaimedException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.claim.exception;
+
+public class ClaimAlreadyClaimedException extends RuntimeException {
+
+    public static ClaimAlreadyClaimedException forToken(String token) {
+        return new ClaimAlreadyClaimedException("SP-0012: Claim already submitted for token: " + token);
+    }
+
+    private ClaimAlreadyClaimedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimTokenExpiredException.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimTokenExpiredException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.claim.exception;
+
+public class ClaimTokenExpiredException extends RuntimeException {
+
+    public static ClaimTokenExpiredException forToken(String token) {
+        return new ClaimTokenExpiredException("SP-0013: Claim token expired: " + token);
+    }
+
+    private ClaimTokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimTokenNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/exception/ClaimTokenNotFoundException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.claim.exception;
+
+public class ClaimTokenNotFoundException extends RuntimeException {
+
+    public static ClaimTokenNotFoundException byToken(String token) {
+        return new ClaimTokenNotFoundException("SP-0011: Claim token not found: " + token);
+    }
+
+    private ClaimTokenNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/GetClaimQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/GetClaimQueryHandler.java
@@ -1,0 +1,34 @@
+package com.stablepay.domain.claim.handler;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.model.ClaimDetails;
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetClaimQueryHandler {
+
+    private final ClaimTokenRepository claimTokenRepository;
+    private final RemittanceRepository remittanceRepository;
+
+    public ClaimDetails handle(String token) {
+        var claimToken = claimTokenRepository.findByToken(token)
+                .orElseThrow(() -> ClaimTokenNotFoundException.byToken(token));
+
+        var remittance = remittanceRepository.findByRemittanceId(claimToken.remittanceId())
+                .orElseThrow(() -> RemittanceNotFoundException.byId(claimToken.remittanceId()));
+
+        return ClaimDetails.builder()
+                .claimToken(claimToken)
+                .remittance(remittance)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -1,0 +1,62 @@
+package com.stablepay.domain.claim.handler;
+
+import java.time.Instant;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
+import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.model.ClaimDetails;
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubmitClaimHandler {
+
+    private final ClaimTokenRepository claimTokenRepository;
+    private final RemittanceRepository remittanceRepository;
+
+    public ClaimDetails handle(String token, String upiId) {
+        var claimToken = claimTokenRepository.findByToken(token)
+                .orElseThrow(() -> ClaimTokenNotFoundException.byToken(token));
+
+        if (claimToken.claimed()) {
+            throw ClaimAlreadyClaimedException.forToken(token);
+        }
+
+        if (claimToken.expiresAt() != null && claimToken.expiresAt().isBefore(Instant.now())) {
+            throw ClaimTokenExpiredException.forToken(token);
+        }
+
+        var updatedClaim = claimToken.toBuilder()
+                .claimed(true)
+                .build();
+        var savedClaim = claimTokenRepository.save(updatedClaim);
+
+        var remittance = remittanceRepository.findByRemittanceId(claimToken.remittanceId())
+                .orElseThrow(() -> RemittanceNotFoundException.byId(claimToken.remittanceId()));
+
+        var updatedRemittance = remittance.toBuilder()
+                .status(RemittanceStatus.CLAIMED)
+                .build();
+        var savedRemittance = remittanceRepository.save(updatedRemittance);
+
+        log.info("Claim submitted for token={}, remittanceId={}, upiId={}",
+                token, claimToken.remittanceId(), upiId);
+
+        return ClaimDetails.builder()
+                .claimToken(savedClaim)
+                .remittance(savedRemittance)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -10,6 +10,7 @@ import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
@@ -38,13 +39,18 @@ public class SubmitClaimHandler {
             throw ClaimTokenExpiredException.forToken(token);
         }
 
-        var updatedClaim = claimToken.toBuilder()
-                .claimed(true)
-                .build();
-        var savedClaim = claimTokenRepository.save(updatedClaim);
-
         var remittance = remittanceRepository.findByRemittanceId(claimToken.remittanceId())
                 .orElseThrow(() -> RemittanceNotFoundException.byId(claimToken.remittanceId()));
+
+        if (remittance.status() != RemittanceStatus.ESCROWED) {
+            throw InvalidRemittanceStateException.forClaim(remittance.status());
+        }
+
+        var updatedClaim = claimToken.toBuilder()
+                .claimed(true)
+                .upiId(upiId)
+                .build();
+        var savedClaim = claimTokenRepository.save(updatedClaim);
 
         var updatedRemittance = remittance.toBuilder()
                 .status(RemittanceStatus.CLAIMED)

--- a/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
@@ -1,0 +1,11 @@
+package com.stablepay.domain.claim.model;
+
+import com.stablepay.domain.remittance.model.Remittance;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record ClaimDetails(
+    ClaimToken claimToken,
+    Remittance remittance
+) {}

--- a/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
@@ -1,5 +1,7 @@
 package com.stablepay.domain.claim.model;
 
+import static java.util.Objects.requireNonNull;
+
 import com.stablepay.domain.remittance.model.Remittance;
 
 import lombok.Builder;
@@ -8,4 +10,9 @@ import lombok.Builder;
 public record ClaimDetails(
     ClaimToken claimToken,
     Remittance remittance
-) {}
+) {
+    public ClaimDetails {
+        requireNonNull(claimToken, "claimToken cannot be null");
+        requireNonNull(remittance, "remittance cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/claim/model/ClaimToken.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/model/ClaimToken.java
@@ -13,6 +13,7 @@ public record ClaimToken(
     UUID remittanceId,
     String token,
     boolean claimed,
+    String upiId,
     Instant createdAt,
     Instant expiresAt
 ) {

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/InvalidRemittanceStateException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/InvalidRemittanceStateException.java
@@ -1,0 +1,15 @@
+package com.stablepay.domain.remittance.exception;
+
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+public class InvalidRemittanceStateException extends RuntimeException {
+
+    public static InvalidRemittanceStateException forClaim(RemittanceStatus currentStatus) {
+        return new InvalidRemittanceStateException(
+                "SP-0014: Cannot claim remittance in status: " + currentStatus);
+    }
+
+    private InvalidRemittanceStateException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/claim/ClaimTokenEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/claim/ClaimTokenEntity.java
@@ -39,6 +39,9 @@ public class ClaimTokenEntity {
     @Column(name = "claimed", nullable = false)
     private boolean claimed;
 
+    @Column(name = "upi_id", length = 100)
+    private String upiId;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 

--- a/backend/src/main/resources/db/migration/V2__add_upi_id_to_claim_tokens.sql
+++ b/backend/src/main/resources/db/migration/V2__add_upi_id_to_claim_tokens.sql
@@ -1,0 +1,1 @@
+ALTER TABLE claim_tokens ADD COLUMN upi_id VARCHAR(100);

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -32,6 +32,7 @@ import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.claim.handler.GetClaimQueryHandler;
 import com.stablepay.domain.claim.handler.SubmitClaimHandler;
 import com.stablepay.domain.claim.model.ClaimDetails;
+import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 
 import lombok.SneakyThrows;
@@ -165,6 +166,23 @@ class ClaimControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isGone())
                 .andExpect(jsonPath("$.errorCode").value("SP-0013"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WhenRemittanceNotEscrowed() {
+        // given
+        given(submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .willThrow(InvalidRemittanceStateException.forClaim(RemittanceStatus.CANCELLED));
+
+        var request = SubmitClaimRequest.builder().upiId(SOME_UPI_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0014"));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -1,0 +1,197 @@
+package com.stablepay.application.controller.claim;
+
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_UPI_ID;
+import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stablepay.application.controller.claim.mapper.ClaimApiMapper;
+import com.stablepay.application.dto.ClaimResponse;
+import com.stablepay.application.dto.SubmitClaimRequest;
+import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
+import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.handler.GetClaimQueryHandler;
+import com.stablepay.domain.claim.handler.SubmitClaimHandler;
+import com.stablepay.domain.claim.model.ClaimDetails;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+import lombok.SneakyThrows;
+
+@WebMvcTest(ClaimController.class)
+class ClaimControllerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GetClaimQueryHandler getClaimQueryHandler;
+
+    @MockitoBean
+    private SubmitClaimHandler submitClaimHandler;
+
+    @MockitoBean
+    private ClaimApiMapper claimApiMapper;
+
+    @Test
+    @SneakyThrows
+    void shouldGetClaimDetails() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder().build();
+        var claimDetails = ClaimDetails.builder()
+                .claimToken(claimToken)
+                .remittance(remittance)
+                .build();
+
+        var response = ClaimResponse.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .claimed(false)
+                .build();
+
+        given(getClaimQueryHandler.handle(SOME_TOKEN)).willReturn(claimDetails);
+        given(claimApiMapper.toResponse(claimDetails)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/claims/{token}", SOME_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.claimed").value(false));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldSubmitClaim() {
+        // given
+        var claimToken = claimTokenBuilder().claimed(true).build();
+        var remittance = remittanceBuilder().status(RemittanceStatus.CLAIMED).build();
+        var claimDetails = ClaimDetails.builder()
+                .claimToken(claimToken)
+                .remittance(remittance)
+                .build();
+
+        var response = ClaimResponse.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .senderId(SOME_SENDER_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.CLAIMED)
+                .claimed(true)
+                .build();
+
+        given(submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID)).willReturn(claimDetails);
+        given(claimApiMapper.toResponse(claimDetails)).willReturn(response);
+
+        var request = SubmitClaimRequest.builder().upiId(SOME_UPI_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CLAIMED"))
+                .andExpect(jsonPath("$.claimed").value(true));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenTokenNotFound() {
+        // given
+        given(getClaimQueryHandler.handle("unknown-token"))
+                .willThrow(ClaimTokenNotFoundException.byToken("unknown-token"));
+
+        // when / then
+        mockMvc.perform(get("/api/claims/{token}", "unknown-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0011"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WhenAlreadyClaimed() {
+        // given
+        given(submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .willThrow(ClaimAlreadyClaimedException.forToken(SOME_TOKEN));
+
+        var request = SubmitClaimRequest.builder().upiId(SOME_UPI_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0012"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn410WhenTokenExpired() {
+        // given
+        given(submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .willThrow(ClaimTokenExpiredException.forToken(SOME_TOKEN));
+
+        var request = SubmitClaimRequest.builder().upiId(SOME_UPI_ID).build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.errorCode").value("SP-0013"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WhenUpiIdInvalid() {
+        // given
+        var request = SubmitClaimRequest.builder().upiId("invalid-no-at-sign").build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0003"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WhenUpiIdEmpty() {
+        // given
+        var request = SubmitClaimRequest.builder().upiId("").build();
+
+        // when / then
+        mockMvc.perform(post("/api/claims/{token}", SOME_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0003"));
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/GetClaimQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/GetClaimQueryHandlerTest.java
@@ -1,0 +1,83 @@
+package com.stablepay.domain.claim.handler;
+
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
+import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.model.ClaimDetails;
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetClaimQueryHandlerTest {
+
+    @Mock
+    private ClaimTokenRepository claimTokenRepository;
+
+    @Mock
+    private RemittanceRepository remittanceRepository;
+
+    @InjectMocks
+    private GetClaimQueryHandler getClaimQueryHandler;
+
+    @Test
+    void shouldReturnClaimDetailsForValidToken() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder().build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        // when
+        var result = getClaimQueryHandler.handle(SOME_TOKEN);
+
+        // then
+        var expected = ClaimDetails.builder()
+                .claimToken(claimToken)
+                .remittance(remittance)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowWhenTokenNotFound() {
+        // given
+        given(claimTokenRepository.findByToken("unknown-token")).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> getClaimQueryHandler.handle("unknown-token"))
+                .isInstanceOf(ClaimTokenNotFoundException.class)
+                .hasMessageContaining("SP-0011");
+    }
+
+    @Test
+    void shouldThrowWhenRemittanceNotFound() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> getClaimQueryHandler.handle(SOME_TOKEN))
+                .isInstanceOf(RemittanceNotFoundException.class)
+                .hasMessageContaining("SP-0010");
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
@@ -22,7 +22,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
 import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
 
@@ -47,11 +49,10 @@ class SubmitClaimHandlerTest {
                 .build();
 
         given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
-
-        var updatedClaim = claimToken.toBuilder().claimed(true).build();
-        given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
-
         given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
+        given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
 
         var updatedRemittance = remittance.toBuilder().status(RemittanceStatus.CLAIMED).build();
         given(remittanceRepository.save(updatedRemittance)).willReturn(updatedRemittance);
@@ -60,8 +61,13 @@ class SubmitClaimHandlerTest {
         var result = submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID);
 
         // then
-        assertThat(result.claimToken().claimed()).isTrue();
-        assertThat(result.remittance().status()).isEqualTo(RemittanceStatus.CLAIMED);
+        var expected = ClaimDetails.builder()
+                .claimToken(updatedClaim)
+                .remittance(updatedRemittance)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
 
         then(claimTokenRepository).should().save(updatedClaim);
         then(remittanceRepository).should().save(updatedRemittance);
@@ -88,6 +94,23 @@ class SubmitClaimHandlerTest {
         assertThatThrownBy(() -> submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
                 .isInstanceOf(ClaimAlreadyClaimedException.class)
                 .hasMessageContaining("SP-0012");
+    }
+
+    @Test
+    void shouldThrowWhenRemittanceNotEscrowed() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder()
+                .status(RemittanceStatus.CANCELLED)
+                .build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        // when / then
+        assertThatThrownBy(() -> submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .isInstanceOf(InvalidRemittanceStateException.class)
+                .hasMessageContaining("SP-0014");
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
@@ -1,0 +1,106 @@
+package com.stablepay.domain.claim.handler;
+
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_EXPIRED_AT;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
+import static com.stablepay.testutil.ClaimTokenFixtures.SOME_UPI_ID;
+import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
+import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SubmitClaimHandlerTest {
+
+    @Mock
+    private ClaimTokenRepository claimTokenRepository;
+
+    @Mock
+    private RemittanceRepository remittanceRepository;
+
+    @InjectMocks
+    private SubmitClaimHandler submitClaimHandler;
+
+    @Test
+    void shouldSubmitClaimSuccessfully() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder()
+                .status(RemittanceStatus.ESCROWED)
+                .build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+
+        var updatedClaim = claimToken.toBuilder().claimed(true).build();
+        given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
+
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        var updatedRemittance = remittance.toBuilder().status(RemittanceStatus.CLAIMED).build();
+        given(remittanceRepository.save(updatedRemittance)).willReturn(updatedRemittance);
+
+        // when
+        var result = submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID);
+
+        // then
+        assertThat(result.claimToken().claimed()).isTrue();
+        assertThat(result.remittance().status()).isEqualTo(RemittanceStatus.CLAIMED);
+
+        then(claimTokenRepository).should().save(updatedClaim);
+        then(remittanceRepository).should().save(updatedRemittance);
+    }
+
+    @Test
+    void shouldThrowWhenTokenNotFound() {
+        // given
+        given(claimTokenRepository.findByToken("unknown-token")).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> submitClaimHandler.handle("unknown-token", SOME_UPI_ID))
+                .isInstanceOf(ClaimTokenNotFoundException.class)
+                .hasMessageContaining("SP-0011");
+    }
+
+    @Test
+    void shouldThrowWhenAlreadyClaimed() {
+        // given
+        var claimToken = claimTokenBuilder().claimed(true).build();
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+
+        // when / then
+        assertThatThrownBy(() -> submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .isInstanceOf(ClaimAlreadyClaimedException.class)
+                .hasMessageContaining("SP-0012");
+    }
+
+    @Test
+    void shouldThrowWhenTokenExpired() {
+        // given
+        var claimToken = claimTokenBuilder()
+                .expiresAt(SOME_EXPIRED_AT)
+                .build();
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+
+        // when / then
+        assertThatThrownBy(() -> submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .isInstanceOf(ClaimTokenExpiredException.class)
+                .hasMessageContaining("SP-0013");
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
@@ -9,13 +9,17 @@ public final class ClaimTokenFixtures {
 
     private ClaimTokenFixtures() {}
 
+    public static final Long SOME_CLAIM_TOKEN_ID = 1L;
     public static final UUID SOME_REMITTANCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
     public static final String SOME_TOKEN = "claim-token-abc-123";
+    public static final String SOME_UPI_ID = "recipient@upi";
     public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
     public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-04-05T10:00:00Z");
+    public static final Instant SOME_EXPIRED_AT = Instant.parse("2026-04-01T10:00:00Z");
 
     public static ClaimToken.ClaimTokenBuilder claimTokenBuilder() {
         return ClaimToken.builder()
+                .id(SOME_CLAIM_TOKEN_ID)
                 .remittanceId(SOME_REMITTANCE_ID)
                 .token(SOME_TOKEN)
                 .claimed(false)

--- a/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/ClaimTokenFixtures.java
@@ -14,7 +14,7 @@ public final class ClaimTokenFixtures {
     public static final String SOME_TOKEN = "claim-token-abc-123";
     public static final String SOME_UPI_ID = "recipient@upi";
     public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
-    public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-04-05T10:00:00Z");
+    public static final Instant SOME_EXPIRES_AT = Instant.parse("2027-04-05T10:00:00Z");
     public static final Instant SOME_EXPIRED_AT = Instant.parse("2026-04-01T10:00:00Z");
 
     public static ClaimToken.ClaimTokenBuilder claimTokenBuilder() {


### PR DESCRIPTION
## STA Issue
Closes #35

## Changes
- Add `GET /api/claims/{token}` endpoint — returns remittance details (amount, sender, FX rate, status) + claim status for the web claim page
- Add `POST /api/claims/{token}` endpoint — validates UPI ID format, marks claim as submitted, updates remittance status to CLAIMED
- Add `GetClaimQueryHandler` — loads claim token and associated remittance via cross-subdomain port access
- Add `SubmitClaimHandler` — validates not-claimed/not-expired guards, persists claim + remittance status update within single transaction
- Add `ClaimDetails` value object — combines ClaimToken + Remittance for cross-aggregate responses
- Add `ClaimApiMapper` (MapStruct) with explicit `@Mapping` for cross-object field extraction
- Add `ClaimResponse` and `SubmitClaimRequest` DTOs with Jakarta Bean Validation (`@Pattern(.*@.*)` for UPI format)
- Add three domain exceptions: `ClaimTokenNotFoundException` (SP-0011 → 404), `ClaimAlreadyClaimedException` (SP-0012 → 409), `ClaimTokenExpiredException` (SP-0013 → 410)
- Register all three exceptions in `GlobalExceptionHandler`
- Enrich `ClaimTokenFixtures` with additional test constants

## Architecture
```
ClaimController → GetClaimQueryHandler → ClaimTokenRepository + RemittanceRepository
ClaimController → SubmitClaimHandler → ClaimTokenRepository + RemittanceRepository
```
- Handlers access ports from both `claim` and `remittance` subdomains (cross-subdomain read is allowed per hexagonal rules)
- Temporal workflow signal for claim submission deferred to STA-32

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (14 new tests: 7 controller + 3 get handler + 4 submit handler)
- [x] Spotless formatting applied
- [x] ArchUnit rules pass
- [x] Hexagonal architecture maintained
- [x] BDDMockito + AssertJ patterns followed
- [x] UPI format validation: non-empty, contains @, max 100 chars
- [ ] Integration tests (deferred — will be covered in follow-up with Testcontainers)

## Note
Temporal workflow signal (`claimSubmitted` signal to workflow) is deferred to STA-32. Currently the handler directly updates remittance status to CLAIMED — the Temporal integration will replace this with a workflow signal when the infrastructure is ready.