### PR TITLE
STA-30: Solana transaction service + escrow instruction builder

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -114,6 +114,9 @@ dependencies {
     // UUID v7
     implementation("com.github.f4b6a3:uuid-creator:6.1.1")
 
+    // Solana SDK
+    implementation("org.sol4k:sol4k:0.5.5")
+
     // Test
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
@@ -1,0 +1,32 @@
+package com.stablepay.domain.remittance.exception;
+
+public class SolanaTransactionException extends RuntimeException {
+
+    private SolanaTransactionException(String message) {
+        super(message);
+    }
+
+    private SolanaTransactionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static SolanaTransactionException submissionFailed(String signature, Throwable cause) {
+        return new SolanaTransactionException(
+                "SP-0010: Solana transaction submission failed for signature: " + signature, cause);
+    }
+
+    public static SolanaTransactionException instructionBuildFailed(String instruction, Throwable cause) {
+        return new SolanaTransactionException(
+                "SP-0011: Failed to build Solana instruction: " + instruction, cause);
+    }
+
+    public static SolanaTransactionException confirmationTimeout(String signature) {
+        return new SolanaTransactionException(
+                "SP-0012: Solana transaction confirmation timeout for signature: " + signature);
+    }
+
+    public static SolanaTransactionException pdaDerivationFailed(String seeds, Throwable cause) {
+        return new SolanaTransactionException(
+                "SP-0013: Failed to derive PDA with seeds: " + seeds, cause);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
@@ -29,4 +29,9 @@ public class SolanaTransactionException extends RuntimeException {
         return new SolanaTransactionException(
                 "SP-0013: Failed to derive PDA with seeds: " + seeds, cause);
     }
+
+    public static SolanaTransactionException claimAuthorityNotConfigured() {
+        return new SolanaTransactionException(
+                "SP-0014: Claim authority private key is not configured");
+    }
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
@@ -13,7 +13,7 @@ public interface SolanaTransactionService {
 
     String claimEscrow(UUID remittanceId, String destinationTokenAccount);
 
-    String refundEscrow(UUID remittanceId);
+    String refundEscrow(UUID remittanceId, String senderWalletAddress);
 
     String getTransactionStatus(String transactionSignature);
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
@@ -1,0 +1,19 @@
+package com.stablepay.domain.remittance.port;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface SolanaTransactionService {
+
+    String depositEscrow(
+            UUID remittanceId,
+            String senderWalletAddress,
+            BigDecimal amountUsdc,
+            long expiryTimestamp);
+
+    String claimEscrow(UUID remittanceId, String destinationTokenAccount);
+
+    String refundEscrow(UUID remittanceId);
+
+    String getTransactionStatus(String transactionSignature);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilder.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilder.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.solana;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.MessageDigest;
@@ -98,7 +99,9 @@ public class EscrowInstructionBuilder {
         return new BaseInstruction(data, keys, solanaProperties.escrowProgramId());
     }
 
-    public Instruction buildRefundInstruction(UUID remittanceId, PublicKey senderWallet) {
+    public Instruction buildRefundInstruction(
+            UUID remittanceId, PublicKey claimAuthority, PublicKey senderWallet) {
+
         var remittanceIdBytes = uuidToBytes(remittanceId);
         var escrowPda = deriveEscrowPda(remittanceIdBytes);
         var vaultAta = deriveAssociatedTokenAddress(escrowPda, solanaProperties.usdcMint());
@@ -107,6 +110,7 @@ public class EscrowInstructionBuilder {
         var data = buildRefundData();
 
         var keys = List.of(
+                AccountMeta.signerAndWritable(claimAuthority),
                 AccountMeta.writable(senderWallet),
                 AccountMeta.writable(escrowPda),
                 AccountMeta.writable(vaultAta),
@@ -209,25 +213,35 @@ public class EscrowInstructionBuilder {
         }
     }
 
+    private static final BigInteger ED25519_P =
+            BigInteger.TWO.pow(255).subtract(BigInteger.valueOf(19));
+    private static final BigInteger ED25519_D = BigInteger.valueOf(-121665)
+            .multiply(BigInteger.valueOf(121666).modInverse(ED25519_P))
+            .mod(ED25519_P);
+
     private static boolean isOnCurve(byte[] point) {
-        try {
-            // Attempt to create a PublicKey and verify a dummy signature.
-            // If the point is on the Ed25519 curve, verify() will not throw.
-            // For PDA derivation, we need off-curve points.
-            // A simpler heuristic: try to use the bytes as a public key
-            // and check using TweetNaCl verify. But since we don't have
-            // direct access to TweetNaCl from Java, we rely on sol4k's
-            // PublicKey construction (which accepts any 32 bytes) and
-            // use a verification attempt as a proxy check.
-            //
-            // In practice, the probability of SHA-256 output landing on
-            // the Ed25519 curve is negligible (~1/2^128), so most nonces
-            // will work on the first try. We still iterate for correctness.
-            var pk = new PublicKey(point);
-            return pk.verify(new byte[64], new byte[32]);
-        } catch (Exception e) {
+        var yBytes = point.clone();
+        yBytes[31] &= 0x7f;
+
+        var reversed = new byte[32];
+        for (var i = 0; i < 32; i++) {
+            reversed[i] = yBytes[31 - i];
+        }
+        var y = new BigInteger(1, reversed);
+
+        if (y.compareTo(ED25519_P) >= 0) {
             return false;
         }
+
+        var y2 = y.modPow(BigInteger.TWO, ED25519_P);
+        var numerator = y2.subtract(BigInteger.ONE).mod(ED25519_P);
+        var denominator = ED25519_D.multiply(y2).add(BigInteger.ONE).mod(ED25519_P);
+        var x2 = numerator.multiply(denominator.modInverse(ED25519_P)).mod(ED25519_P);
+
+        var exp = ED25519_P.subtract(BigInteger.ONE).shiftRight(1);
+        var legendreSymbol = x2.modPow(exp, ED25519_P);
+
+        return legendreSymbol.equals(BigInteger.ONE) || x2.equals(BigInteger.ZERO);
     }
 
     static byte[] uuidToBytes(UUID uuid) {

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilder.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilder.java
@@ -1,0 +1,244 @@
+package com.stablepay.infrastructure.solana;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.sol4k.AccountMeta;
+import org.sol4k.PublicKey;
+import org.sol4k.instruction.BaseInstruction;
+import org.sol4k.instruction.Instruction;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EscrowInstructionBuilder {
+
+    private static final PublicKey TOKEN_PROGRAM_ID =
+            new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    private static final PublicKey ASSOCIATED_TOKEN_PROGRAM_ID =
+            new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+    private static final PublicKey SYSTEM_PROGRAM_ID =
+            new PublicKey("11111111111111111111111111111111");
+    private static final PublicKey RENT_SYSVAR =
+            new PublicKey("SysvarRent111111111111111111111111111111111");
+    private static final byte[] PDA_MARKER = "ProgramDerivedAddress".getBytes();
+
+    private static final int USDC_DECIMALS = 6;
+    private static final byte[] ESCROW_SEED_PREFIX = "escrow".getBytes();
+
+    private final SolanaProperties solanaProperties;
+
+    public Instruction buildDepositInstruction(
+            UUID remittanceId,
+            PublicKey senderWallet,
+            PublicKey claimAuthority,
+            BigDecimal amountUsdc,
+            long expiryTimestamp) {
+
+        var remittanceIdBytes = uuidToBytes(remittanceId);
+        var escrowPda = deriveEscrowPda(remittanceIdBytes);
+        var senderAta = deriveAssociatedTokenAddress(senderWallet, solanaProperties.usdcMint());
+        var vaultAta = deriveAssociatedTokenAddress(escrowPda, solanaProperties.usdcMint());
+        var lamports = usdcToLamports(amountUsdc);
+
+        var data = buildDepositData(remittanceIdBytes, lamports, expiryTimestamp);
+
+        var keys = List.of(
+                AccountMeta.signerAndWritable(senderWallet),
+                AccountMeta.writable(escrowPda),
+                AccountMeta.writable(vaultAta),
+                AccountMeta.writable(senderAta),
+                new AccountMeta(claimAuthority, false, false),
+                new AccountMeta(solanaProperties.usdcMint(), false, false),
+                new AccountMeta(TOKEN_PROGRAM_ID, false, false),
+                new AccountMeta(ASSOCIATED_TOKEN_PROGRAM_ID, false, false),
+                new AccountMeta(SYSTEM_PROGRAM_ID, false, false),
+                new AccountMeta(RENT_SYSVAR, false, false));
+
+        log.debug("Built deposit instruction for remittance {} with escrow PDA {}",
+                remittanceId, escrowPda.toBase58());
+
+        return new BaseInstruction(data, keys, solanaProperties.escrowProgramId());
+    }
+
+    public Instruction buildClaimInstruction(
+            UUID remittanceId,
+            PublicKey claimAuthority,
+            PublicKey destinationTokenAccount) {
+
+        var remittanceIdBytes = uuidToBytes(remittanceId);
+        var escrowPda = deriveEscrowPda(remittanceIdBytes);
+        var vaultAta = deriveAssociatedTokenAddress(escrowPda, solanaProperties.usdcMint());
+
+        var data = buildClaimData();
+
+        var keys = List.of(
+                AccountMeta.signerAndWritable(claimAuthority),
+                AccountMeta.writable(escrowPda),
+                AccountMeta.writable(vaultAta),
+                AccountMeta.writable(destinationTokenAccount),
+                new AccountMeta(solanaProperties.usdcMint(), false, false),
+                new AccountMeta(TOKEN_PROGRAM_ID, false, false));
+
+        log.debug("Built claim instruction for remittance {} with destination {}",
+                remittanceId, destinationTokenAccount.toBase58());
+
+        return new BaseInstruction(data, keys, solanaProperties.escrowProgramId());
+    }
+
+    public Instruction buildRefundInstruction(UUID remittanceId, PublicKey senderWallet) {
+        var remittanceIdBytes = uuidToBytes(remittanceId);
+        var escrowPda = deriveEscrowPda(remittanceIdBytes);
+        var vaultAta = deriveAssociatedTokenAddress(escrowPda, solanaProperties.usdcMint());
+        var senderAta = deriveAssociatedTokenAddress(senderWallet, solanaProperties.usdcMint());
+
+        var data = buildRefundData();
+
+        var keys = List.of(
+                AccountMeta.writable(senderWallet),
+                AccountMeta.writable(escrowPda),
+                AccountMeta.writable(vaultAta),
+                AccountMeta.writable(senderAta),
+                new AccountMeta(solanaProperties.usdcMint(), false, false),
+                new AccountMeta(TOKEN_PROGRAM_ID, false, false));
+
+        log.debug("Built refund instruction for remittance {} returning to {}",
+                remittanceId, senderWallet.toBase58());
+
+        return new BaseInstruction(data, keys, solanaProperties.escrowProgramId());
+    }
+
+    public PublicKey deriveEscrowPda(byte[] remittanceIdBytes) {
+        try {
+            return findProgramDerivedAddress(
+                    List.of(ESCROW_SEED_PREFIX, remittanceIdBytes),
+                    solanaProperties.escrowProgramId());
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.pdaDerivationFailed(
+                    "escrow:" + Arrays.toString(remittanceIdBytes), e);
+        }
+    }
+
+    public PublicKey deriveAssociatedTokenAddress(PublicKey owner, PublicKey mint) {
+        try {
+            return PublicKey.findProgramDerivedAddress(owner, mint)
+                    .getPublicKey();
+        } catch (Exception e) {
+            throw SolanaTransactionException.pdaDerivationFailed(
+                    "ata:" + owner.toBase58() + ":" + mint.toBase58(), e);
+        }
+    }
+
+    byte[] buildDepositData(byte[] remittanceIdBytes, long lamports, long expiryTimestamp) {
+        var discriminator = anchorDiscriminator("global:deposit");
+        var buffer = ByteBuffer.allocate(8 + 16 + 8 + 8)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .put(discriminator)
+                .put(remittanceIdBytes)
+                .putLong(lamports)
+                .putLong(expiryTimestamp);
+        return buffer.array();
+    }
+
+    byte[] buildClaimData() {
+        return anchorDiscriminator("global:claim");
+    }
+
+    byte[] buildRefundData() {
+        return anchorDiscriminator("global:refund");
+    }
+
+    byte[] anchorDiscriminator(String instructionName) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var hash = digest.digest(instructionName.getBytes());
+            return Arrays.copyOfRange(hash, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    static PublicKey findProgramDerivedAddress(List<byte[]> seeds, PublicKey programId) {
+        for (var nonce = 255; nonce >= 0; nonce--) {
+            try {
+                var address = createProgramAddress(seeds, (byte) nonce, programId);
+                return address;
+            } catch (IllegalArgumentException e) {
+                // nonce produces on-curve point, try next
+            }
+        }
+        throw new RuntimeException("Unable to find program derived address");
+    }
+
+    private static PublicKey createProgramAddress(
+            List<byte[]> seeds, byte nonce, PublicKey programId) {
+        try {
+            var totalSize = seeds.stream().mapToInt(s -> s.length).sum()
+                    + 1 // nonce byte
+                    + programId.bytes().length
+                    + PDA_MARKER.length;
+
+            var buffer = ByteBuffer.allocate(totalSize);
+            seeds.forEach(buffer::put);
+            buffer.put(nonce);
+            buffer.put(programId.bytes());
+            buffer.put(PDA_MARKER);
+
+            var hash = MessageDigest.getInstance("SHA-256").digest(buffer.array());
+
+            if (isOnCurve(hash)) {
+                throw new IllegalArgumentException("Invalid seeds: address is on curve");
+            }
+            return new PublicKey(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static boolean isOnCurve(byte[] point) {
+        try {
+            // Attempt to create a PublicKey and verify a dummy signature.
+            // If the point is on the Ed25519 curve, verify() will not throw.
+            // For PDA derivation, we need off-curve points.
+            // A simpler heuristic: try to use the bytes as a public key
+            // and check using TweetNaCl verify. But since we don't have
+            // direct access to TweetNaCl from Java, we rely on sol4k's
+            // PublicKey construction (which accepts any 32 bytes) and
+            // use a verification attempt as a proxy check.
+            //
+            // In practice, the probability of SHA-256 output landing on
+            // the Ed25519 curve is negligible (~1/2^128), so most nonces
+            // will work on the first try. We still iterate for correctness.
+            var pk = new PublicKey(point);
+            return pk.verify(new byte[64], new byte[32]);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static byte[] uuidToBytes(UUID uuid) {
+        var buffer = ByteBuffer.allocate(16)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putLong(uuid.getMostSignificantBits())
+                .putLong(uuid.getLeastSignificantBits());
+        return buffer.array();
+    }
+
+    static long usdcToLamports(BigDecimal amountUsdc) {
+        return amountUsdc.movePointRight(USDC_DECIMALS).longValueExact();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
@@ -1,0 +1,28 @@
+package com.stablepay.infrastructure.solana;
+
+import org.sol4k.Connection;
+import org.sol4k.PublicKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SolanaConfig {
+
+    @Bean
+    public Connection solanaConnection(
+            @Value("${stablepay.solana.rpc-url:#{T(org.sol4k.RpcUrl).DEVNET.getUrl()}}") String rpcUrl) {
+        return new Connection(rpcUrl);
+    }
+
+    @Bean
+    public SolanaProperties solanaProperties(
+            @Value("${stablepay.solana.escrow-program-id}") String escrowProgramId,
+            @Value("${stablepay.solana.usdc-mint}") String usdcMint,
+            @Value("${stablepay.solana.claim-authority-private-key:}") String claimAuthorityPrivateKey) {
+        return new SolanaProperties(
+                new PublicKey(escrowProgramId),
+                new PublicKey(usdcMint),
+                claimAuthorityPrivateKey);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
@@ -11,7 +11,7 @@ public class SolanaConfig {
 
     @Bean
     public Connection solanaConnection(
-            @Value("${stablepay.solana.rpc-url:#{T(org.sol4k.RpcUrl).DEVNET.getUrl()}}") String rpcUrl) {
+            @Value("${stablepay.solana.rpc-url:https://api.devnet.solana.com}") String rpcUrl) {
         return new Connection(rpcUrl);
     }
 

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaProperties.java
@@ -1,5 +1,7 @@
 package com.stablepay.infrastructure.solana;
 
+import java.util.Objects;
+
 import org.sol4k.PublicKey;
 
 import lombok.Builder;
@@ -9,4 +11,9 @@ public record SolanaProperties(
     PublicKey escrowProgramId,
     PublicKey usdcMint,
     String claimAuthorityPrivateKey
-) {}
+) {
+    public SolanaProperties {
+        Objects.requireNonNull(escrowProgramId, "escrowProgramId must not be null");
+        Objects.requireNonNull(usdcMint, "usdcMint must not be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaProperties.java
@@ -1,0 +1,12 @@
+package com.stablepay.infrastructure.solana;
+
+import org.sol4k.PublicKey;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SolanaProperties(
+    PublicKey escrowProgramId,
+    PublicKey usdcMint,
+    String claimAuthorityPrivateKey
+) {}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -38,14 +38,20 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
 
         try {
             var senderWallet = new PublicKey(senderWalletAddress);
-            var claimAuthority = deriveClaimAuthorityPublicKey();
+            var claimAuthority = resolveClaimAuthorityKeypair().getPublicKey();
 
             var instruction = escrowInstructionBuilder.buildDepositInstruction(
                     remittanceId, senderWallet, claimAuthority, amountUsdc, expiryTimestamp);
 
+            // TODO: Deposit requires sender wallet signature via MPC sidecar (STA-7).
+            // For now, build the transaction unsigned — it will fail on sendTransaction
+            // until MPC signing is integrated.
             var blockhash = solanaConnection.getLatestBlockhash();
             var message = TransactionMessage.newMessage(senderWallet, blockhash, instruction);
             var transaction = new VersionedTransaction(message);
+
+            log.warn("Deposit transaction for remittance {} is unsigned — MPC signing not yet integrated",
+                    remittanceId);
 
             var signature = solanaConnection.sendTransaction(transaction);
             log.info("Escrow deposit submitted for remittance {} with signature {}",
@@ -91,15 +97,15 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
     }
 
     @Override
-    public String refundEscrow(UUID remittanceId) {
+    public String refundEscrow(UUID remittanceId, String senderWalletAddress) {
         log.info("Submitting escrow refund for remittance {}", remittanceId);
 
         try {
             var claimAuthorityKeypair = resolveClaimAuthorityKeypair();
-            var senderWallet = claimAuthorityKeypair.getPublicKey();
+            var senderWallet = new PublicKey(senderWalletAddress);
 
             var instruction = escrowInstructionBuilder.buildRefundInstruction(
-                    remittanceId, senderWallet);
+                    remittanceId, claimAuthorityKeypair.getPublicKey(), senderWallet);
 
             var blockhash = solanaConnection.getLatestBlockhash();
             var message = TransactionMessage.newMessage(
@@ -131,19 +137,10 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
         return "CONFIRMED";
     }
 
-    private PublicKey deriveClaimAuthorityPublicKey() {
-        var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
-        if (privateKeyStr == null || privateKeyStr.isBlank()) {
-            return Keypair.generate().getPublicKey();
-        }
-        return Keypair.fromSecretKey(Base58.decode(privateKeyStr)).getPublicKey();
-    }
-
     private Keypair resolveClaimAuthorityKeypair() {
         var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
         if (privateKeyStr == null || privateKeyStr.isBlank()) {
-            log.warn("No claim authority private key configured, generating ephemeral keypair");
-            return Keypair.generate();
+            throw SolanaTransactionException.claimAuthorityNotConfigured();
         }
         return Keypair.fromSecretKey(Base58.decode(privateKeyStr));
     }

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -1,0 +1,150 @@
+package com.stablepay.infrastructure.solana;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.sol4k.Base58;
+import org.sol4k.Connection;
+import org.sol4k.Keypair;
+import org.sol4k.PublicKey;
+import org.sol4k.TransactionMessage;
+import org.sol4k.VersionedTransaction;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+import com.stablepay.domain.remittance.port.SolanaTransactionService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SolanaTransactionServiceAdapter implements SolanaTransactionService {
+
+    private final Connection solanaConnection;
+    private final EscrowInstructionBuilder escrowInstructionBuilder;
+    private final SolanaProperties solanaProperties;
+
+    @Override
+    public String depositEscrow(
+            UUID remittanceId,
+            String senderWalletAddress,
+            BigDecimal amountUsdc,
+            long expiryTimestamp) {
+
+        log.info("Submitting escrow deposit for remittance {} amount {} USDC",
+                remittanceId, amountUsdc);
+
+        try {
+            var senderWallet = new PublicKey(senderWalletAddress);
+            var claimAuthority = deriveClaimAuthorityPublicKey();
+
+            var instruction = escrowInstructionBuilder.buildDepositInstruction(
+                    remittanceId, senderWallet, claimAuthority, amountUsdc, expiryTimestamp);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(senderWallet, blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+
+            var signature = solanaConnection.sendTransaction(transaction);
+            log.info("Escrow deposit submitted for remittance {} with signature {}",
+                    remittanceId, signature);
+
+            return signature;
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "deposit:" + remittanceId, e);
+        }
+    }
+
+    @Override
+    public String claimEscrow(UUID remittanceId, String destinationTokenAccount) {
+        log.info("Submitting escrow claim for remittance {}", remittanceId);
+
+        try {
+            var claimAuthorityKeypair = resolveClaimAuthorityKeypair();
+            var destination = new PublicKey(destinationTokenAccount);
+
+            var instruction = escrowInstructionBuilder.buildClaimInstruction(
+                    remittanceId, claimAuthorityKeypair.getPublicKey(), destination);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(
+                    claimAuthorityKeypair.getPublicKey(), blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+            transaction.sign(claimAuthorityKeypair);
+
+            var signature = solanaConnection.sendTransaction(transaction);
+            log.info("Escrow claim submitted for remittance {} with signature {}",
+                    remittanceId, signature);
+
+            return signature;
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "claim:" + remittanceId, e);
+        }
+    }
+
+    @Override
+    public String refundEscrow(UUID remittanceId) {
+        log.info("Submitting escrow refund for remittance {}", remittanceId);
+
+        try {
+            var claimAuthorityKeypair = resolveClaimAuthorityKeypair();
+            var senderWallet = claimAuthorityKeypair.getPublicKey();
+
+            var instruction = escrowInstructionBuilder.buildRefundInstruction(
+                    remittanceId, senderWallet);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(
+                    claimAuthorityKeypair.getPublicKey(), blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+            transaction.sign(claimAuthorityKeypair);
+
+            var signature = solanaConnection.sendTransaction(transaction);
+            log.info("Escrow refund submitted for remittance {} with signature {}",
+                    remittanceId, signature);
+
+            return signature;
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "refund:" + remittanceId, e);
+        }
+    }
+
+    @Override
+    public String getTransactionStatus(String transactionSignature) {
+        log.debug("Checking status for transaction {}", transactionSignature);
+
+        // sol4k does not expose getSignatureStatuses RPC.
+        // For now, return a stub status. Full confirmation polling
+        // will be implemented via raw JSON-RPC in a follow-up.
+        log.info("Transaction status check for {} (stub: returning CONFIRMED)", transactionSignature);
+        return "CONFIRMED";
+    }
+
+    private PublicKey deriveClaimAuthorityPublicKey() {
+        var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
+        if (privateKeyStr == null || privateKeyStr.isBlank()) {
+            return Keypair.generate().getPublicKey();
+        }
+        return Keypair.fromSecretKey(Base58.decode(privateKeyStr)).getPublicKey();
+    }
+
+    private Keypair resolveClaimAuthorityKeypair() {
+        var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
+        if (privateKeyStr == null || privateKeyStr.isBlank()) {
+            log.warn("No claim authority private key configured, generating ephemeral keypair");
+            return Keypair.generate();
+        }
+        return Keypair.fromSecretKey(Base58.decode(privateKeyStr));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,11 @@ stablepay:
   fx:
     api:
       base-url: https://open.er-api.com
+  solana:
+    rpc-url: https://api.devnet.solana.com
+    escrow-program-id: ${STABLEPAY_ESCROW_PROGRAM_ID:11111111111111111111111111111111}
+    usdc-mint: ${USDC_MINT:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU}
+    claim-authority-private-key: ${CLAIM_AUTHORITY_PRIVATE_KEY:}
 
 management:
   endpoints:

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilderTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilderTest.java
@@ -1,0 +1,279 @@
+package com.stablepay.infrastructure.solana;
+
+import static com.stablepay.testutil.SolanaFixtures.SOME_AMOUNT_LAMPORTS;
+import static com.stablepay.testutil.SolanaFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.SolanaFixtures.SOME_CLAIM_AUTHORITY;
+import static com.stablepay.testutil.SolanaFixtures.SOME_EXPIRY_TIMESTAMP;
+import static com.stablepay.testutil.SolanaFixtures.SOME_PROGRAM_ID;
+import static com.stablepay.testutil.SolanaFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.SolanaFixtures.SOME_SENDER_WALLET;
+import static com.stablepay.testutil.SolanaFixtures.SOME_USDC_MINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sol4k.PublicKey;
+
+class EscrowInstructionBuilderTest {
+
+    private EscrowInstructionBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        var properties = new SolanaProperties(
+                new PublicKey(SOME_PROGRAM_ID),
+                new PublicKey(SOME_USDC_MINT),
+                "");
+        builder = new EscrowInstructionBuilder(properties);
+    }
+
+    @Test
+    void shouldBuildDepositInstructionWithCorrectProgramId() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+
+        // when
+        var instruction = builder.buildDepositInstruction(
+                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+        // then
+        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+    }
+
+    @Test
+    void shouldBuildDepositInstructionWithCorrectAccountCount() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+
+        // when
+        var instruction = builder.buildDepositInstruction(
+                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+        // then
+        assertThat(instruction.getKeys()).hasSize(10);
+    }
+
+    @Test
+    void shouldBuildDepositInstructionWithSenderAsSignerAndWritable() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+
+        // when
+        var instruction = builder.buildDepositInstruction(
+                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+        // then
+        var senderMeta = instruction.getKeys().getFirst();
+        assertThat(senderMeta.getPublicKey()).isEqualTo(senderWallet);
+        assertThat(senderMeta.getSigner()).isTrue();
+        assertThat(senderMeta.getWritable()).isTrue();
+    }
+
+    @Test
+    void shouldBuildDepositDataWithCorrectDiscriminator() throws Exception {
+        // given
+        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+
+        // when
+        var data = builder.buildDepositData(
+                remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+
+        // then
+        var expectedDiscriminator = Arrays.copyOfRange(
+                MessageDigest.getInstance("SHA-256").digest("global:deposit".getBytes()), 0, 8);
+        var actualDiscriminator = Arrays.copyOfRange(data, 0, 8);
+        assertThat(actualDiscriminator).isEqualTo(expectedDiscriminator);
+    }
+
+    @Test
+    void shouldBuildDepositDataWithCorrectLayout() {
+        // given
+        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+
+        // when
+        var data = builder.buildDepositData(
+                remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+
+        // then
+        assertThat(data).hasSize(8 + 16 + 8 + 8);
+
+        var buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
+        buffer.position(8);
+        var actualRemittanceId = new byte[16];
+        buffer.get(actualRemittanceId);
+        assertThat(actualRemittanceId).isEqualTo(remittanceIdBytes);
+
+        var actualAmount = buffer.getLong();
+        assertThat(actualAmount).isEqualTo(SOME_AMOUNT_LAMPORTS);
+
+        var actualExpiry = buffer.getLong();
+        assertThat(actualExpiry).isEqualTo(SOME_EXPIRY_TIMESTAMP);
+    }
+
+    @Test
+    void shouldBuildClaimInstructionWithCorrectProgramId() {
+        // given
+        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+        var destination = new PublicKey("DestToken111111111111111111111111111111111");
+
+        // when
+        var instruction = builder.buildClaimInstruction(
+                SOME_REMITTANCE_ID, claimAuthority, destination);
+
+        // then
+        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+    }
+
+    @Test
+    void shouldBuildClaimInstructionWithCorrectAccountCount() {
+        // given
+        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+        var destination = new PublicKey("DestToken111111111111111111111111111111111");
+
+        // when
+        var instruction = builder.buildClaimInstruction(
+                SOME_REMITTANCE_ID, claimAuthority, destination);
+
+        // then
+        assertThat(instruction.getKeys()).hasSize(6);
+    }
+
+    @Test
+    void shouldBuildClaimDataWithOnlyDiscriminator() {
+        // when
+        var data = builder.buildClaimData();
+
+        // then
+        assertThat(data).hasSize(8);
+        var expectedDiscriminator = builder.anchorDiscriminator("global:claim");
+        assertThat(data).isEqualTo(expectedDiscriminator);
+    }
+
+    @Test
+    void shouldBuildRefundInstructionWithCorrectProgramId() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+
+        // when
+        var instruction = builder.buildRefundInstruction(SOME_REMITTANCE_ID, senderWallet);
+
+        // then
+        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+    }
+
+    @Test
+    void shouldBuildRefundInstructionWithCorrectAccountCount() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+
+        // when
+        var instruction = builder.buildRefundInstruction(SOME_REMITTANCE_ID, senderWallet);
+
+        // then
+        assertThat(instruction.getKeys()).hasSize(6);
+    }
+
+    @Test
+    void shouldBuildRefundDataWithOnlyDiscriminator() {
+        // when
+        var data = builder.buildRefundData();
+
+        // then
+        assertThat(data).hasSize(8);
+        var expectedDiscriminator = builder.anchorDiscriminator("global:refund");
+        assertThat(data).isEqualTo(expectedDiscriminator);
+    }
+
+    @Test
+    void shouldConvertUsdcToLamportsCorrectly() {
+        // given
+        var amount = new BigDecimal("100.50");
+
+        // when
+        var lamports = EscrowInstructionBuilder.usdcToLamports(amount);
+
+        // then
+        assertThat(lamports).isEqualTo(100_500_000L);
+    }
+
+    @Test
+    void shouldConvertUuidToBytesCorrectly() {
+        // given
+        var uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+        // when
+        var bytes = EscrowInstructionBuilder.uuidToBytes(uuid);
+
+        // then
+        assertThat(bytes).hasSize(16);
+        var reconstructed = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+        var mostSig = reconstructed.getLong();
+        var leastSig = reconstructed.getLong();
+        assertThat(new UUID(mostSig, leastSig)).isEqualTo(uuid);
+    }
+
+    @Test
+    void shouldProduceDeterministicAnchorDiscriminator() {
+        // when
+        var discriminator1 = builder.anchorDiscriminator("global:deposit");
+        var discriminator2 = builder.anchorDiscriminator("global:deposit");
+
+        // then
+        assertThat(discriminator1).isEqualTo(discriminator2);
+        assertThat(discriminator1).hasSize(8);
+    }
+
+    @Test
+    void shouldProduceDifferentDiscriminatorsForDifferentInstructions() {
+        // when
+        var depositDisc = builder.anchorDiscriminator("global:deposit");
+        var claimDisc = builder.anchorDiscriminator("global:claim");
+        var refundDisc = builder.anchorDiscriminator("global:refund");
+
+        // then
+        assertThat(depositDisc).isNotEqualTo(claimDisc);
+        assertThat(depositDisc).isNotEqualTo(refundDisc);
+        assertThat(claimDisc).isNotEqualTo(refundDisc);
+    }
+
+    @Test
+    void shouldDeriveConsistentEscrowPda() {
+        // given
+        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+
+        // when
+        var pda1 = builder.deriveEscrowPda(remittanceIdBytes);
+        var pda2 = builder.deriveEscrowPda(remittanceIdBytes);
+
+        // then
+        assertThat(pda1).isEqualTo(pda2);
+    }
+
+    @Test
+    void shouldDeriveDifferentPdasForDifferentRemittances() {
+        // given
+        var id1Bytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+        var id2Bytes = EscrowInstructionBuilder.uuidToBytes(
+                UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
+
+        // when
+        var pda1 = builder.deriveEscrowPda(id1Bytes);
+        var pda2 = builder.deriveEscrowPda(id2Bytes);
+
+        // then
+        assertThat(pda1).isNotEqualTo(pda2);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilderTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/EscrowInstructionBuilderTest.java
@@ -18,7 +18,9 @@ import java.util.Arrays;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.sol4k.AccountMeta;
 import org.sol4k.PublicKey;
 
 class EscrowInstructionBuilderTest {
@@ -34,246 +36,283 @@ class EscrowInstructionBuilderTest {
         builder = new EscrowInstructionBuilder(properties);
     }
 
-    @Test
-    void shouldBuildDepositInstructionWithCorrectProgramId() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+    @Nested
+    class DepositInstruction {
 
-        // when
-        var instruction = builder.buildDepositInstruction(
-                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
-                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+        @Test
+        void shouldBuildDepositInstructionWithCorrectProgramId() {
+            // given
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
 
-        // then
-        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+            // when
+            var instruction = builder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+        }
+
+        @Test
+        void shouldBuildDepositInstructionWithCorrectAccountCount() {
+            // given
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+
+            // when
+            var instruction = builder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            assertThat(instruction.getKeys()).hasSize(10);
+        }
+
+        @Test
+        void shouldBuildDepositInstructionWithSenderAsSignerAndWritable() {
+            // given
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+
+            // when
+            var instruction = builder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthority,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            var expected = AccountMeta.signerAndWritable(senderWallet);
+            assertThat(instruction.getKeys().getFirst())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldBuildDepositDataWithCorrectDiscriminator() throws Exception {
+            // given
+            var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+
+            // when
+            var data = builder.buildDepositData(
+                    remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            var expectedDiscriminator = Arrays.copyOfRange(
+                    MessageDigest.getInstance("SHA-256").digest("global:deposit".getBytes()), 0, 8);
+            var actualDiscriminator = Arrays.copyOfRange(data, 0, 8);
+            assertThat(actualDiscriminator).isEqualTo(expectedDiscriminator);
+        }
+
+        @Test
+        void shouldBuildDepositDataWithCorrectLayout() {
+            // given
+            var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+
+            // when
+            var data = builder.buildDepositData(
+                    remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            assertThat(data).hasSize(8 + 16 + 8 + 8);
+
+            var buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
+            buffer.position(8);
+            var actualRemittanceId = new byte[16];
+            buffer.get(actualRemittanceId);
+            assertThat(actualRemittanceId).isEqualTo(remittanceIdBytes);
+
+            var actualAmount = buffer.getLong();
+            assertThat(actualAmount).isEqualTo(SOME_AMOUNT_LAMPORTS);
+
+            var actualExpiry = buffer.getLong();
+            assertThat(actualExpiry).isEqualTo(SOME_EXPIRY_TIMESTAMP);
+        }
     }
 
-    @Test
-    void shouldBuildDepositInstructionWithCorrectAccountCount() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+    @Nested
+    class ClaimInstruction {
 
-        // when
-        var instruction = builder.buildDepositInstruction(
-                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
-                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+        @Test
+        void shouldBuildClaimInstructionWithCorrectProgramId() {
+            // given
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+            var destination = new PublicKey("DestToken111111111111111111111111111111111");
 
-        // then
-        assertThat(instruction.getKeys()).hasSize(10);
+            // when
+            var instruction = builder.buildClaimInstruction(
+                    SOME_REMITTANCE_ID, claimAuthority, destination);
+
+            // then
+            assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+        }
+
+        @Test
+        void shouldBuildClaimInstructionWithCorrectAccountCount() {
+            // given
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+            var destination = new PublicKey("DestToken111111111111111111111111111111111");
+
+            // when
+            var instruction = builder.buildClaimInstruction(
+                    SOME_REMITTANCE_ID, claimAuthority, destination);
+
+            // then
+            assertThat(instruction.getKeys()).hasSize(6);
+        }
+
+        @Test
+        void shouldBuildClaimDataWithOnlyDiscriminator() {
+            // when
+            var data = builder.buildClaimData();
+
+            // then
+            assertThat(data).hasSize(8);
+            var expectedDiscriminator = builder.anchorDiscriminator("global:claim");
+            assertThat(data).isEqualTo(expectedDiscriminator);
+        }
     }
 
-    @Test
-    void shouldBuildDepositInstructionWithSenderAsSignerAndWritable() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+    @Nested
+    class RefundInstruction {
 
-        // when
-        var instruction = builder.buildDepositInstruction(
-                SOME_REMITTANCE_ID, senderWallet, claimAuthority,
-                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+        @Test
+        void shouldBuildRefundInstructionWithCorrectProgramId() {
+            // given
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
 
-        // then
-        var senderMeta = instruction.getKeys().getFirst();
-        assertThat(senderMeta.getPublicKey()).isEqualTo(senderWallet);
-        assertThat(senderMeta.getSigner()).isTrue();
-        assertThat(senderMeta.getWritable()).isTrue();
+            // when
+            var instruction = builder.buildRefundInstruction(
+                    SOME_REMITTANCE_ID, claimAuthority, senderWallet);
+
+            // then
+            assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
+        }
+
+        @Test
+        void shouldBuildRefundInstructionWithCorrectAccountCount() {
+            // given
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+
+            // when
+            var instruction = builder.buildRefundInstruction(
+                    SOME_REMITTANCE_ID, claimAuthority, senderWallet);
+
+            // then
+            assertThat(instruction.getKeys()).hasSize(7);
+        }
+
+        @Test
+        void shouldBuildRefundInstructionWithClaimAuthorityAsSigner() {
+            // given
+            var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+
+            // when
+            var instruction = builder.buildRefundInstruction(
+                    SOME_REMITTANCE_ID, claimAuthority, senderWallet);
+
+            // then
+            var expected = AccountMeta.signerAndWritable(claimAuthority);
+            assertThat(instruction.getKeys().getFirst())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldBuildRefundDataWithOnlyDiscriminator() {
+            // when
+            var data = builder.buildRefundData();
+
+            // then
+            assertThat(data).hasSize(8);
+            var expectedDiscriminator = builder.anchorDiscriminator("global:refund");
+            assertThat(data).isEqualTo(expectedDiscriminator);
+        }
     }
 
-    @Test
-    void shouldBuildDepositDataWithCorrectDiscriminator() throws Exception {
-        // given
-        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+    @Nested
+    class Utility {
 
-        // when
-        var data = builder.buildDepositData(
-                remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+        @Test
+        void shouldConvertUsdcToLamportsCorrectly() {
+            // given
+            var amount = new BigDecimal("100.50");
 
-        // then
-        var expectedDiscriminator = Arrays.copyOfRange(
-                MessageDigest.getInstance("SHA-256").digest("global:deposit".getBytes()), 0, 8);
-        var actualDiscriminator = Arrays.copyOfRange(data, 0, 8);
-        assertThat(actualDiscriminator).isEqualTo(expectedDiscriminator);
-    }
+            // when
+            var lamports = EscrowInstructionBuilder.usdcToLamports(amount);
 
-    @Test
-    void shouldBuildDepositDataWithCorrectLayout() {
-        // given
-        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+            // then
+            assertThat(lamports).isEqualTo(100_500_000L);
+        }
 
-        // when
-        var data = builder.buildDepositData(
-                remittanceIdBytes, SOME_AMOUNT_LAMPORTS, SOME_EXPIRY_TIMESTAMP);
+        @Test
+        void shouldConvertUuidToBytesCorrectly() {
+            // given
+            var uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
 
-        // then
-        assertThat(data).hasSize(8 + 16 + 8 + 8);
+            // when
+            var bytes = EscrowInstructionBuilder.uuidToBytes(uuid);
 
-        var buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);
-        buffer.position(8);
-        var actualRemittanceId = new byte[16];
-        buffer.get(actualRemittanceId);
-        assertThat(actualRemittanceId).isEqualTo(remittanceIdBytes);
+            // then
+            assertThat(bytes).hasSize(16);
+            var reconstructed = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+            var mostSig = reconstructed.getLong();
+            var leastSig = reconstructed.getLong();
+            assertThat(new UUID(mostSig, leastSig)).isEqualTo(uuid);
+        }
 
-        var actualAmount = buffer.getLong();
-        assertThat(actualAmount).isEqualTo(SOME_AMOUNT_LAMPORTS);
+        @Test
+        void shouldProduceDeterministicAnchorDiscriminator() {
+            // when
+            var discriminator1 = builder.anchorDiscriminator("global:deposit");
+            var discriminator2 = builder.anchorDiscriminator("global:deposit");
 
-        var actualExpiry = buffer.getLong();
-        assertThat(actualExpiry).isEqualTo(SOME_EXPIRY_TIMESTAMP);
-    }
+            // then
+            assertThat(discriminator1).isEqualTo(discriminator2);
+            assertThat(discriminator1).hasSize(8);
+        }
 
-    @Test
-    void shouldBuildClaimInstructionWithCorrectProgramId() {
-        // given
-        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
-        var destination = new PublicKey("DestToken111111111111111111111111111111111");
+        @Test
+        void shouldProduceDifferentDiscriminatorsForDifferentInstructions() {
+            // when
+            var depositDisc = builder.anchorDiscriminator("global:deposit");
+            var claimDisc = builder.anchorDiscriminator("global:claim");
+            var refundDisc = builder.anchorDiscriminator("global:refund");
 
-        // when
-        var instruction = builder.buildClaimInstruction(
-                SOME_REMITTANCE_ID, claimAuthority, destination);
+            // then
+            assertThat(depositDisc).isNotEqualTo(claimDisc);
+            assertThat(depositDisc).isNotEqualTo(refundDisc);
+            assertThat(claimDisc).isNotEqualTo(refundDisc);
+        }
 
-        // then
-        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
-    }
+        @Test
+        void shouldDeriveConsistentEscrowPda() {
+            // given
+            var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
 
-    @Test
-    void shouldBuildClaimInstructionWithCorrectAccountCount() {
-        // given
-        var claimAuthority = new PublicKey(SOME_CLAIM_AUTHORITY);
-        var destination = new PublicKey("DestToken111111111111111111111111111111111");
+            // when
+            var pda1 = builder.deriveEscrowPda(remittanceIdBytes);
+            var pda2 = builder.deriveEscrowPda(remittanceIdBytes);
 
-        // when
-        var instruction = builder.buildClaimInstruction(
-                SOME_REMITTANCE_ID, claimAuthority, destination);
+            // then
+            assertThat(pda1).isEqualTo(pda2);
+        }
 
-        // then
-        assertThat(instruction.getKeys()).hasSize(6);
-    }
+        @Test
+        void shouldDeriveDifferentPdasForDifferentRemittances() {
+            // given
+            var id1Bytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
+            var id2Bytes = EscrowInstructionBuilder.uuidToBytes(
+                    UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
 
-    @Test
-    void shouldBuildClaimDataWithOnlyDiscriminator() {
-        // when
-        var data = builder.buildClaimData();
+            // when
+            var pda1 = builder.deriveEscrowPda(id1Bytes);
+            var pda2 = builder.deriveEscrowPda(id2Bytes);
 
-        // then
-        assertThat(data).hasSize(8);
-        var expectedDiscriminator = builder.anchorDiscriminator("global:claim");
-        assertThat(data).isEqualTo(expectedDiscriminator);
-    }
-
-    @Test
-    void shouldBuildRefundInstructionWithCorrectProgramId() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-
-        // when
-        var instruction = builder.buildRefundInstruction(SOME_REMITTANCE_ID, senderWallet);
-
-        // then
-        assertThat(instruction.getProgramId()).isEqualTo(new PublicKey(SOME_PROGRAM_ID));
-    }
-
-    @Test
-    void shouldBuildRefundInstructionWithCorrectAccountCount() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-
-        // when
-        var instruction = builder.buildRefundInstruction(SOME_REMITTANCE_ID, senderWallet);
-
-        // then
-        assertThat(instruction.getKeys()).hasSize(6);
-    }
-
-    @Test
-    void shouldBuildRefundDataWithOnlyDiscriminator() {
-        // when
-        var data = builder.buildRefundData();
-
-        // then
-        assertThat(data).hasSize(8);
-        var expectedDiscriminator = builder.anchorDiscriminator("global:refund");
-        assertThat(data).isEqualTo(expectedDiscriminator);
-    }
-
-    @Test
-    void shouldConvertUsdcToLamportsCorrectly() {
-        // given
-        var amount = new BigDecimal("100.50");
-
-        // when
-        var lamports = EscrowInstructionBuilder.usdcToLamports(amount);
-
-        // then
-        assertThat(lamports).isEqualTo(100_500_000L);
-    }
-
-    @Test
-    void shouldConvertUuidToBytesCorrectly() {
-        // given
-        var uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-
-        // when
-        var bytes = EscrowInstructionBuilder.uuidToBytes(uuid);
-
-        // then
-        assertThat(bytes).hasSize(16);
-        var reconstructed = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
-        var mostSig = reconstructed.getLong();
-        var leastSig = reconstructed.getLong();
-        assertThat(new UUID(mostSig, leastSig)).isEqualTo(uuid);
-    }
-
-    @Test
-    void shouldProduceDeterministicAnchorDiscriminator() {
-        // when
-        var discriminator1 = builder.anchorDiscriminator("global:deposit");
-        var discriminator2 = builder.anchorDiscriminator("global:deposit");
-
-        // then
-        assertThat(discriminator1).isEqualTo(discriminator2);
-        assertThat(discriminator1).hasSize(8);
-    }
-
-    @Test
-    void shouldProduceDifferentDiscriminatorsForDifferentInstructions() {
-        // when
-        var depositDisc = builder.anchorDiscriminator("global:deposit");
-        var claimDisc = builder.anchorDiscriminator("global:claim");
-        var refundDisc = builder.anchorDiscriminator("global:refund");
-
-        // then
-        assertThat(depositDisc).isNotEqualTo(claimDisc);
-        assertThat(depositDisc).isNotEqualTo(refundDisc);
-        assertThat(claimDisc).isNotEqualTo(refundDisc);
-    }
-
-    @Test
-    void shouldDeriveConsistentEscrowPda() {
-        // given
-        var remittanceIdBytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
-
-        // when
-        var pda1 = builder.deriveEscrowPda(remittanceIdBytes);
-        var pda2 = builder.deriveEscrowPda(remittanceIdBytes);
-
-        // then
-        assertThat(pda1).isEqualTo(pda2);
-    }
-
-    @Test
-    void shouldDeriveDifferentPdasForDifferentRemittances() {
-        // given
-        var id1Bytes = EscrowInstructionBuilder.uuidToBytes(SOME_REMITTANCE_ID);
-        var id2Bytes = EscrowInstructionBuilder.uuidToBytes(
-                UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
-
-        // when
-        var pda1 = builder.deriveEscrowPda(id1Bytes);
-        var pda2 = builder.deriveEscrowPda(id2Bytes);
-
-        // then
-        assertThat(pda1).isNotEqualTo(pda2);
+            // then
+            assertThat(pda1).isNotEqualTo(pda2);
+        }
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -1,22 +1,35 @@
 package com.stablepay.infrastructure.solana;
 
 import static com.stablepay.testutil.SolanaFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.SolanaFixtures.SOME_BLOCKHASH;
+import static com.stablepay.testutil.SolanaFixtures.SOME_CLAIM_AUTHORITY_PRIVATE_KEY;
+import static com.stablepay.testutil.SolanaFixtures.SOME_CLAIM_AUTHORITY_PUBLIC_KEY;
 import static com.stablepay.testutil.SolanaFixtures.SOME_DESTINATION_TOKEN_ACCOUNT;
 import static com.stablepay.testutil.SolanaFixtures.SOME_EXPIRY_TIMESTAMP;
+import static com.stablepay.testutil.SolanaFixtures.SOME_PROGRAM_ID;
 import static com.stablepay.testutil.SolanaFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.SolanaFixtures.SOME_SENDER_WALLET;
 import static com.stablepay.testutil.SolanaFixtures.SOME_TRANSACTION_SIGNATURE;
+import static com.stablepay.testutil.SolanaFixtures.SOME_USDC_MINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sol4k.AccountMeta;
 import org.sol4k.Connection;
 import org.sol4k.PublicKey;
+import org.sol4k.VersionedTransaction;
+import org.sol4k.instruction.BaseInstruction;
 
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 
@@ -29,70 +42,162 @@ class SolanaTransactionServiceAdapterTest {
     @Mock
     private EscrowInstructionBuilder escrowInstructionBuilder;
 
-    private SolanaProperties solanaProperties;
-
-    private SolanaTransactionServiceAdapter adapter;
+    private SolanaProperties propertiesWithKey;
+    private SolanaProperties propertiesWithoutKey;
 
     @BeforeEach
     void setUp() {
-        solanaProperties = new SolanaProperties(
-                new PublicKey("EscrowProgram111111111111111111111111111111"),
-                new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+        propertiesWithKey = new SolanaProperties(
+                new PublicKey(SOME_PROGRAM_ID),
+                new PublicKey(SOME_USDC_MINT),
+                SOME_CLAIM_AUTHORITY_PRIVATE_KEY);
+        propertiesWithoutKey = new SolanaProperties(
+                new PublicKey(SOME_PROGRAM_ID),
+                new PublicKey(SOME_USDC_MINT),
                 "");
-        adapter = new SolanaTransactionServiceAdapter(
-                solanaConnection, escrowInstructionBuilder, solanaProperties);
     }
 
-    @Test
-    void shouldReturnConfirmedForTransactionStatusStub() {
-        // given
-        var signature = SOME_TRANSACTION_SIGNATURE;
+    @Nested
+    class GetTransactionStatus {
 
-        // when
-        var result = adapter.getTransactionStatus(signature);
+        @Test
+        void shouldReturnConfirmedForTransactionStatusStub() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
 
-        // then
-        assertThat(result).isEqualTo("CONFIRMED");
+            // when
+            var result = adapter.getTransactionStatus(SOME_TRANSACTION_SIGNATURE);
+
+            // then
+            assertThat(result).isEqualTo("CONFIRMED");
+        }
     }
 
-    @Test
-    void shouldThrowSolanaTransactionExceptionWhenDepositBuildFails() {
-        // given
-        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
-        given(escrowInstructionBuilder.buildDepositInstruction(
-                SOME_REMITTANCE_ID,
-                senderWallet,
-                senderWallet,
-                SOME_AMOUNT_USDC,
-                SOME_EXPIRY_TIMESTAMP))
-                .willThrow(new RuntimeException("Build failed"));
+    @Nested
+    class ClaimEscrow {
 
-        // when / then
-        assertThatThrownBy(() -> adapter.depositEscrow(
-                SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
-                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
-                .isInstanceOf(SolanaTransactionException.class)
-                .hasMessageContaining("SP-0010");
+        @Test
+        void shouldSubmitClaimTransactionAndReturnSignature() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+            var destination = new PublicKey(SOME_DESTINATION_TOKEN_ACCOUNT);
+            var instruction = new BaseInstruction(
+                    new byte[8], List.of(AccountMeta.signerAndWritable(claimAuthorityPubKey)),
+                    new PublicKey(SOME_PROGRAM_ID));
+
+            given(escrowInstructionBuilder.buildClaimInstruction(
+                    SOME_REMITTANCE_ID, claimAuthorityPubKey, destination))
+                    .willReturn(instruction);
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(solanaConnection.sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            var result = adapter.claimEscrow(SOME_REMITTANCE_ID, SOME_DESTINATION_TOKEN_ACCOUNT);
+
+            // then
+            assertThat(result).isEqualTo(SOME_TRANSACTION_SIGNATURE);
+            then(solanaConnection).should().sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull());
+        }
+
+        @Test
+        void shouldThrowWhenClaimAuthorityNotConfigured() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.claimEscrow(
+                    SOME_REMITTANCE_ID, SOME_DESTINATION_TOKEN_ACCOUNT))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0014");
+        }
     }
 
-    @Test
-    void shouldThrowSolanaTransactionExceptionWhenClaimBuildFails() {
-        // given — adapter has empty claim authority key, generates ephemeral keypair
-        // The connection call will fail because no instruction was built
+    @Nested
+    class RefundEscrow {
 
-        // when / then
-        assertThatThrownBy(() -> adapter.claimEscrow(
-                SOME_REMITTANCE_ID, SOME_DESTINATION_TOKEN_ACCOUNT))
-                .isInstanceOf(SolanaTransactionException.class);
+        @Test
+        void shouldSubmitRefundTransactionAndReturnSignature() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var instruction = new BaseInstruction(
+                    new byte[8], List.of(AccountMeta.signerAndWritable(claimAuthorityPubKey)),
+                    new PublicKey(SOME_PROGRAM_ID));
+
+            given(escrowInstructionBuilder.buildRefundInstruction(
+                    SOME_REMITTANCE_ID, claimAuthorityPubKey, senderWallet))
+                    .willReturn(instruction);
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(solanaConnection.sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            var result = adapter.refundEscrow(SOME_REMITTANCE_ID, SOME_SENDER_WALLET);
+
+            // then
+            assertThat(result).isEqualTo(SOME_TRANSACTION_SIGNATURE);
+            then(solanaConnection).should().sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull());
+        }
+
+        @Test
+        void shouldThrowWhenClaimAuthorityNotConfiguredForRefund() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.refundEscrow(SOME_REMITTANCE_ID, SOME_SENDER_WALLET))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0014");
+        }
     }
 
-    @Test
-    void shouldThrowSolanaTransactionExceptionWhenRefundBuildFails() {
-        // given — adapter has empty claim authority key, generates ephemeral keypair
-        // The connection call will fail because no instruction was built
+    @Nested
+    class DepositEscrow {
 
-        // when / then
-        assertThatThrownBy(() -> adapter.refundEscrow(SOME_REMITTANCE_ID))
-                .isInstanceOf(SolanaTransactionException.class);
+        @Test
+        void shouldThrowWhenClaimAuthorityNotConfiguredForDeposit() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.depositEscrow(
+                    SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0014");
+        }
+
+        @Test
+        void shouldThrowSolanaTransactionExceptionWhenDepositBuildFails() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+
+            given(escrowInstructionBuilder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID,
+                    senderWallet,
+                    claimAuthorityPubKey,
+                    SOME_AMOUNT_USDC,
+                    SOME_EXPIRY_TIMESTAMP))
+                    .willThrow(new RuntimeException("Build failed"));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.depositEscrow(
+                    SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0010");
+        }
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -1,0 +1,98 @@
+package com.stablepay.infrastructure.solana;
+
+import static com.stablepay.testutil.SolanaFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.SolanaFixtures.SOME_DESTINATION_TOKEN_ACCOUNT;
+import static com.stablepay.testutil.SolanaFixtures.SOME_EXPIRY_TIMESTAMP;
+import static com.stablepay.testutil.SolanaFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.SolanaFixtures.SOME_SENDER_WALLET;
+import static com.stablepay.testutil.SolanaFixtures.SOME_TRANSACTION_SIGNATURE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sol4k.Connection;
+import org.sol4k.PublicKey;
+
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+
+@ExtendWith(MockitoExtension.class)
+class SolanaTransactionServiceAdapterTest {
+
+    @Mock
+    private Connection solanaConnection;
+
+    @Mock
+    private EscrowInstructionBuilder escrowInstructionBuilder;
+
+    private SolanaProperties solanaProperties;
+
+    private SolanaTransactionServiceAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        solanaProperties = new SolanaProperties(
+                new PublicKey("EscrowProgram111111111111111111111111111111"),
+                new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+                "");
+        adapter = new SolanaTransactionServiceAdapter(
+                solanaConnection, escrowInstructionBuilder, solanaProperties);
+    }
+
+    @Test
+    void shouldReturnConfirmedForTransactionStatusStub() {
+        // given
+        var signature = SOME_TRANSACTION_SIGNATURE;
+
+        // when
+        var result = adapter.getTransactionStatus(signature);
+
+        // then
+        assertThat(result).isEqualTo("CONFIRMED");
+    }
+
+    @Test
+    void shouldThrowSolanaTransactionExceptionWhenDepositBuildFails() {
+        // given
+        var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+        given(escrowInstructionBuilder.buildDepositInstruction(
+                SOME_REMITTANCE_ID,
+                senderWallet,
+                senderWallet,
+                SOME_AMOUNT_USDC,
+                SOME_EXPIRY_TIMESTAMP))
+                .willThrow(new RuntimeException("Build failed"));
+
+        // when / then
+        assertThatThrownBy(() -> adapter.depositEscrow(
+                SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                .isInstanceOf(SolanaTransactionException.class)
+                .hasMessageContaining("SP-0010");
+    }
+
+    @Test
+    void shouldThrowSolanaTransactionExceptionWhenClaimBuildFails() {
+        // given — adapter has empty claim authority key, generates ephemeral keypair
+        // The connection call will fail because no instruction was built
+
+        // when / then
+        assertThatThrownBy(() -> adapter.claimEscrow(
+                SOME_REMITTANCE_ID, SOME_DESTINATION_TOKEN_ACCOUNT))
+                .isInstanceOf(SolanaTransactionException.class);
+    }
+
+    @Test
+    void shouldThrowSolanaTransactionExceptionWhenRefundBuildFails() {
+        // given — adapter has empty claim authority key, generates ephemeral keypair
+        // The connection call will fail because no instruction was built
+
+        // when / then
+        assertThatThrownBy(() -> adapter.refundEscrow(SOME_REMITTANCE_ID))
+                .isInstanceOf(SolanaTransactionException.class);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
@@ -30,4 +30,10 @@ public final class SolanaFixtures {
 
     public static final String SOME_BLOCKHASH =
             "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi";
+
+    public static final String SOME_CLAIM_AUTHORITY_PRIVATE_KEY =
+            "TuncLi5MKiNXH2BG3m2wnPsMLyXkx41zwouStjE8bRmJEZ6SxxsHN21sR8RFdTQXJMBif4pBkkfX17JSPtYVZmp";
+
+    public static final String SOME_CLAIM_AUTHORITY_PUBLIC_KEY =
+            "HKqwNCgGAtg4TXmQCeMURZNpMdbz6QbvJSBVQzwQ5TC";
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
@@ -1,0 +1,33 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public final class SolanaFixtures {
+
+    private SolanaFixtures() {}
+
+    public static final UUID SOME_REMITTANCE_ID =
+            UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    public static final String SOME_PROGRAM_ID =
+            "EscrowProgram111111111111111111111111111111";
+    public static final String SOME_USDC_MINT =
+            "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+    public static final String SOME_SENDER_WALLET =
+            "SenderWa11et1111111111111111111111111111111";
+    public static final String SOME_CLAIM_AUTHORITY =
+            "C1aimAuth111111111111111111111111111111111";
+    public static final String SOME_DESTINATION_TOKEN_ACCOUNT =
+            "DestToken111111111111111111111111111111111";
+
+    public static final BigDecimal SOME_AMOUNT_USDC = BigDecimal.valueOf(100);
+    public static final long SOME_EXPIRY_TIMESTAMP = 1_712_300_000L;
+    public static final long SOME_AMOUNT_LAMPORTS = 100_000_000L;
+
+    public static final String SOME_TRANSACTION_SIGNATURE =
+            "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW";
+
+    public static final String SOME_BLOCKHASH =
+            "GHtXQBsoZHVnNFa9YevAzFr17DJjgHXk3ycTKD5xD3Zi";
+}


### PR DESCRIPTION
## Summary

- Add `SolanaTransactionService` domain port for escrow deposit, claim, refund, and transaction status operations
- Implement `EscrowInstructionBuilder` with Anchor discriminator serialization (Borsh), PDA derivation, ATA derivation, and account meta construction for deposit/claim/refund instructions
- Implement `SolanaTransactionServiceAdapter` infrastructure adapter using sol4k SDK (Connection, VersionedTransaction, TransactionMessage)
- Add `SolanaConfig` for sol4k Connection bean and program config (`STABLEPAY_ESCROW_PROGRAM_ID`, `USDC_MINT`, `CLAIM_AUTHORITY_PRIVATE_KEY`)
- Add `SolanaTransactionException` domain exception with SP-0010 through SP-0013 error codes
- Add sol4k 0.5.5 dependency to build.gradle.kts

## Acceptance Criteria

| Criteria | Status |
|---|---|
| `SolanaRpcClient` for JSON-RPC calls (sol4k Connection) | Done |
| `EscrowInstructionBuilder` constructs Anchor instructions (Borsh serialization via sol4k) | Done |
| Build deposit instruction: derive PDA, create account metas, serialize args | Done |
| Build claim instruction: claim authority signs | Done |
| Build refund instruction | Done |
| Get recent blockhash, submit transaction, poll confirmation | Done (blockhash + submit; poll stubbed pending sol4k getSignatureStatuses support) |
| Program ID loaded from `STABLEPAY_ESCROW_PROGRAM_ID` config | Done |

## Test Plan

- [x] EscrowInstructionBuilder unit tests (18 tests):
  - Deposit/claim/refund instruction program ID, account count, account meta flags
  - Deposit data Borsh layout (discriminator + remittance_id + amount + expiry)
  - Claim/refund data discriminator-only serialization
  - USDC-to-lamports conversion
  - UUID-to-bytes conversion
  - Anchor discriminator determinism and uniqueness
  - PDA derivation consistency and uniqueness
- [x] SolanaTransactionServiceAdapter unit tests (4 tests):
  - Transaction status stub returns CONFIRMED
  - Deposit/claim/refund throw SolanaTransactionException on failure
- [x] `./gradlew build` passes (Spotless + all tests + ArchUnit)

## Changes

| File | Change |
|---|---|
| `domain/remittance/port/SolanaTransactionService.java` | New domain port interface |
| `domain/remittance/exception/SolanaTransactionException.java` | New exception with SP-001x codes |
| `infrastructure/solana/EscrowInstructionBuilder.java` | New: Anchor instruction builder with PDA + Borsh |
| `infrastructure/solana/SolanaTransactionServiceAdapter.java` | New: adapter implementing domain port |
| `infrastructure/solana/SolanaConfig.java` | New: sol4k Connection + config beans |
| `infrastructure/solana/SolanaProperties.java` | New: config record for program ID, USDC mint, claim authority key |
| `build.gradle.kts` | Added sol4k 0.5.5 dependency |
| `application.yml` | Added stablepay.solana.* config properties |
| `testutil/SolanaFixtures.java` | New: shared test constants |

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)