### PR TITLE
STA-32: Workflow implementation (lifecycle, expiry timer, claim signal)

### DIFF
--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
@@ -1,5 +1,7 @@
 package com.stablepay.infrastructure.temporal;
 
+import java.math.BigDecimal;
+
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 
 import io.temporal.activity.ActivityInterface;
@@ -7,11 +9,15 @@ import io.temporal.activity.ActivityInterface;
 @ActivityInterface
 public interface RemittanceLifecycleActivities {
 
-    byte[] signEscrowDeposit(byte[] unsignedTxBytes);
+    String depositEscrow(
+            String remittanceId,
+            String senderWalletAddress,
+            BigDecimal amountUsdc,
+            long expiryTimestamp);
 
-    byte[] signEscrowRelease(byte[] unsignedTxBytes);
+    String releaseEscrow(String remittanceId, String destinationTokenAccount);
 
-    String submitToSolana(byte[] signedTxBytes);
+    String refundEscrow(String remittanceId, String senderWalletAddress);
 
     void sendClaimSms(String recipientPhone, String claimUrl);
 

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -18,65 +18,56 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
     private static final Logger log = Workflow.getLogger(RemittanceLifecycleWorkflowImpl.class);
 
-    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
-    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final Duration SOLANA_ACTIVITY_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration SMS_ACTIVITY_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration STATUS_UPDATE_TIMEOUT = Duration.ofSeconds(10);
+    private static final int SOLANA_MAX_ATTEMPTS = 3;
+    private static final int SMS_MAX_ATTEMPTS = 3;
 
-    private final RemittanceLifecycleActivities activities =
-            Workflow.newActivityStub(RemittanceLifecycleActivities.class, defaultActivityOptions());
+    private final RemittanceLifecycleActivities solanaActivities =
+            Workflow.newActivityStub(RemittanceLifecycleActivities.class, solanaActivityOptions());
+
+    private final RemittanceLifecycleActivities smsActivities =
+            Workflow.newActivityStub(RemittanceLifecycleActivities.class, smsActivityOptions());
+
+    private final RemittanceLifecycleActivities statusActivities =
+            Workflow.newActivityStub(RemittanceLifecycleActivities.class, statusUpdateActivityOptions());
 
     private UUID remittanceId;
     private RemittanceStatus currentStatus = RemittanceStatus.INITIATED;
-    private String escrowPda;
+    private String escrowTxSignature;
     private boolean smsNotificationFailed;
     private boolean claimReceived;
+    private boolean refundInitiated;
     private ClaimSignal pendingClaim;
 
     @Override
     public RemittanceWorkflowResult execute(RemittanceWorkflowRequest request) {
         this.remittanceId = request.remittanceId();
-        log.info("Starting remittance workflow for remittanceId={}", remittanceId);
+        log.info("Starting remittance lifecycle workflow for remittanceId={}", remittanceId);
 
-        activities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.ESCROWED);
+        var depositSignature = depositEscrow(request);
+        this.escrowTxSignature = depositSignature;
+
+        statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.ESCROWED);
         currentStatus = RemittanceStatus.ESCROWED;
+        log.info("Remittance {} escrowed with tx={}", remittanceId, depositSignature);
 
