### PR TITLE
STA-55: Expand GlobalExceptionHandler for all domain exceptions

### DIFF
--- a/backend/src/main/java/com/stablepay/application/config/ClockConfig.java
+++ b/backend/src/main/java/com/stablepay/application/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.stablepay.application.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -1,5 +1,10 @@
 package com.stablepay.application.config;
 
+import java.time.Clock;
+import java.time.Instant;
+
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,123 +23,115 @@ import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final Clock clock;
 
     @ExceptionHandler(WalletNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleWalletNotFound(WalletNotFoundException ex) {
+    public ErrorResponse handleWalletNotFound(
+            WalletNotFoundException ex, HttpServletRequest request) {
         log.warn("Wallet not found: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0006")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0006", ex.getMessage(), request);
     }
 
     @ExceptionHandler(InsufficientBalanceException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleInsufficientBalance(InsufficientBalanceException ex) {
+    public ErrorResponse handleInsufficientBalance(
+            InsufficientBalanceException ex, HttpServletRequest request) {
         log.warn("Insufficient balance: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0002")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0002", ex.getMessage(), request);
     }
 
     @ExceptionHandler(TreasuryDepletedException.class)
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
-    public ErrorResponse handleTreasuryDepleted(TreasuryDepletedException ex) {
+    public ErrorResponse handleTreasuryDepleted(
+            TreasuryDepletedException ex, HttpServletRequest request) {
         log.warn("Treasury depleted: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0007")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0007", ex.getMessage(), request);
     }
 
     @ExceptionHandler(WalletAlreadyExistsException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    public ErrorResponse handleWalletAlreadyExists(WalletAlreadyExistsException ex) {
+    public ErrorResponse handleWalletAlreadyExists(
+            WalletAlreadyExistsException ex, HttpServletRequest request) {
         log.warn("Wallet already exists: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0008")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0008", ex.getMessage(), request);
     }
 
     @ExceptionHandler(UnsupportedCorridorException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleUnsupportedCorridor(UnsupportedCorridorException ex) {
+    public ErrorResponse handleUnsupportedCorridor(
+            UnsupportedCorridorException ex, HttpServletRequest request) {
         log.warn("Unsupported corridor requested: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0009")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0009", ex.getMessage(), request);
     }
 
     @ExceptionHandler(ClaimTokenNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleClaimTokenNotFound(ClaimTokenNotFoundException ex) {
+    public ErrorResponse handleClaimTokenNotFound(
+            ClaimTokenNotFoundException ex, HttpServletRequest request) {
         log.warn("Claim token not found: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0011")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0011", ex.getMessage(), request);
     }
 
     @ExceptionHandler(ClaimAlreadyClaimedException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    public ErrorResponse handleClaimAlreadyClaimed(ClaimAlreadyClaimedException ex) {
+    public ErrorResponse handleClaimAlreadyClaimed(
+            ClaimAlreadyClaimedException ex, HttpServletRequest request) {
         log.warn("Claim already submitted: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0012")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0012", ex.getMessage(), request);
     }
 
     @ExceptionHandler(ClaimTokenExpiredException.class)
     @ResponseStatus(HttpStatus.GONE)
-    public ErrorResponse handleClaimTokenExpired(ClaimTokenExpiredException ex) {
+    public ErrorResponse handleClaimTokenExpired(
+            ClaimTokenExpiredException ex, HttpServletRequest request) {
         log.warn("Claim token expired: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0013")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0013", ex.getMessage(), request);
     }
 
     @ExceptionHandler(InvalidRemittanceStateException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    public ErrorResponse handleInvalidRemittanceState(InvalidRemittanceStateException ex) {
+    public ErrorResponse handleInvalidRemittanceState(
+            InvalidRemittanceStateException ex, HttpServletRequest request) {
         log.warn("Invalid remittance state: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0014")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0014", ex.getMessage(), request);
     }
 
     @ExceptionHandler(RemittanceNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleRemittanceNotFound(RemittanceNotFoundException ex) {
+    public ErrorResponse handleRemittanceNotFound(
+            RemittanceNotFoundException ex, HttpServletRequest request) {
         log.warn("Remittance not found: {}", ex.getMessage());
-        return ErrorResponse.builder()
-                .errorCode("SP-0010")
-                .message(ex.getMessage())
-                .build();
+        return buildResponse("SP-0010", ex.getMessage(), request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleValidation(MethodArgumentNotValidException ex) {
+    public ErrorResponse handleValidation(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
         var message = ex.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .reduce((a, b) -> a + "; " + b)
                 .orElse("Validation failed");
         log.warn("Validation error: {}", message);
+        return buildResponse("SP-0003", message, request);
+    }
+
+    private ErrorResponse buildResponse(
+            String errorCode, String message, HttpServletRequest request) {
         return ErrorResponse.builder()
-                .errorCode("SP-0003")
+                .errorCode(errorCode)
                 .message(message)
+                .timestamp(Instant.now(clock))
+                .path(request.getRequestURI())
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ErrorResponse.java
@@ -1,9 +1,13 @@
 package com.stablepay.application.dto;
 
+import java.time.Instant;
+
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ErrorResponse(
     String errorCode,
-    String message
+    String message,
+    Instant timestamp,
+    String path
 ) {}

--- a/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,263 @@
+package com.stablepay.application.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
+import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
+import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
+import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
+import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
+import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+
+import lombok.SneakyThrows;
+
+class GlobalExceptionHandlerTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-05T12:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        var objectMapper = new ObjectMapper()
+                .findAndRegisterModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        @SuppressWarnings("removal")
+        var converter = new MappingJackson2HttpMessageConverter(objectMapper);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new StubController())
+                .setControllerAdvice(new GlobalExceptionHandler(FIXED_CLOCK))
+                .setMessageConverters(converter)
+                .build();
+    }
+
+    @RestController
+    static class StubController {
+
+        @GetMapping("/test/wallet-not-found")
+        public void walletNotFound() {
+            throw WalletNotFoundException.byId(1L);
+        }
+
+        @GetMapping("/test/insufficient-balance")
+        public void insufficientBalance() {
+            throw InsufficientBalanceException.forAmount(
+                    BigDecimal.valueOf(500), BigDecimal.valueOf(100));
+        }
+
+        @GetMapping("/test/treasury-depleted")
+        public void treasuryDepleted() {
+            throw TreasuryDepletedException.insufficientTreasury(
+                    BigDecimal.valueOf(1000), BigDecimal.valueOf(50));
+        }
+
+        @GetMapping("/test/wallet-already-exists")
+        public void walletAlreadyExists() {
+            throw WalletAlreadyExistsException.forUserId("user-123");
+        }
+
+        @GetMapping("/test/unsupported-corridor")
+        public void unsupportedCorridor() {
+            throw UnsupportedCorridorException.forPair("USD", "EUR");
+        }
+
+        @GetMapping("/test/claim-token-not-found")
+        public void claimTokenNotFound() {
+            throw ClaimTokenNotFoundException.byToken("missing-token");
+        }
+
+        @GetMapping("/test/claim-already-claimed")
+        public void claimAlreadyClaimed() {
+            throw ClaimAlreadyClaimedException.forToken("already-claimed-token");
+        }
+
+        @GetMapping("/test/claim-token-expired")
+        public void claimTokenExpired() {
+            throw ClaimTokenExpiredException.forToken("expired-token");
+        }
+
+        @GetMapping("/test/invalid-remittance-state")
+        public void invalidRemittanceState() {
+            throw InvalidRemittanceStateException.forClaim(RemittanceStatus.CANCELLED);
+        }
+
+        @GetMapping("/test/remittance-not-found")
+        public void remittanceNotFound() {
+            throw RemittanceNotFoundException.byId(
+                    UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WithEnrichedResponseForWalletNotFound() {
+        // given — stub endpoint throws WalletNotFoundException
+
+        // when / then
+        mockMvc.perform(get("/test/wallet-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0006"))
+                .andExpect(jsonPath("$.message").value("SP-0006: Wallet not found: 1"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/wallet-not-found"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WithEnrichedResponseForInsufficientBalance() {
+        // given — stub endpoint throws InsufficientBalanceException
+
+        // when / then
+        mockMvc.perform(get("/test/insufficient-balance"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0002"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0002: Insufficient balance. Requested: 500, Available: 100"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/insufficient-balance"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn503WithEnrichedResponseForTreasuryDepleted() {
+        // given — stub endpoint throws TreasuryDepletedException
+
+        // when / then
+        mockMvc.perform(get("/test/treasury-depleted"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.errorCode").value("SP-0007"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0007: Treasury depleted. Requested: 1000, Available: 50"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/treasury-depleted"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WithEnrichedResponseForWalletAlreadyExists() {
+        // given — stub endpoint throws WalletAlreadyExistsException
+
+        // when / then
+        mockMvc.perform(get("/test/wallet-already-exists"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0008"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0008: Wallet already exists for userId: user-123"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/wallet-already-exists"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WithEnrichedResponseForUnsupportedCorridor() {
+        // given — stub endpoint throws UnsupportedCorridorException
+
+        // when / then
+        mockMvc.perform(get("/test/unsupported-corridor"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0009"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0009: Unsupported corridor: USD -> EUR"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/unsupported-corridor"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WithEnrichedResponseForClaimTokenNotFound() {
+        // given — stub endpoint throws ClaimTokenNotFoundException
+
+        // when / then
+        mockMvc.perform(get("/test/claim-token-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0011"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0011: Claim token not found: missing-token"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/claim-token-not-found"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WithEnrichedResponseForClaimAlreadyClaimed() {
+        // given — stub endpoint throws ClaimAlreadyClaimedException
+
+        // when / then
+        mockMvc.perform(get("/test/claim-already-claimed"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0012"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0012: Claim already submitted for token: already-claimed-token"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/claim-already-claimed"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn410WithEnrichedResponseForClaimTokenExpired() {
+        // given — stub endpoint throws ClaimTokenExpiredException
+
+        // when / then
+        mockMvc.perform(get("/test/claim-token-expired"))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.errorCode").value("SP-0013"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0013: Claim token expired: expired-token"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/claim-token-expired"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WithEnrichedResponseForInvalidRemittanceState() {
+        // given — stub endpoint throws InvalidRemittanceStateException
+
+        // when / then
+        mockMvc.perform(get("/test/invalid-remittance-state"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0014"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0014: Cannot claim remittance in status: CANCELLED"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/invalid-remittance-state"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WithEnrichedResponseForRemittanceNotFound() {
+        // given — stub endpoint throws RemittanceNotFoundException
+
+        // when / then
+        mockMvc.perform(get("/test/remittance-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0010"))
+                .andExpect(jsonPath("$.message").value(
+                        "SP-0010: Remittance not found: 11111111-1111-1111-1111-111111111111"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/remittance-not-found"));
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
@@ -1,21 +1,28 @@
 package com.stablepay.application.config;
 
+import static com.stablepay.testutil.TestClockConfig.FIXED_INSTANT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
 import java.time.Clock;
-import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,18 +43,18 @@ import lombok.SneakyThrows;
 
 class GlobalExceptionHandlerTest {
 
-    private static final Instant FIXED_INSTANT = Instant.parse("2026-04-05T12:00:00Z");
     private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
 
     private MockMvc mockMvc;
 
+    @SuppressWarnings("removal")
     @BeforeEach
     void setUp() {
         var objectMapper = new ObjectMapper()
                 .findAndRegisterModules()
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        @SuppressWarnings("removal")
-        var converter = new MappingJackson2HttpMessageConverter(objectMapper);
+        var converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper);
 
         mockMvc = MockMvcBuilders.standaloneSetup(new StubController())
                 .setControllerAdvice(new GlobalExceptionHandler(FIXED_CLOCK))
@@ -110,6 +117,11 @@ class GlobalExceptionHandlerTest {
             throw RemittanceNotFoundException.byId(
                     UUID.fromString("11111111-1111-1111-1111-111111111111"));
         }
+
+        @PostMapping("/test/validation")
+        public void validation(@Valid @RequestBody ValidationRequest request) {}
+
+        record ValidationRequest(@NotBlank String name) {}
     }
 
     @Test
@@ -259,5 +271,21 @@ class GlobalExceptionHandlerTest {
                         "SP-0010: Remittance not found: 11111111-1111-1111-1111-111111111111"))
                 .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
                 .andExpect(jsonPath("$.path").value("/test/remittance-not-found"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WithEnrichedResponseForValidationError() {
+        // given
+        var body = "{\"name\": \"\"}";
+
+        // when / then
+        mockMvc.perform(post("/test/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0003"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/validation"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,10 +35,12 @@ import com.stablepay.domain.claim.handler.SubmitClaimHandler;
 import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.testutil.TestClockConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(ClaimController.class)
+@Import(TestClockConfig.class)
 class ClaimControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,10 +22,12 @@ import com.stablepay.application.controller.fx.mapper.FxRateApiMapper;
 import com.stablepay.application.dto.FxRateResponse;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.fx.handler.GetFxRateQueryHandler;
+import com.stablepay.testutil.TestClockConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(FxRateController.class)
+@Import(TestClockConfig.class)
 class FxRateControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
@@ -39,10 +40,12 @@ import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
 import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
+import com.stablepay.testutil.TestClockConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(RemittanceController.class)
+@Import(TestClockConfig.class)
 class RemittanceControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,10 +31,12 @@ import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
 import com.stablepay.domain.wallet.handler.FundWalletHandler;
+import com.stablepay.testutil.TestClockConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(WalletController.class)
+@Import(TestClockConfig.class)
 class WalletControllerTest {
 
     private static final BigDecimal SOME_FUND_AMOUNT = BigDecimal.valueOf(500);

--- a/backend/src/test/java/com/stablepay/testutil/TestClockConfig.java
+++ b/backend/src/test/java/com/stablepay/testutil/TestClockConfig.java
@@ -1,0 +1,19 @@
+package com.stablepay.testutil;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestClockConfig {
+
+    public static final Instant FIXED_INSTANT = Instant.parse("2026-04-05T12:00:00Z");
+
+    @Bean
+    public Clock clock() {
+        return Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+    }
+}


### PR DESCRIPTION
## Summary

- Enrich `ErrorResponse` record with `timestamp` (Instant) and `path` (request URI) fields for improved API debugging
- Refactor `GlobalExceptionHandler` to use an injected `Clock` bean and `HttpServletRequest` to populate the enriched response via a shared `buildResponse()` helper
- Add dedicated `GlobalExceptionHandlerTest` with 10 tests covering every domain exception handler, verifying status code, error code, message, timestamp, and path

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Handle `RemittanceNotFoundException` -> 404 (SP-0010) | Done |
| Handle `InsufficientBalanceException` -> 400 (SP-0002) | Done |
| Handle `WalletNotFoundException` -> 404 (SP-0006) | Done |
| Handle `TreasuryDepletedException` -> 503 (SP-0007) | Done |
| Handle `WalletAlreadyExistsException` -> 409 (SP-0008) | Done |
| Handle `UnsupportedCorridorException` -> 400 (SP-0009) | Done |
| Handle `ClaimTokenExpiredException` -> 410 Gone (SP-0013) | Done |
| Handle `ClaimAlreadyClaimedException` -> 409 Conflict (SP-0012) | Done |
| Handle `MethodArgumentNotValidException` -> 400 with field errors | Done |
| Enriched ErrorResponse: errorCode, message, timestamp, path | Done |
| Single GlobalExceptionHandler shared across all controllers | Done |
| No catch-all Exception.class handler | Done |

## Test Plan

- [x] 10 new tests in `GlobalExceptionHandlerTest` verify every exception type with enriched response
- [x] All 4 existing controller test classes updated with `TestClockConfig` import
- [x] All 85 unit tests pass
- [x] Spotless formatting check passes
- [x] Full `./gradlew build` green

## Changes

| File | Change |
|---|---|
| `ErrorResponse.java` | Added `timestamp` and `path` fields |
| `GlobalExceptionHandler.java` | Injected `Clock`, added `HttpServletRequest` to all handlers, extracted `buildResponse()` |
| `ClockConfig.java` | New `@Configuration` providing `Clock.systemUTC()` bean |
| `GlobalExceptionHandlerTest.java` | New standalone MockMvc test for all 10 exception handlers |
| `TestClockConfig.java` | New shared `@TestConfiguration` with fixed clock for `@WebMvcTest` tests |
| `*ControllerTest.java` (4 files) | Added `@Import(TestClockConfig.class)` for Clock dependency |

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)