### PR TITLE
STA-57: OpenAPI documentation (springdoc-openapi)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -151,6 +151,9 @@ dependencies {
     // UUID v7
     implementation("com.github.f4b6a3:uuid-creator:6.1.1")
 
+    // OpenAPI / Swagger UI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
     // Solana SDK
     implementation("org.sol4k:sol4k:0.7.0")
 

--- a/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.stablepay.test.PgTest;

--- a/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
@@ -25,9 +25,11 @@ class OpenApiIntegrationTest {
     void shouldServeOpenApiSpec() {
         // given — springdoc auto-configuration exposes /v3/api-docs
 
-        // when / then
-        mockMvc.perform(get("/v3/api-docs"))
-                .andExpect(status().isOk())
+        // when
+        var result = mockMvc.perform(get("/v3/api-docs"));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.openapi").exists())
                 .andExpect(jsonPath("$.info.title").value("StablePay API"))
                 .andExpect(jsonPath("$.info.version").value("0.1.0"))
@@ -39,9 +41,11 @@ class OpenApiIntegrationTest {
     void shouldGroupEndpointsByTag() {
         // given — controllers are annotated with @Tag
 
-        // when / then
-        mockMvc.perform(get("/v3/api-docs"))
-                .andExpect(status().isOk())
+        // when
+        var result = mockMvc.perform(get("/v3/api-docs"));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.tags[?(@.name == 'Wallets')]").exists())
                 .andExpect(jsonPath("$.tags[?(@.name == 'Remittances')]").exists())
                 .andExpect(jsonPath("$.tags[?(@.name == 'Claims')]").exists())
@@ -53,9 +57,11 @@ class OpenApiIntegrationTest {
     void shouldDocumentErrorResponseSchema() {
         // given — ErrorResponse is referenced in @ApiResponse annotations
 
-        // when / then
-        mockMvc.perform(get("/v3/api-docs"))
-                .andExpect(status().isOk())
+        // when
+        var result = mockMvc.perform(get("/v3/api-docs"));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists())
                 .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.errorCode").exists())
                 .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.message").exists())

--- a/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/config/OpenApiIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.stablepay.application.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.stablepay.test.PgTest;
+
+import lombok.SneakyThrows;
+
+@PgTest
+@AutoConfigureMockMvc
+class OpenApiIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @SneakyThrows
+    void shouldServeOpenApiSpec() {
+        // given — springdoc auto-configuration exposes /v3/api-docs
+
+        // when / then
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists())
+                .andExpect(jsonPath("$.info.title").value("StablePay API"))
+                .andExpect(jsonPath("$.info.version").value("0.1.0"))
+                .andExpect(jsonPath("$.paths").isNotEmpty());
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldGroupEndpointsByTag() {
+        // given — controllers are annotated with @Tag
+
+        // when / then
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tags[?(@.name == 'Wallets')]").exists())
+                .andExpect(jsonPath("$.tags[?(@.name == 'Remittances')]").exists())
+                .andExpect(jsonPath("$.tags[?(@.name == 'Claims')]").exists())
+                .andExpect(jsonPath("$.tags[?(@.name == 'FX Rate')]").exists());
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldDocumentErrorResponseSchema() {
+        // given — ErrorResponse is referenced in @ApiResponse annotations
+
+        // when / then
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.errorCode").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.message").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.timestamp").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse.properties.path").exists());
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/stablepay/application/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.stablepay.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI stablePayOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("StablePay API")
+                        .description("Cross-border stablecoin remittance API on Solana. "
+                                + "Enables instant, low-cost USD to INR remittances via USDC "
+                                + "with MPC wallet abstraction and guaranteed delivery.")
+                        .version("0.1.0")
+                        .contact(new Contact()
+                                .name("StablePay Team")
+                                .url("https://github.com/stablepay"))
+                        .license(new License()
+                                .name("MIT")));
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/controller/claim/ClaimController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/claim/ClaimController.java
@@ -11,15 +11,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.stablepay.application.controller.claim.mapper.ClaimApiMapper;
 import com.stablepay.application.dto.ClaimResponse;
+import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.SubmitClaimRequest;
 import com.stablepay.domain.claim.handler.GetClaimQueryHandler;
 import com.stablepay.domain.claim.handler.SubmitClaimHandler;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/claims")
 @RequiredArgsConstructor
+@Tag(name = "Claims", description = "Recipient claim page and submission")
 public class ClaimController {
 
     private final GetClaimQueryHandler getClaimQueryHandler;
@@ -27,12 +35,30 @@ public class ClaimController {
     private final ClaimApiMapper claimApiMapper;
 
     @GetMapping("/{token}")
+    @Operation(summary = "Get claim details", description = "Retrieves remittance claim details by the claim token sent via SMS")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Claim details retrieved"),
+        @ApiResponse(responseCode = "404", description = "Claim token not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "410", description = "Claim token expired",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ClaimResponse getClaim(@PathVariable String token) {
         var claimDetails = getClaimQueryHandler.handle(token);
         return claimApiMapper.toResponse(claimDetails);
     }
 
     @PostMapping("/{token}")
+    @Operation(summary = "Submit claim", description = "Submits a claim with the recipient's UPI ID to receive the INR payout")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Claim submitted"),
+        @ApiResponse(responseCode = "404", description = "Claim token not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "Claim already submitted",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "410", description = "Claim token expired",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ClaimResponse submitClaim(
             @PathVariable String token,
             @Valid @RequestBody SubmitClaimRequest request) {

--- a/backend/src/main/java/com/stablepay/application/controller/fx/FxRateController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/fx/FxRateController.java
@@ -6,20 +6,34 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.stablepay.application.controller.fx.mapper.FxRateApiMapper;
+import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.FxRateResponse;
 import com.stablepay.domain.fx.handler.GetFxRateQueryHandler;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/fx")
 @RequiredArgsConstructor
+@Tag(name = "FX Rate", description = "Foreign exchange rate lookup")
 public class FxRateController {
 
     private final GetFxRateQueryHandler getFxRateQueryHandler;
     private final FxRateApiMapper fxRateApiMapper;
 
     @GetMapping("/{from}-{to}")
+    @Operation(summary = "Get FX rate", description = "Returns the current exchange rate for the given currency pair (e.g. USD-INR)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "FX rate retrieved"),
+        @ApiResponse(responseCode = "400", description = "Unsupported currency corridor",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public FxRateResponse getRate(@PathVariable String from, @PathVariable String to) {
         var quote = getFxRateQueryHandler.handle(from.toUpperCase(), to.toUpperCase());
         return fxRateApiMapper.toResponse(quote);

--- a/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
@@ -18,16 +18,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.stablepay.application.controller.remittance.mapper.RemittanceApiMapper;
 import com.stablepay.application.dto.CreateRemittanceRequest;
+import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.RemittanceResponse;
 import com.stablepay.domain.remittance.handler.CreateRemittanceHandler;
 import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
 import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/remittances")
 @RequiredArgsConstructor
+@Tag(name = "Remittances", description = "Cross-border remittance creation and tracking")
 public class RemittanceController {
 
     private final CreateRemittanceHandler createRemittanceHandler;
@@ -37,6 +45,12 @@ public class RemittanceController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create remittance", description = "Initiates a new USD to INR remittance with locked FX rate")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Remittance created"),
+        @ApiResponse(responseCode = "400", description = "Validation error or insufficient balance",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public RemittanceResponse createRemittance(@Valid @RequestBody CreateRemittanceRequest request) {
         var remittance = createRemittanceHandler.handle(
                 request.senderId(), request.recipientPhone(), request.amountUsdc());
@@ -44,12 +58,22 @@ public class RemittanceController {
     }
 
     @GetMapping("/{remittanceId}")
+    @Operation(summary = "Get remittance", description = "Retrieves a remittance by its unique identifier")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Remittance found"),
+        @ApiResponse(responseCode = "404", description = "Remittance not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public RemittanceResponse getRemittance(@PathVariable UUID remittanceId) {
         var remittance = getRemittanceQueryHandler.handle(remittanceId);
         return remittanceApiMapper.toResponse(remittance);
     }
 
     @GetMapping
+    @Operation(summary = "List remittances", description = "Returns a paginated list of remittances for a sender")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Remittances retrieved")
+    })
     public Page<RemittanceResponse> listRemittances(
             @RequestParam String senderId,
             Pageable pageable) {

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
@@ -12,16 +12,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
 import com.stablepay.application.dto.CreateWalletRequest;
+import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.FundWalletRequest;
 import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
 import com.stablepay.domain.wallet.handler.FundWalletHandler;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/wallets")
 @RequiredArgsConstructor
+@Tag(name = "Wallets", description = "MPC wallet creation and demo treasury funding")
 public class WalletController {
 
     private final CreateWalletHandler createWalletHandler;
@@ -30,12 +38,28 @@ public class WalletController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create wallet", description = "Creates an MPC-backed Solana wallet for the given user")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Wallet created"),
+        @ApiResponse(responseCode = "400", description = "Validation error",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "Wallet already exists for this user",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public WalletResponse createWallet(@Valid @RequestBody CreateWalletRequest request) {
         var wallet = createWalletHandler.handle(request.userId());
         return walletApiMapper.toResponse(wallet);
     }
 
     @PostMapping("/{id}/fund")
+    @Operation(summary = "Fund wallet", description = "Adds demo USDC from the treasury to the wallet")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Wallet funded"),
+        @ApiResponse(responseCode = "404", description = "Wallet not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Treasury depleted",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public WalletResponse fundWallet(
             @PathVariable Long id,
             @Valid @RequestBody FundWalletRequest request) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -60,6 +60,15 @@ stablepay:
       - Authorization
     max-age: 3600
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: method
+  packages-to-scan: com.stablepay.application.controller
+
 management:
   endpoints:
     web:

--- a/backend/src/test/java/com/stablepay/application/config/OpenApiConfigTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/OpenApiConfigTest.java
@@ -1,0 +1,98 @@
+package com.stablepay.application.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+
+class OpenApiConfigTest {
+
+    private final OpenApiConfig openApiConfig = new OpenApiConfig();
+
+    @Test
+    void shouldConfigureApiTitle() {
+        // given
+        var openApi = openApiConfig.stablePayOpenApi();
+
+        // when
+        var title = openApi.getInfo().getTitle();
+
+        // then
+        assertThat(title).isEqualTo("StablePay API");
+    }
+
+    @Test
+    void shouldConfigureApiVersion() {
+        // given
+        var openApi = openApiConfig.stablePayOpenApi();
+
+        // when
+        var version = openApi.getInfo().getVersion();
+
+        // then
+        assertThat(version).isEqualTo("0.1.0");
+    }
+
+    @Test
+    void shouldConfigureApiDescription() {
+        // given
+        var openApi = openApiConfig.stablePayOpenApi();
+
+        // when
+        var description = openApi.getInfo().getDescription();
+
+        // then
+        assertThat(description).contains("Cross-border stablecoin remittance");
+    }
+
+    @Test
+    void shouldConfigureContact() {
+        // given
+        var openApi = openApiConfig.stablePayOpenApi();
+
+        // when
+        var contact = openApi.getInfo().getContact();
+
+        // then
+        assertThat(contact.getName()).isEqualTo("StablePay Team");
+        assertThat(contact.getUrl()).isEqualTo("https://github.com/stablepay");
+    }
+
+    @Test
+    void shouldConfigureLicense() {
+        // given
+        var openApi = openApiConfig.stablePayOpenApi();
+
+        // when
+        var license = openApi.getInfo().getLicense();
+
+        // then
+        assertThat(license.getName()).isEqualTo("MIT");
+    }
+
+    @Test
+    void shouldReturnFullyConfiguredOpenApiBean() {
+        // given — expected OpenAPI configuration
+        var expected = new OpenAPI()
+                .info(new io.swagger.v3.oas.models.info.Info()
+                        .title("StablePay API")
+                        .description("Cross-border stablecoin remittance API on Solana. "
+                                + "Enables instant, low-cost USD to INR remittances via USDC "
+                                + "with MPC wallet abstraction and guaranteed delivery.")
+                        .version("0.1.0")
+                        .contact(new io.swagger.v3.oas.models.info.Contact()
+                                .name("StablePay Team")
+                                .url("https://github.com/stablepay"))
+                        .license(new io.swagger.v3.oas.models.info.License()
+                                .name("MIT")));
+
+        // when
+        var result = openApiConfig.stablePayOpenApi();
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/config/OpenApiConfigTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/OpenApiConfigTest.java
@@ -11,69 +11,8 @@ class OpenApiConfigTest {
     private final OpenApiConfig openApiConfig = new OpenApiConfig();
 
     @Test
-    void shouldConfigureApiTitle() {
-        // given
-        var openApi = openApiConfig.stablePayOpenApi();
-
-        // when
-        var title = openApi.getInfo().getTitle();
-
-        // then
-        assertThat(title).isEqualTo("StablePay API");
-    }
-
-    @Test
-    void shouldConfigureApiVersion() {
-        // given
-        var openApi = openApiConfig.stablePayOpenApi();
-
-        // when
-        var version = openApi.getInfo().getVersion();
-
-        // then
-        assertThat(version).isEqualTo("0.1.0");
-    }
-
-    @Test
-    void shouldConfigureApiDescription() {
-        // given
-        var openApi = openApiConfig.stablePayOpenApi();
-
-        // when
-        var description = openApi.getInfo().getDescription();
-
-        // then
-        assertThat(description).contains("Cross-border stablecoin remittance");
-    }
-
-    @Test
-    void shouldConfigureContact() {
-        // given
-        var openApi = openApiConfig.stablePayOpenApi();
-
-        // when
-        var contact = openApi.getInfo().getContact();
-
-        // then
-        assertThat(contact.getName()).isEqualTo("StablePay Team");
-        assertThat(contact.getUrl()).isEqualTo("https://github.com/stablepay");
-    }
-
-    @Test
-    void shouldConfigureLicense() {
-        // given
-        var openApi = openApiConfig.stablePayOpenApi();
-
-        // when
-        var license = openApi.getInfo().getLicense();
-
-        // then
-        assertThat(license.getName()).isEqualTo("MIT");
-    }
-
-    @Test
     void shouldReturnFullyConfiguredOpenApiBean() {
-        // given — expected OpenAPI configuration
+        // given
         var expected = new OpenAPI()
                 .info(new io.swagger.v3.oas.models.info.Info()
                         .title("StablePay API")


### PR DESCRIPTION
## Summary
- Adds `springdoc-openapi-starter-webmvc-ui` 2.8.8 for auto-generated Swagger UI and OpenAPI spec
- Configures OpenAPI info bean with API title, version, description, contact, and license
- Annotates all four controllers with `@Tag` for grouping (Wallets, Remittances, Claims, FX Rate) and `@Operation`/`@ApiResponses` with error response schemas
- Configures springdoc paths and package scanning in `application.yml`
- Swagger UI available at `/swagger-ui.html`, OpenAPI spec at `/v3/api-docs`

Closes #60

## Test plan
- [x] Unit tests verify `OpenApiConfig` bean produces correct title, version, description, contact, license
- [x] Golden-rule test uses `usingRecursiveComparison()` to verify full bean configuration
- [x] Integration test verifies `/v3/api-docs` returns valid JSON with expected info, tags, and schemas
- [x] `./gradlew build` passes (compile + Spotless + 183 unit tests)
- [ ] Manual: visit `/swagger-ui.html` after `./gradlew bootRun` to verify interactive docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)