### PR TITLE
STA-22: Docker setup for two MPC sidecar instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
     -Dorg.gradle.daemon=false
     -Dorg.gradle.parallel=true
     -Dorg.gradle.caching=true
+  GO_VERSION: '1.26'
   SOLANA_VERSION: '2.2.7'
   ANCHOR_VERSION: '0.32.1'
   NODE_VERSION: '22'
@@ -106,6 +107,22 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew assemble
+
+  mpc-sidecar-test:
+    name: MPC Sidecar Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: mpc-sidecar
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: mpc-sidecar/go.sum
+      - run: go build ./...
+      - run: go test ./... -v -count=1 -timeout 120s
 
   anchor-build:
     name: Anchor Build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,40 @@ services:
       timeout: 5s
       retries: 5
 
+  mpc-sidecar-0:
+    build:
+      context: ./mpc-sidecar
+      dockerfile: Dockerfile
+    ports:
+      - "50051:50051"
+      - "7000:7000"
+    environment:
+      PARTY_ID: 0
+      GRPC_PORT: 50051
+      P2P_PORT: 7000
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 50051 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  mpc-sidecar-1:
+    build:
+      context: ./mpc-sidecar
+      dockerfile: Dockerfile
+    ports:
+      - "50052:50051"
+      - "7001:7000"
+    environment:
+      PARTY_ID: 1
+      GRPC_PORT: 50051
+      P2P_PORT: 7000
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 50051 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   backend:
     image: stablepay-backend:latest
     build:
@@ -63,6 +97,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       TEMPORAL_ADDRESS: temporal:7233
+      MPC_SIDECAR_0_URL: mpc-sidecar-0:50051
+      MPC_SIDECAR_1_URL: mpc-sidecar-1:50051
     depends_on:
       postgres:
         condition: service_healthy
@@ -70,6 +106,10 @@ services:
         condition: service_healthy
       temporal:
         condition: service_started
+      mpc-sidecar-0:
+        condition: service_healthy
+      mpc-sidecar-1:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
       interval: 15s

--- a/mpc-sidecar/.dockerignore
+++ b/mpc-sidecar/.dockerignore
@@ -1,0 +1,6 @@
+*.dylib
+*.exe
+*.test
+.git
+.gitignore
+README.md

--- a/mpc-sidecar/Dockerfile
+++ b/mpc-sidecar/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build
+FROM golang:1.26-alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /mpc-sidecar ./cmd/sidecar
+
+# Stage 2: Runtime
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /mpc-sidecar /usr/local/bin/mpc-sidecar
+
+EXPOSE 50051 7000
+
+ENTRYPOINT ["mpc-sidecar"]


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (`golang:1.26` → `alpine:3.21`) producing a ~15MB runtime image
- Two Docker Compose services (`mpc-sidecar-0`, `mpc-sidecar-1`) with correct port mapping:
  - party-0: gRPC `50051`, P2P `7000`
  - party-1: gRPC `50052`, P2P `7001`
- Health checks via `nc -z` on gRPC port
- Backend service now `depends_on` both sidecars (healthy) and receives `MPC_SIDECAR_0_URL` / `MPC_SIDECAR_1_URL` env vars
- CI job added for MPC sidecar Go build + test

## Test plan
- [x] `docker compose build mpc-sidecar-0` succeeds
- [x] `docker compose up mpc-sidecar-0 mpc-sidecar-1 -d` starts both instances
- [x] Both containers reach `healthy` status
- [x] Logs show correct `partyID`, `gRPC`, and `P2P` ports
- [x] `go test ./...` passes locally

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #22
Closes #16 17 18 19 20 21
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21