-        try {
-            var claimUrl = request.claimBaseUrl() + request.claimToken();
-            activities.sendClaimSms(request.recipientPhone(), claimUrl);
-        } catch (Exception e) {
-            smsNotificationFailed = true;
-            log.warn("SMS notification failed for remittanceId={}", remittanceId, e);
-        }
+        sendClaimNotification(request);
 
         var claimed = Workflow.await(request.claimExpiryTimeout(), () -> claimReceived);
 
         if (claimed && pendingClaim != null) {
-            activities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.CLAIMED);
-            currentStatus = RemittanceStatus.CLAIMED;
-
-            activities.simulateInrDisbursement(pendingClaim.upiId(), request.amountUsdc().toPlainString());
-            activities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.DELIVERED);
-            currentStatus = RemittanceStatus.DELIVERED;
-
-            return RemittanceWorkflowResult.builder()
-                    .remittanceId(remittanceId)
-                    .finalStatus(RemittanceStatus.DELIVERED.name())
-                    .escrowPda(escrowPda)
-                    .build();
-        } else {
-            activities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.REFUNDED);
-            currentStatus = RemittanceStatus.REFUNDED;
-
-            return RemittanceWorkflowResult.builder()
-                    .remittanceId(remittanceId)
-                    .finalStatus(RemittanceStatus.REFUNDED.name())
-                    .escrowPda(escrowPda)
-                    .build();
+            return processClaim(request);
         }
+
+        return processExpiry(request);
     }
 
     @Override
     public void claimSubmitted(ClaimSignal claimSignal) {
-        log.info("Claim signal received for claimToken={}", claimSignal.claimToken());
+        log.info("Claim signal received for remittanceId={}, claimToken={}",
+                remittanceId, claimSignal.claimToken());
         this.pendingClaim = claimSignal;
         this.claimReceived = true;
     }
@@ -86,16 +77,112 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
         return RemittanceWorkflowStatus.builder()
                 .remittanceId(remittanceId)
                 .currentStatus(currentStatus != null ? currentStatus.name() : null)
-                .escrowPda(escrowPda)
+                .escrowPda(escrowTxSignature)
                 .smsNotificationFailed(smsNotificationFailed)
                 .build();
     }
 
