### PR TITLE
STA-56: Backend Docker image

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+.gradle/
+build/
+!build/libs/
+.idea/
+*.iml
+*.iws
+*.ipr
+.git/
+.gitignore
+.githooks/
+src/
+gradle/
+gradlew
+gradlew.bat
+settings.gradle.kts
+build.gradle.kts
+gradle.properties

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+FROM eclipse-temurin:25-jre-alpine
+
+RUN addgroup -g 1000 stablepay && \
+    adduser -u 1000 -G stablepay -s /bin/sh -D stablepay
+
+WORKDIR /app
+
+COPY build/libs/*.jar app.jar
+
+RUN chown -R stablepay:stablepay /app
+
+USER stablepay
+
+EXPOSE 8080
+
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
+ENV SPRING_PROFILES_ACTIVE=docker
+
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar app.jar"]

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -5,6 +5,31 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "8.4.0"
     id("com.google.protobuf") version "0.9.6"
+    id("com.google.cloud.tools.jib") version "3.4.5"
+}
+
+jib {
+    from {
+        image = "docker://eclipse-temurin:25-jre-alpine"
+    }
+    to {
+        image = "stablepay-backend"
+        tags = setOf("latest", version.toString())
+    }
+    container {
+        mainClass = "com.stablepay.Application"
+        jvmFlags = listOf(
+            "-XX:+UseG1GC",
+            "-XX:MaxRAMPercentage=75.0",
+            "-Djava.security.egd=file:/dev/./urandom"
+        )
+        ports = listOf("8080")
+        environment = mapOf(
+            "SPRING_PROFILES_ACTIVE" to "docker"
+        )
+        creationTime.set("USE_CURRENT_TIMESTAMP")
+        user = "1000:1000"
+    }
 }
 
 group = "com.stablepay"

--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -1,0 +1,37 @@
+spring:
+  autoconfigure:
+    exclude: []
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_NAME:stablepay}
+    username: ${DB_USER:stablepay}
+    password: ${DB_PASSWORD:stablepay}
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
+
+spring.temporal:
+  connection:
+    target: ${TEMPORAL_ADDRESS:temporal:7233}
+  workers:
+    - name: remittance-worker
+      task-queue: remittance-task-queue
+  workers-auto-discovery:
+    packages:
+      - com.stablepay.infrastructure.temporal
+
+stablepay:
+  fx:
+    api:
+      base-url: ${FX_API_BASE_URL:https://open.er-api.com}
+  mpc:
+    sidecar:
+      host: ${MPC_SIDECAR_HOST:mpc-sidecar}
+      port: ${MPC_SIDECAR_PORT:50051}
+  cors:
+    allowed-origins:
+      - ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
+logging:
+  level:
+    com.stablepay: ${LOG_LEVEL:INFO}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,5 +46,36 @@ services:
       timeout: 5s
       retries: 5
 
+  backend:
+    image: stablepay-backend:latest
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: stablepay
+      DB_USER: stablepay
+      DB_PASSWORD: stablepay
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      TEMPORAL_ADDRESS: temporal:7233
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      temporal:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- Add Jib plugin (3.4.5) to `build.gradle.kts` enabling `./gradlew jibDockerBuild` to produce a `stablepay-backend` Docker image based on Eclipse Temurin 25 JRE Alpine
- Add `Dockerfile` as an alternative build path (requires pre-built JAR via `./gradlew bootJar`)
- Create `application-docker.yml` Spring profile for containerized deployment with environment-variable-driven config for PostgreSQL, Redis, and Temporal
- Add `backend` service to `docker-compose.yml` with health check, dependency ordering on postgres/redis/temporal, and all required environment variables

## How to build & run

### Option 1: Jib (recommended)
```bash
cd backend
./gradlew jibDockerBuild          # builds stablepay-backend:latest
docker run -p 8080:8080 stablepay-backend
```

### Option 2: Dockerfile
```bash
cd backend
./gradlew bootJar
docker build -t stablepay-backend .
docker run -p 8080:8080 stablepay-backend
```

### Option 3: Docker Compose (full stack)
```bash
cd backend && ./gradlew jibDockerBuild   # build image first
docker compose up -d                      # starts postgres, temporal, redis, backend
```

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew jibDockerBuild` produces `stablepay-backend:latest` image
- [x] `docker build -t stablepay-backend .` succeeds
- [x] Docker Compose config validates (`docker compose config`)
- [ ] `docker compose up -d` starts backend connected to PostgreSQL, Redis, Temporal

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)