### PR TITLE
STA-45: Twilio SMS integration for claim link delivery

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -154,6 +154,9 @@ dependencies {
     // Solana SDK
     implementation("org.sol4k:sol4k:0.7.0")
 
+    // Twilio SMS
+    implementation("com.twilio.sdk:twilio:10.7.0")
+
     // Test
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")

--- a/backend/src/main/java/com/stablepay/domain/common/exception/SmsDeliveryException.java
+++ b/backend/src/main/java/com/stablepay/domain/common/exception/SmsDeliveryException.java
@@ -1,0 +1,30 @@
+package com.stablepay.domain.common.exception;
+
+public class SmsDeliveryException extends RuntimeException {
+
+    public static SmsDeliveryException forRecipient(String phoneNumber, Throwable cause) {
+        return new SmsDeliveryException(
+                "SP-0017: SMS delivery failed for recipient: " + maskPhone(phoneNumber),
+                cause);
+    }
+
+    public static SmsDeliveryException forRecipient(String phoneNumber, String reason) {
+        return new SmsDeliveryException(
+                "SP-0017: SMS delivery failed for recipient: " + maskPhone(phoneNumber) + " - " + reason);
+    }
+
+    private SmsDeliveryException(String message) {
+        super(message);
+    }
+
+    private SmsDeliveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    private static String maskPhone(String phone) {
+        if (phone == null || phone.length() <= 4) {
+            return "****";
+        }
+        return phone.substring(0, phone.length() - 4) + "****";
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioConfig.java
@@ -1,0 +1,37 @@
+package com.stablepay.infrastructure.sms;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.twilio.Twilio;
+import com.twilio.http.TwilioRestClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "stablepay.twilio.enabled", havingValue = "true")
+@EnableConfigurationProperties(TwilioProperties.class)
+public class TwilioConfig {
+
+    @Bean
+    public TwilioRestClient twilioRestClient(TwilioProperties properties) {
+        log.info("Initializing Twilio client for account {}", maskAccountSid(properties.accountSid()));
+        Twilio.init(properties.accountSid(), properties.authToken());
+        return new TwilioRestClient.Builder(properties.accountSid(), properties.authToken()).build();
+    }
+
+    @Bean
+    public TwilioSmsAdapter twilioSmsAdapter(TwilioRestClient twilioRestClient, TwilioProperties properties) {
+        return new TwilioSmsAdapter(twilioRestClient, properties);
+    }
+
+    private static String maskAccountSid(String sid) {
+        if (sid == null || sid.length() <= 8) {
+            return "****";
+        }
+        return sid.substring(0, 4) + "****" + sid.substring(sid.length() - 4);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioProperties.java
@@ -1,0 +1,15 @@
+package com.stablepay.infrastructure.sms;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Builder;
+
+@ConfigurationProperties(prefix = "stablepay.twilio")
+@Builder(toBuilder = true)
+public record TwilioProperties(
+    @NotBlank String accountSid,
+    @NotBlank String authToken,
+    @NotBlank String phoneNumber
+) {}

--- a/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioSmsAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/sms/TwilioSmsAdapter.java
@@ -1,0 +1,48 @@
+package com.stablepay.infrastructure.sms;
+
+import com.stablepay.domain.common.exception.SmsDeliveryException;
+import com.stablepay.domain.common.port.SmsProvider;
+import com.twilio.exception.ApiException;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.rest.api.v2010.account.MessageCreator;
+import com.twilio.type.PhoneNumber;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TwilioSmsAdapter implements SmsProvider {
+
+    private final TwilioRestClient twilioRestClient;
+    private final TwilioProperties twilioProperties;
+
+    @Override
+    public void sendSms(String phoneNumber, String message) {
+        log.info("Sending SMS to {}", maskPhone(phoneNumber));
+        try {
+            var messageCreator = createMessage(phoneNumber, message);
+            var result = messageCreator.create(twilioRestClient);
+            log.info("SMS sent successfully to {} with SID {}", maskPhone(phoneNumber), result.getSid());
+        } catch (ApiException ex) {
+            log.error("Twilio API error sending SMS to {}: {} (code: {})",
+                    maskPhone(phoneNumber), ex.getMessage(), ex.getCode());
+            throw SmsDeliveryException.forRecipient(phoneNumber, ex);
+        }
+    }
+
+    MessageCreator createMessage(String phoneNumber, String message) {
+        return Message.creator(
+                new PhoneNumber(phoneNumber),
+                new PhoneNumber(twilioProperties.phoneNumber()),
+                message);
+    }
+
+    private String maskPhone(String phone) {
+        if (phone == null || phone.length() <= 4) {
+            return "****";
+        }
+        return phone.substring(0, phone.length() - 4) + "****";
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,6 +40,11 @@ stablepay:
     escrow-program-id: ${STABLEPAY_ESCROW_PROGRAM_ID:11111111111111111111111111111111}
     usdc-mint: ${USDC_MINT:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU}
     claim-authority-private-key: ${CLAIM_AUTHORITY_PRIVATE_KEY:}
+  twilio:
+    enabled: ${TWILIO_ENABLED:false}
+    account-sid: ${TWILIO_ACCOUNT_SID:}
+    auth-token: ${TWILIO_AUTH_TOKEN:}
+    phone-number: ${TWILIO_PHONE_NUMBER:}
   temporal:
     workflow-execution-timeout: PT48H
     workflow-run-timeout: PT2H

--- a/backend/src/test/java/com/stablepay/infrastructure/sms/TwilioSmsAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/sms/TwilioSmsAdapterTest.java
@@ -1,0 +1,91 @@
+package com.stablepay.infrastructure.sms;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.common.exception.SmsDeliveryException;
+import com.twilio.exception.ApiException;
+import com.twilio.http.TwilioRestClient;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.rest.api.v2010.account.MessageCreator;
+
+@ExtendWith(MockitoExtension.class)
+class TwilioSmsAdapterTest {
+
+    private static final String SOME_PHONE_NUMBER = "+919876543210";
+    private static final String SOME_FROM_NUMBER = "+15017250604";
+    private static final String SOME_MESSAGE = "You have a StablePay remittance! Claim your funds: https://claim.stablepay.app/abc-123";
+    private static final String SOME_MESSAGE_SID = "SM1234567890abcdef1234567890abcdef";
+
+    @Mock
+    private TwilioRestClient twilioRestClient;
+
+    @Mock
+    private MessageCreator messageCreator;
+
+    @Mock
+    private Message message;
+
+    @Test
+    void shouldSendSmsViaTwilioApi() {
+        // given
+        var properties = TwilioProperties.builder()
+                .accountSid("AC_test_account_sid")
+                .authToken("test_auth_token")
+                .phoneNumber(SOME_FROM_NUMBER)
+                .build();
+        var adapter = new TestableTwilioSmsAdapter(twilioRestClient, properties, messageCreator);
+
+        given(messageCreator.create(twilioRestClient)).willReturn(message);
+        given(message.getSid()).willReturn(SOME_MESSAGE_SID);
+
+        // when
+        adapter.sendSms(SOME_PHONE_NUMBER, SOME_MESSAGE);
+
+        // then
+        then(messageCreator).should().create(twilioRestClient);
+    }
+
+    @Test
+    void shouldThrowSmsDeliveryExceptionWhenTwilioApiFails() {
+        // given
+        var properties = TwilioProperties.builder()
+                .accountSid("AC_test_account_sid")
+                .authToken("test_auth_token")
+                .phoneNumber(SOME_FROM_NUMBER)
+                .build();
+        var adapter = new TestableTwilioSmsAdapter(twilioRestClient, properties, messageCreator);
+
+        given(messageCreator.create(twilioRestClient))
+                .willThrow(new ApiException("Unable to create record: The 'To' number is not a valid phone number.", 21211));
+
+        // when / then
+        assertThatThrownBy(() -> adapter.sendSms(SOME_PHONE_NUMBER, SOME_MESSAGE))
+                .isInstanceOf(SmsDeliveryException.class)
+                .hasMessageContaining("SP-0017")
+                .hasCauseInstanceOf(ApiException.class);
+    }
+
+    private static class TestableTwilioSmsAdapter extends TwilioSmsAdapter {
+        private final MessageCreator stubbedCreator;
+
+        TestableTwilioSmsAdapter(
+                TwilioRestClient twilioRestClient,
+                TwilioProperties twilioProperties,
+                MessageCreator stubbedCreator) {
+            super(twilioRestClient, twilioProperties);
+            this.stubbedCreator = stubbedCreator;
+        }
+
+        @Override
+        MessageCreator createMessage(String phoneNumber, String message) {
+            return stubbedCreator;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TwilioSmsAdapter` implementing the `SmsProvider` domain port to send claim link SMS via Twilio Programmable SMS API
- Add `TwilioConfig` with conditional bean creation (`stablepay.twilio.enabled=true`) so the adapter is disabled by default and in test profiles
- Add `SmsDeliveryException` (SP-0017) domain exception wrapping Twilio API errors with masked phone numbers
- Add unit tests covering successful SMS delivery and Twilio API error propagation

## Details
The adapter uses a `TwilioRestClient` bean and `TwilioProperties` configuration record to send SMS messages. When Twilio is not enabled, the existing mock/stub `SmsProvider` bean (from `IntegrationTestConfig` or stub profile) takes effect. Credentials are sourced from environment variables: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`.

Closes #45

## Test plan
- [x] Unit tests: `TwilioSmsAdapterTest` — success path and API error path
- [x] Full `./gradlew build` passes (compile + Spotless + all tests)
- [ ] Manual verification: set `TWILIO_ENABLED=true` with sandbox Twilio credentials and send to a verified test number

🤖 Generated with [Claude Code](https://claude.com/claude-code)