-    private static ActivityOptions defaultActivityOptions() {
+    private String depositEscrow(RemittanceWorkflowRequest request) {
+        log.info("Depositing escrow for remittanceId={}", remittanceId);
+        return solanaActivities.depositEscrow(
+                remittanceId.toString(),
+                request.senderAddress(),
+                request.amountUsdc(),
+                request.escrowExpiryTimestamp());
+    }
+
+    private void sendClaimNotification(RemittanceWorkflowRequest request) {
+        try {
+            var claimUrl = request.claimBaseUrl() + request.claimToken();
+            smsActivities.sendClaimSms(request.recipientPhone(), claimUrl);
+            log.info("Claim SMS sent for remittanceId={}", remittanceId);
+        } catch (Exception e) {
+            smsNotificationFailed = true;
+            log.warn("SMS notification failed for remittanceId={}, continuing workflow", remittanceId, e);
+        }
+    }
+
+    private RemittanceWorkflowResult processClaim(RemittanceWorkflowRequest request) {
+        log.info("Processing claim for remittanceId={}", remittanceId);
+
+        var releaseSignature = solanaActivities.releaseEscrow(
+                remittanceId.toString(),
+                pendingClaim.destinationAddress());
+
+        statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.CLAIMED);
+        currentStatus = RemittanceStatus.CLAIMED;
+        log.info("Escrow released for remittanceId={} with tx={}", remittanceId, releaseSignature);
+
+        solanaActivities.simulateInrDisbursement(
+                pendingClaim.upiId(),
+                request.amountUsdc().toPlainString());
+
+        statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.DELIVERED);
+        currentStatus = RemittanceStatus.DELIVERED;
+        log.info("Remittance {} delivered successfully", remittanceId);
+
+        return RemittanceWorkflowResult.builder()
+                .remittanceId(remittanceId)
+                .finalStatus(RemittanceStatus.DELIVERED.name())
+                .escrowPda(escrowTxSignature)
+                .txSignature(releaseSignature)
+                .build();
+    }
+
+    private RemittanceWorkflowResult processExpiry(RemittanceWorkflowRequest request) {
+        log.info("Claim expiry timeout reached for remittanceId={}, checking claim flag", remittanceId);
+
+        if (claimReceived && pendingClaim != null) {
+            log.info("Claim received during timeout check for remittanceId={}, processing claim", remittanceId);
+            return processClaim(request);
+        }
+
+        refundInitiated = true;
+        log.info("No claim received for remittanceId={}, initiating refund", remittanceId);
+
+        var refundSignature = solanaActivities.refundEscrow(
+                remittanceId.toString(),
+                request.senderAddress());
+
+        statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.REFUNDED);
+        currentStatus = RemittanceStatus.REFUNDED;
+        log.info("Remittance {} refunded with tx={}", remittanceId, refundSignature);
+
+        return RemittanceWorkflowResult.builder()
+                .remittanceId(remittanceId)
+                .finalStatus(RemittanceStatus.REFUNDED.name())
+                .escrowPda(escrowTxSignature)
+                .txSignature(refundSignature)
+                .build();
+    }
+
+    private static ActivityOptions solanaActivityOptions() {
         return ActivityOptions.newBuilder()
-                .setStartToCloseTimeout(DEFAULT_TIMEOUT)
+                .setStartToCloseTimeout(SOLANA_ACTIVITY_TIMEOUT)
                 .setRetryOptions(RetryOptions.newBuilder()
-                        .setMaximumAttempts(DEFAULT_MAX_ATTEMPTS)
+                        .setMaximumAttempts(SOLANA_MAX_ATTEMPTS)
+                        .setInitialInterval(Duration.ofSeconds(2))
+                        .setBackoffCoefficient(2.0)
+                        .build())
+                .build();
+    }
+
+    private static ActivityOptions smsActivityOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(SMS_ACTIVITY_TIMEOUT)
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(SMS_MAX_ATTEMPTS)
+                        .setInitialInterval(Duration.ofSeconds(5))
+                        .setBackoffCoefficient(2.0)
+                        .build())
+                .build();
+    }
+
+    private static ActivityOptions statusUpdateActivityOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(STATUS_UPDATE_TIMEOUT)
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(SOLANA_MAX_ATTEMPTS)
                         .setInitialInterval(Duration.ofSeconds(1))
                         .setBackoffCoefficient(2.0)
                         .build())

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
@@ -14,5 +14,6 @@ public record RemittanceWorkflowRequest(
     BigDecimal amountUsdc,
     String claimToken,
     String claimBaseUrl,
-    Duration claimExpiryTimeout
+    Duration claimExpiryTimeout,
+    long escrowExpiryTimestamp
 ) {}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarter.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.temporal;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -33,6 +34,10 @@ public class TemporalRemittanceWorkflowStarter implements RemittanceWorkflowStar
         var temporal = properties.temporal();
         var workflow = workflowFactory.createRemittanceWorkflow(remittanceId);
 
+        var escrowExpiryTimestamp = Instant.now()
+                .plus(temporal.claimExpiryTimeout())
+                .getEpochSecond();
+
         var request = RemittanceWorkflowRequest.builder()
                 .remittanceId(remittanceId)
                 .senderAddress(senderAddress)
@@ -41,6 +46,7 @@ public class TemporalRemittanceWorkflowStarter implements RemittanceWorkflowStar
                 .claimToken(claimToken)
                 .claimBaseUrl(temporal.claimBaseUrl())
                 .claimExpiryTimeout(temporal.claimExpiryTimeout())
+                .escrowExpiryTimestamp(escrowExpiryTimestamp)
                 .build();
 
         try {

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
@@ -1,0 +1,440 @@
+package com.stablepay.infrastructure.temporal;
+
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_CLAIM_BASE_URL;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_CLAIM_TOKEN;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_DEPOSIT_TX_SIGNATURE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_DESTINATION_ADDRESS;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_ESCROW_EXPIRY_TIMESTAMP;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_RECIPIENT_PHONE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_REFUND_TX_SIGNATURE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_RELEASE_TX_SIGNATURE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_SENDER_ADDRESS;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_UPI_ID;
+import static com.stablepay.testutil.WorkflowFixtures.workflowRequestBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.remittance.model.RemittanceStatus;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+
+class RemittanceLifecycleWorkflowImplTest {
+
+    private static final String TASK_QUEUE = "test-remittance-lifecycle";
+
+    private TestWorkflowEnvironment testEnv;
+    private Worker worker;
+    private WorkflowClient client;
+    private RemittanceLifecycleActivities activities;
+
+    @BeforeEach
+    void setUp() {
+        testEnv = TestWorkflowEnvironment.newInstance();
+        worker = testEnv.newWorker(TASK_QUEUE);
+        worker.registerWorkflowImplementationTypes(RemittanceLifecycleWorkflowImpl.class);
+
+        activities = mock(RemittanceLifecycleActivities.class);
+        worker.registerActivitiesImplementations(activities);
+
+        client = testEnv.getWorkflowClient();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testEnv.close();
+    }
+
+    @Test
+    void shouldCompleteFullLifecycleFromDepositThroughClaimToDelivered() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflowId = RemittanceLifecycleWorkflow.workflowId(SOME_REMITTANCE_ID);
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofMinutes(1), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DELIVERED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
+
+        then(activities).should().sendClaimSms(
+                SOME_RECIPIENT_PHONE,
+                SOME_CLAIM_BASE_URL + SOME_CLAIM_TOKEN);
+
+        then(activities).should().releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.CLAIMED);
+
+        then(activities).should().simulateInrDisbursement(
+                SOME_UPI_ID, SOME_AMOUNT_USDC.toPlainString());
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
+    }
+
+    @Test
+    void shouldRefundWhenNoClaimReceivedWithinExpiryTimeout() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofSeconds(1))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_REFUND_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.REFUNDED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_REFUND_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
+
+        then(activities).should().refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.REFUNDED);
+
+        then(activities).should(never()).releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS);
+    }
+
+    @Test
+    void shouldContinueWorkflowWhenSmsNotificationFails() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofSeconds(1))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_REFUND_TX_SIGNATURE);
+
+        willThrow(new RuntimeException("SMS delivery failed"))
+                .given(activities).sendClaimSms(
+                        SOME_RECIPIENT_PHONE,
+                        SOME_CLAIM_BASE_URL + SOME_CLAIM_TOKEN);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.REFUNDED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_REFUND_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
+    }
+
+    @Test
+    void shouldSetSmsFailureFlagAndStillCompleteWhenClaimReceived() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        willThrow(new RuntimeException("SMS delivery failed"))
+                .given(activities).sendClaimSms(
+                        SOME_RECIPIENT_PHONE,
+                        SOME_CLAIM_BASE_URL + SOME_CLAIM_TOKEN);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflowId = "sms-fail-claim-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofMinutes(1), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DELIVERED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnCurrentStatusViaQueryDuringWorkflow() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflowId = "query-status-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var statusHolder = new CompletableFuture<RemittanceWorkflowStatus>();
+
+        testEnv.registerDelayedCallback(Duration.ofHours(1), () -> {
+            var queryStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            statusHolder.complete(queryStub.getStatus());
+
+            var claimSignal = ClaimSignal.builder()
+                    .claimToken(SOME_CLAIM_TOKEN)
+                    .upiId(SOME_UPI_ID)
+                    .destinationAddress(SOME_DESTINATION_ADDRESS)
+                    .build();
+            queryStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        workflow.execute(request);
+
+        var status = statusHolder.join();
+
+        // then
+        var expected = RemittanceWorkflowStatus.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .currentStatus(RemittanceStatus.ESCROWED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .smsNotificationFailed(false)
+                .build();
+
+        assertThat(status)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldProcessClaimReceivedJustBeforeTimeout() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflowId = "claim-before-timeout-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofHours(47), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DELIVERED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should(never()).refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarterTest.java
@@ -72,10 +72,15 @@ class TemporalRemittanceWorkflowStarterTest {
                 .claimToken(SOME_CLAIM_TOKEN)
                 .claimBaseUrl("https://claim.stablepay.app/")
                 .claimExpiryTimeout(Duration.ofHours(48))
+                .escrowExpiryTimestamp(0L)
                 .build();
 
         assertThat(requestCaptor.getValue())
                 .usingRecursiveComparison()
+                .ignoringFields("escrowExpiryTimestamp")
                 .isEqualTo(expected);
+
+        assertThat(requestCaptor.getValue().escrowExpiryTimestamp())
+                .isPositive();
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WorkflowFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WorkflowFixtures.java
@@ -24,6 +24,10 @@ public final class WorkflowFixtures {
     public static final String SOME_DESTINATION_ADDRESS = "DsT1NaTi0nAdDr3sS9876543210AbCdEfGhIjKl";
     public static final String SOME_CLAIM_BASE_URL = "https://claim.stablepay.app/";
     public static final Duration SOME_CLAIM_EXPIRY_TIMEOUT = Duration.ofHours(48);
+    public static final long SOME_ESCROW_EXPIRY_TIMESTAMP = 1743861600L;
+    public static final String SOME_DEPOSIT_TX_SIGNATURE = "DepositTx1234567890AbCdEfGhIjKlMnOp";
+    public static final String SOME_RELEASE_TX_SIGNATURE = "ReleaseTx1234567890AbCdEfGhIjKlMnOp";
+    public static final String SOME_REFUND_TX_SIGNATURE = "RefundTx1234567890AbCdEfGhIjKlMnOpQr";
 
     public static RemittanceWorkflowRequest.RemittanceWorkflowRequestBuilder workflowRequestBuilder() {
         return RemittanceWorkflowRequest.builder()
@@ -33,7 +37,8 @@ public final class WorkflowFixtures {
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .claimToken(SOME_CLAIM_TOKEN)
                 .claimBaseUrl(SOME_CLAIM_BASE_URL)
-                .claimExpiryTimeout(SOME_CLAIM_EXPIRY_TIMEOUT);
+                .claimExpiryTimeout(SOME_CLAIM_EXPIRY_TIMEOUT)
+                .escrowExpiryTimestamp(SOME_ESCROW_EXPIRY_TIMESTAMP);
     }
 
     public static RemittanceWorkflowResult.RemittanceWorkflowResultBuilder workflowResultBuilder() {


### PR DESCRIPTION
## Summary

- Implement the full RemittanceLifecycleWorkflow orchestrating INITIATED -> ESCROWED -> CLAIMED -> DELIVERED with 48-hour expiry timer and auto-refund
- Redesign activity interface with higher-level operations (depositEscrow, releaseEscrow, refundEscrow) matching the SolanaTransactionService port, replacing low-level byte[] signing methods
- Add separate activity stubs with tailored retry options per activity type (Solana: 60s/3 retries, SMS: 30s/3, status updates: 10s/3)
- Implement claim-after-timeout mutex resolution: check claimReceived flag before initiating refund after expiry
- SMS failure handling: catch ActivityFailure, set smsNotificationFailed flag, continue workflow
- Add escrowExpiryTimestamp to workflow request for on-chain Solana escrow expiry
- Add 6 comprehensive Temporal test framework tests using TestWorkflowEnvironment with mocked activities and registerDelayedCallback for signal/timer timing

Closes #32

## Test plan

- [x] Happy path: deposit -> SMS -> claim signal -> release -> disbursement -> DELIVERED
- [x] Expiry: no claim within timeout -> refund -> REFUNDED
- [x] SMS failure: workflow continues with smsNotificationFailed flag, still completes on claim
- [x] SMS failure: refunds correctly when no claim and SMS failed
- [x] Query: workflow status queryable mid-execution (ESCROWED state)
- [x] Claim just before timeout: signal at 47h still processes claim, no refund
- [x] `./gradlew build` passes (all 121 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #4