### PR TITLE
STA-62: Wire E2E backend flow — claim tokens, workflow start, MPC signing

### DIFF
--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -55,20 +55,15 @@ public class SubmitClaimHandler {
                 .build();
         var savedClaim = claimTokenRepository.save(updatedClaim);
 
-        var updatedRemittance = remittance.toBuilder()
-                .status(RemittanceStatus.CLAIMED)
-                .build();
-        var savedRemittance = remittanceRepository.save(updatedRemittance);
-
-        log.info("Claim submitted for token={}, remittanceId={}, upiId={}",
-                token, claimToken.remittanceId(), upiId);
+        log.info("Claim submitted for remittanceId={}, upiId={}",
+                claimToken.remittanceId(), upiId);
 
         claimSignaler.ifPresent(signaler ->
                 signaler.signalClaim(claimToken.remittanceId(), token, upiId));
 
         return ClaimDetails.builder()
                 .claimToken(savedClaim)
-                .remittance(savedRemittance)
+                .remittance(remittance)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -1,6 +1,7 @@
 package com.stablepay.domain.claim.handler;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +14,7 @@ import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceClaimSignaler;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class SubmitClaimHandler {
 
     private final ClaimTokenRepository claimTokenRepository;
     private final RemittanceRepository remittanceRepository;
+    private final Optional<RemittanceClaimSignaler> claimSignaler;
 
     public ClaimDetails handle(String token, String upiId) {
         var claimToken = claimTokenRepository.findByToken(token)
@@ -59,6 +62,9 @@ public class SubmitClaimHandler {
 
         log.info("Claim submitted for token={}, remittanceId={}, upiId={}",
                 token, claimToken.remittanceId(), upiId);
+
+        claimSignaler.ifPresent(signaler ->
+                signaler.signalClaim(claimToken.remittanceId(), token, upiId));
 
         return ClaimDetails.builder()
                 .claimToken(savedClaim)

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
@@ -2,16 +2,22 @@ package com.stablepay.domain.remittance.handler;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.claim.model.ClaimToken;
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.fx.model.FxQuote;
 import com.stablepay.domain.fx.port.FxRateProvider;
 import com.stablepay.domain.remittance.model.Remittance;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
+import com.stablepay.domain.remittance.port.RemittanceWorkflowStarter;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.port.WalletRepository;
 
@@ -24,9 +30,13 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class CreateRemittanceHandler {
 
+    private static final Duration CLAIM_EXPIRY = Duration.ofHours(48);
+
     private final RemittanceRepository remittanceRepository;
     private final WalletRepository walletRepository;
     private final FxRateProvider fxRateProvider;
+    private final ClaimTokenRepository claimTokenRepository;
+    private final Optional<RemittanceWorkflowStarter> workflowStarter;
 
     public Remittance handle(String senderId, String recipientPhone, BigDecimal amountUsdc) {
         var wallet = walletRepository.findByUserId(senderId)
@@ -50,10 +60,30 @@ public class CreateRemittanceHandler {
                 .build();
 
         var saved = remittanceRepository.save(remittance);
-        log.info("Created remittance remittanceId={}, senderId={}, amountUsdc={}, fxRate={}",
-                saved.remittanceId(), senderId, amountUsdc, fxQuote.rate());
 
-        return saved;
+        var claimToken = ClaimToken.builder()
+                .remittanceId(saved.remittanceId())
+                .token(UUID.randomUUID().toString())
+                .claimed(false)
+                .expiresAt(Instant.now().plus(CLAIM_EXPIRY))
+                .build();
+        var savedClaim = claimTokenRepository.save(claimToken);
+
+        var finalRemittance = remittanceRepository.save(
+                saved.toBuilder().claimTokenId(savedClaim.token()).build());
+
+        log.info("Created remittance remittanceId={}, senderId={}, amountUsdc={}, fxRate={}, claimToken={}",
+                finalRemittance.remittanceId(), senderId, amountUsdc, fxQuote.rate(), savedClaim.token());
+
+        workflowStarter.ifPresent(starter ->
+                starter.startWorkflow(
+                        finalRemittance.remittanceId(),
+                        wallet.solanaAddress(),
+                        recipientPhone,
+                        amountUsdc,
+                        savedClaim.token()));
+
+        return finalRemittance;
     }
 
     private BigDecimal calculateInrAmount(BigDecimal amountUsdc, FxQuote fxQuote) {

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
@@ -72,16 +72,15 @@ public class CreateRemittanceHandler {
         var finalRemittance = remittanceRepository.save(
                 saved.toBuilder().claimTokenId(savedClaim.token()).build());
 
-        log.info("Created remittance remittanceId={}, senderId={}, amountUsdc={}, fxRate={}, claimToken={}",
-                finalRemittance.remittanceId(), senderId, amountUsdc, fxQuote.rate(), savedClaim.token());
+        log.info("Created remittance remittanceId={}, senderId={}, amountUsdc={}, fxRate={}",
+                finalRemittance.remittanceId(), senderId, amountUsdc, fxQuote.rate());
 
-        workflowStarter.ifPresent(starter ->
-                starter.startWorkflow(
-                        finalRemittance.remittanceId(),
-                        wallet.solanaAddress(),
-                        recipientPhone,
-                        amountUsdc,
-                        savedClaim.token()));
+        workflowStarter.ifPresent(starter -> starter.startWorkflow(
+                finalRemittance.remittanceId(),
+                wallet.solanaAddress(),
+                recipientPhone,
+                amountUsdc,
+                savedClaim.token()));
 
         return finalRemittance;
     }

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceClaimSignaler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceClaimSignaler.java
@@ -1,0 +1,8 @@
+package com.stablepay.domain.remittance.port;
+
+import java.util.UUID;
+
+public interface RemittanceClaimSignaler {
+
+    void signalClaim(UUID remittanceId, String claimToken, String upiId);
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/port/WalletRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/port/WalletRepository.java
@@ -8,4 +8,5 @@ public interface WalletRepository {
     Wallet save(Wallet wallet);
     Optional<Wallet> findById(Long id);
     Optional<Wallet> findByUserId(String userId);
+    Optional<Wallet> findBySolanaAddress(String solanaAddress);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/claim/ClaimTokenJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/claim/ClaimTokenJpaRepository.java
@@ -2,8 +2,16 @@ package com.stablepay.infrastructure.db.claim;
 
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 
 interface ClaimTokenJpaRepository extends JpaRepository<ClaimTokenEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "4000")})
     Optional<ClaimTokenEntity> findByToken(String token);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletJpaRepository.java
@@ -18,4 +18,6 @@ interface WalletJpaRepository extends JpaRepository<WalletEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "4000")})
     Optional<WalletEntity> findById(Long id);
+
+    Optional<WalletEntity> findBySolanaAddress(String solanaAddress);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryAdapter.java
@@ -38,4 +38,9 @@ class WalletRepositoryAdapter implements WalletRepository {
     public Optional<Wallet> findByUserId(String userId) {
         return jpaRepository.findByUserId(userId).map(mapper::toDomain);
     }
+
+    @Override
+    public Optional<Wallet> findBySolanaAddress(String solanaAddress) {
+        return jpaRepository.findBySolanaAddress(solanaAddress).map(mapper::toDomain);
+    }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/sms/LoggingSmsAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/sms/LoggingSmsAdapter.java
@@ -1,0 +1,19 @@
+package com.stablepay.infrastructure.sms;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.common.port.SmsProvider;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@ConditionalOnMissingBean(SmsProvider.class)
+public class LoggingSmsAdapter implements SmsProvider {
+
+    @Override
+    public void sendSms(String phoneNumber, String message) {
+        log.info("[SMS] To: {} | Message: {}", phoneNumber, message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -58,6 +58,12 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
 
             var messageBytes = message.serialize();
             var mpcSignature = mpcWalletClient.signTransaction(messageBytes, wallet.keyShareData());
+            if (mpcSignature == null || mpcSignature.length != 64) {
+                throw SolanaTransactionException.submissionFailed(
+                        "deposit:" + remittanceId,
+                        new IllegalStateException("Invalid MPC signature: expected 64 bytes, got "
+                                + (mpcSignature == null ? "null" : mpcSignature.length)));
+            }
             transaction.addSignature(Base58.encode(mpcSignature));
             log.info("Deposit transaction for remittance {} signed via MPC", remittanceId);
 

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
+import com.stablepay.domain.wallet.port.MpcWalletClient;
+import com.stablepay.domain.wallet.port.WalletRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,8 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
     private final Connection solanaConnection;
     private final EscrowInstructionBuilder escrowInstructionBuilder;
     private final SolanaProperties solanaProperties;
+    private final MpcWalletClient mpcWalletClient;
+    private final WalletRepository walletRepository;
 
     @Override
     public String depositEscrow(
@@ -43,15 +47,19 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
             var instruction = escrowInstructionBuilder.buildDepositInstruction(
                     remittanceId, senderWallet, claimAuthority, amountUsdc, expiryTimestamp);
 
-            // TODO: Deposit requires sender wallet signature via MPC sidecar (STA-7).
-            // For now, build the transaction unsigned — it will fail on sendTransaction
-            // until MPC signing is integrated.
+            var wallet = walletRepository.findBySolanaAddress(senderWalletAddress)
+                    .orElseThrow(() -> SolanaTransactionException.submissionFailed(
+                            "deposit:" + remittanceId,
+                            new IllegalStateException("No wallet found for address: " + senderWalletAddress)));
+
             var blockhash = solanaConnection.getLatestBlockhash();
             var message = TransactionMessage.newMessage(senderWallet, blockhash, instruction);
             var transaction = new VersionedTransaction(message);
 
-            log.warn("Deposit transaction for remittance {} is unsigned — MPC signing not yet integrated",
-                    remittanceId);
+            var messageBytes = message.serialize();
+            var mpcSignature = mpcWalletClient.signTransaction(messageBytes, wallet.keyShareData());
+            transaction.addSignature(Base58.encode(mpcSignature));
+            log.info("Deposit transaction for remittance {} signed via MPC", remittanceId);
 
             var signature = solanaConnection.sendTransaction(transaction);
             log.info("Escrow deposit submitted for remittance {} with signature {}",

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignaler.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignaler.java
@@ -1,0 +1,53 @@
+package com.stablepay.infrastructure.temporal;
+
+import java.util.UUID;
+
+import org.sol4k.Base58;
+import org.sol4k.Keypair;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.remittance.port.RemittanceClaimSignaler;
+import com.stablepay.infrastructure.solana.SolanaProperties;
+
+import io.temporal.client.WorkflowClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnBean(WorkflowClient.class)
+public class TemporalRemittanceClaimSignaler implements RemittanceClaimSignaler {
+
+    private final WorkflowClient workflowClient;
+    private final SolanaProperties solanaProperties;
+
+    @Override
+    public void signalClaim(UUID remittanceId, String claimToken, String upiId) {
+        var workflowId = RemittanceLifecycleWorkflow.workflowId(remittanceId);
+        log.info("Signaling claim for workflowId={}, claimToken={}", workflowId, claimToken);
+
+        var workflow = workflowClient.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class, workflowId);
+
+        var destinationAddress = resolveClaimDestination();
+        var signal = ClaimSignal.builder()
+                .claimToken(claimToken)
+                .upiId(upiId)
+                .destinationAddress(destinationAddress)
+                .build();
+
+        workflow.claimSubmitted(signal);
+        log.info("Claim signal sent for workflowId={}", workflowId);
+    }
+
+    private String resolveClaimDestination() {
+        var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
+        if (privateKeyStr == null || privateKeyStr.isBlank()) {
+            return "";
+        }
+        return Keypair.fromSecretKey(Base58.decode(privateKeyStr))
+                .getPublicKey().toBase58();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignaler.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignaler.java
@@ -7,6 +7,7 @@ import org.sol4k.Keypair;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.remittance.port.RemittanceClaimSignaler;
 import com.stablepay.infrastructure.solana.SolanaProperties;
 
@@ -26,7 +27,7 @@ public class TemporalRemittanceClaimSignaler implements RemittanceClaimSignaler 
     @Override
     public void signalClaim(UUID remittanceId, String claimToken, String upiId) {
         var workflowId = RemittanceLifecycleWorkflow.workflowId(remittanceId);
-        log.info("Signaling claim for workflowId={}, claimToken={}", workflowId, claimToken);
+        log.info("Signaling claim for workflowId={}", workflowId);
 
         var workflow = workflowClient.newWorkflowStub(
                 RemittanceLifecycleWorkflow.class, workflowId);
@@ -45,7 +46,7 @@ public class TemporalRemittanceClaimSignaler implements RemittanceClaimSignaler 
     private String resolveClaimDestination() {
         var privateKeyStr = solanaProperties.claimAuthorityPrivateKey();
         if (privateKeyStr == null || privateKeyStr.isBlank()) {
-            return "";
+            throw SolanaTransactionException.claimAuthorityNotConfigured();
         }
         return Keypair.fromSecretKey(Base58.decode(privateKeyStr))
                 .getPublicKey().toBase58();

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
@@ -13,9 +13,9 @@ import static org.mockito.BDDMockito.then;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,6 +26,7 @@ import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.port.RemittanceClaimSignaler;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,8 +38,16 @@ class SubmitClaimHandlerTest {
     @Mock
     private RemittanceRepository remittanceRepository;
 
-    @InjectMocks
+    @Mock
+    private RemittanceClaimSignaler claimSignaler;
+
     private SubmitClaimHandler submitClaimHandler;
+
+    @BeforeEach
+    void setUp() {
+        submitClaimHandler = new SubmitClaimHandler(
+                claimTokenRepository, remittanceRepository, Optional.of(claimSignaler));
+    }
 
     @Test
     void shouldSubmitClaimSuccessfully() {

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 
 import java.util.Optional;
 
@@ -63,23 +64,75 @@ class SubmitClaimHandlerTest {
         var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
         given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
 
-        var updatedRemittance = remittance.toBuilder().status(RemittanceStatus.CLAIMED).build();
-        given(remittanceRepository.save(updatedRemittance)).willReturn(updatedRemittance);
-
         // when
         var result = submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID);
 
         // then
         var expected = ClaimDetails.builder()
                 .claimToken(updatedClaim)
-                .remittance(updatedRemittance)
+                .remittance(remittance)
                 .build();
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
 
         then(claimTokenRepository).should().save(updatedClaim);
-        then(remittanceRepository).should().save(updatedRemittance);
+        then(claimSignaler).should().signalClaim(SOME_REMITTANCE_ID, SOME_TOKEN, SOME_UPI_ID);
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenSignalerFails() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder()
+                .status(RemittanceStatus.ESCROWED)
+                .build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
+        given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
+
+        willThrow(new RuntimeException("Temporal unavailable"))
+                .given(claimSignaler).signalClaim(SOME_REMITTANCE_ID, SOME_TOKEN, SOME_UPI_ID);
+
+        // when / then
+        assertThatThrownBy(() -> submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Temporal unavailable");
+    }
+
+    @Test
+    void shouldSubmitClaimWithoutSignalerWhenNotConfigured() {
+        // given
+        var handler = new SubmitClaimHandler(
+                claimTokenRepository, remittanceRepository, Optional.empty());
+
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder()
+                .status(RemittanceStatus.ESCROWED)
+                .build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+
+        var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
+        given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
+
+        // when
+        var result = handler.handle(SOME_TOKEN, SOME_UPI_ID);
+
+        // then
+        var expected = ClaimDetails.builder()
+                .claimToken(updatedClaim)
+                .remittance(remittance)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(claimSignaler).shouldHaveNoInteractions();
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
@@ -5,7 +5,6 @@ import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,18 +16,20 @@ import static org.mockito.BDDMockito.then;
 import java.math.BigDecimal;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.fx.port.FxRateProvider;
 import com.stablepay.domain.remittance.model.Remittance;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
+import com.stablepay.domain.remittance.port.RemittanceWorkflowStarter;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.port.WalletRepository;
@@ -45,11 +46,26 @@ class CreateRemittanceHandlerTest {
     @Mock
     private FxRateProvider fxRateProvider;
 
+    @Mock
+    private ClaimTokenRepository claimTokenRepository;
+
+    @Mock
+    private RemittanceWorkflowStarter workflowStarter;
+
     @Captor
     private ArgumentCaptor<Remittance> remittanceCaptor;
 
-    @InjectMocks
     private CreateRemittanceHandler createRemittanceHandler;
+
+    @BeforeEach
+    void setUp() {
+        createRemittanceHandler = new CreateRemittanceHandler(
+                remittanceRepository,
+                walletRepository,
+                fxRateProvider,
+                claimTokenRepository,
+                Optional.of(workflowStarter));
+    }
 
     @Test
     void shouldCreateRemittanceWithLockedFxRate() {
@@ -68,34 +84,25 @@ class CreateRemittanceHandlerTest {
 
         given(fxRateProvider.getRate("USD", "INR")).willReturn(fxQuote);
 
-        given(remittanceRepository.save(argThat(r ->
-                r.senderId().equals(SOME_SENDER_ID)
-                        && r.status() == RemittanceStatus.INITIATED)))
+        given(remittanceRepository.save(argThat(r -> r != null && r.senderId() != null)))
                 .willAnswer(invocation -> invocation.<Remittance>getArgument(0).toBuilder().id(1L).build());
 
+        given(claimTokenRepository.save(argThat(ct -> ct != null && !ct.claimed())))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
         // when
-        createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
+        var result = createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
 
         // then
-        then(remittanceRepository).should().save(remittanceCaptor.capture());
-
-        var expected = Remittance.builder()
-                .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
-                .recipientPhone(SOME_RECIPIENT_PHONE)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .amountInr(SOME_AMOUNT_INR)
-                .fxRate(SOME_FX_RATE)
-                .status(RemittanceStatus.INITIATED)
-                .smsNotificationFailed(false)
-                .build();
-
-        assertThat(remittanceCaptor.getValue())
-                .usingRecursiveComparison()
-                .ignoringFields("remittanceId")
-                .isEqualTo(expected);
+        assertThat(result.senderId()).isEqualTo(SOME_SENDER_ID);
+        assertThat(result.status()).isEqualTo(RemittanceStatus.INITIATED);
+        assertThat(result.amountUsdc()).isEqualByComparingTo(SOME_AMOUNT_USDC);
+        assertThat(result.amountInr()).isEqualByComparingTo(SOME_AMOUNT_INR);
+        assertThat(result.fxRate()).isEqualByComparingTo(SOME_FX_RATE);
+        assertThat(result.claimTokenId()).isNotNull();
 
         then(walletRepository).should().save(reservedWallet);
+        then(claimTokenRepository).should().save(argThat(ct -> !ct.claimed() && ct.expiresAt() != null));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.claim.model.ClaimToken;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.fx.port.FxRateProvider;
 import com.stablepay.domain.remittance.model.Remittance;
@@ -54,6 +56,9 @@ class CreateRemittanceHandlerTest {
 
     @Captor
     private ArgumentCaptor<Remittance> remittanceCaptor;
+
+    @Captor
+    private ArgumentCaptor<ClaimToken> claimTokenCaptor;
 
     private CreateRemittanceHandler createRemittanceHandler;
 
@@ -94,15 +99,117 @@ class CreateRemittanceHandlerTest {
         var result = createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
 
         // then
-        assertThat(result.senderId()).isEqualTo(SOME_SENDER_ID);
-        assertThat(result.status()).isEqualTo(RemittanceStatus.INITIATED);
-        assertThat(result.amountUsdc()).isEqualByComparingTo(SOME_AMOUNT_USDC);
-        assertThat(result.amountInr()).isEqualByComparingTo(SOME_AMOUNT_INR);
-        assertThat(result.fxRate()).isEqualByComparingTo(SOME_FX_RATE);
-        assertThat(result.claimTokenId()).isNotNull();
+        var expected = result.toBuilder()
+                .id(1L)
+                .senderId(SOME_SENDER_ID)
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
+                .fxRate(SOME_FX_RATE)
+                .status(RemittanceStatus.INITIATED)
+                .smsNotificationFailed(false)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(expected);
 
         then(walletRepository).should().save(reservedWallet);
-        then(claimTokenRepository).should().save(argThat(ct -> !ct.claimed() && ct.expiresAt() != null));
+        then(claimTokenRepository).should().save(claimTokenCaptor.capture());
+        var savedClaimToken = claimTokenCaptor.getValue();
+        var expectedClaimToken = ClaimToken.builder()
+                .remittanceId(result.remittanceId())
+                .token(savedClaimToken.token())
+                .claimed(false)
+                .expiresAt(savedClaimToken.expiresAt())
+                .build();
+        assertThat(savedClaimToken)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "createdAt")
+                .isEqualTo(expectedClaimToken);
+        assertThat(savedClaimToken.expiresAt()).isNotNull();
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenWorkflowStarterFails() {
+        // given
+        var wallet = walletBuilder()
+                .availableBalance(BigDecimal.valueOf(500))
+                .totalBalance(BigDecimal.valueOf(500))
+                .build();
+
+        var fxQuote = fxQuoteBuilder().build();
+
+        given(walletRepository.findByUserId(SOME_SENDER_ID)).willReturn(Optional.of(wallet));
+
+        var reservedWallet = wallet.reserveBalance(SOME_AMOUNT_USDC);
+        given(walletRepository.save(reservedWallet)).willReturn(reservedWallet);
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(fxQuote);
+
+        given(remittanceRepository.save(argThat(r -> r != null && r.senderId() != null)))
+                .willAnswer(invocation -> invocation.<Remittance>getArgument(0).toBuilder().id(1L).build());
+
+        given(claimTokenRepository.save(argThat(ct -> ct != null && !ct.claimed())))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        willThrow(new RuntimeException("Temporal unavailable"))
+                .given(workflowStarter).startWorkflow(
+                        argThat(id -> id != null),
+                        argThat(addr -> addr != null),
+                        argThat(phone -> phone != null),
+                        argThat(amt -> amt != null),
+                        argThat(tok -> tok != null));
+
+        // when / then
+        assertThatThrownBy(() -> createRemittanceHandler.handle(
+                SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Temporal unavailable");
+    }
+
+    @Test
+    void shouldCreateRemittanceWithoutWorkflowStarterWhenNotConfigured() {
+        // given
+        var handler = new CreateRemittanceHandler(
+                remittanceRepository, walletRepository, fxRateProvider,
+                claimTokenRepository, Optional.empty());
+
+        var wallet = walletBuilder()
+                .availableBalance(BigDecimal.valueOf(500))
+                .totalBalance(BigDecimal.valueOf(500))
+                .build();
+
+        var fxQuote = fxQuoteBuilder().build();
+
+        given(walletRepository.findByUserId(SOME_SENDER_ID)).willReturn(Optional.of(wallet));
+
+        var reservedWallet = wallet.reserveBalance(SOME_AMOUNT_USDC);
+        given(walletRepository.save(reservedWallet)).willReturn(reservedWallet);
+
+        given(fxRateProvider.getRate("USD", "INR")).willReturn(fxQuote);
+
+        given(remittanceRepository.save(argThat(r -> r != null && r.senderId() != null)))
+                .willAnswer(invocation -> invocation.<Remittance>getArgument(0).toBuilder().id(1L).build());
+
+        given(claimTokenRepository.save(argThat(ct -> ct != null && !ct.claimed())))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        var result = handler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC);
+
+        // then
+        var expected = result.toBuilder()
+                .senderId(SOME_SENDER_ID)
+                .status(RemittanceStatus.INITIATED)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "createdAt", "updatedAt")
+                .isEqualTo(expected);
+
+        then(workflowStarter).shouldHaveNoInteractions();
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -32,6 +32,8 @@ import org.sol4k.VersionedTransaction;
 import org.sol4k.instruction.BaseInstruction;
 
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+import com.stablepay.domain.wallet.port.MpcWalletClient;
+import com.stablepay.domain.wallet.port.WalletRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SolanaTransactionServiceAdapterTest {
@@ -41,6 +43,12 @@ class SolanaTransactionServiceAdapterTest {
 
     @Mock
     private EscrowInstructionBuilder escrowInstructionBuilder;
+
+    @Mock
+    private MpcWalletClient mpcWalletClient;
+
+    @Mock
+    private WalletRepository walletRepository;
 
     private SolanaProperties propertiesWithKey;
     private SolanaProperties propertiesWithoutKey;
@@ -64,7 +72,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldReturnConfirmedForTransactionStatusStub() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
 
             // when
             var result = adapter.getTransactionStatus(SOME_TRANSACTION_SIGNATURE);
@@ -81,7 +90,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldSubmitClaimTransactionAndReturnSignature() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
             var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
             var destination = new PublicKey(SOME_DESTINATION_TOKEN_ACCOUNT);
             var instruction = new BaseInstruction(
@@ -107,7 +117,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldThrowWhenClaimAuthorityNotConfigured() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey,
+                    mpcWalletClient, walletRepository);
 
             // when / then
             assertThatThrownBy(() -> adapter.claimEscrow(
@@ -124,7 +135,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldSubmitRefundTransactionAndReturnSignature() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
             var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
             var senderWallet = new PublicKey(SOME_SENDER_WALLET);
             var instruction = new BaseInstruction(
@@ -150,7 +162,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldThrowWhenClaimAuthorityNotConfiguredForRefund() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey,
+                    mpcWalletClient, walletRepository);
 
             // when / then
             assertThatThrownBy(() -> adapter.refundEscrow(SOME_REMITTANCE_ID, SOME_SENDER_WALLET))
@@ -166,7 +179,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldThrowWhenClaimAuthorityNotConfiguredForDeposit() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithoutKey,
+                    mpcWalletClient, walletRepository);
 
             // when / then
             assertThatThrownBy(() -> adapter.depositEscrow(
@@ -180,7 +194,8 @@ class SolanaTransactionServiceAdapterTest {
         void shouldThrowSolanaTransactionExceptionWhenDepositBuildFails() {
             // given
             var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithKey);
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
             var senderWallet = new PublicKey(SOME_SENDER_WALLET);
             var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
 

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -11,12 +11,14 @@ import static com.stablepay.testutil.SolanaFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.SolanaFixtures.SOME_SENDER_WALLET;
 import static com.stablepay.testutil.SolanaFixtures.SOME_TRANSACTION_SIGNATURE;
 import static com.stablepay.testutil.SolanaFixtures.SOME_USDC_MINT;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -174,6 +176,112 @@ class SolanaTransactionServiceAdapterTest {
 
     @Nested
     class DepositEscrow {
+
+        @Test
+        void shouldSignDepositViaMpcAndReturnSignature() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+            var wallet = walletBuilder()
+                    .solanaAddress(SOME_SENDER_WALLET)
+                    .keyShareData(new byte[]{1, 2, 3})
+                    .build();
+            var instruction = new BaseInstruction(
+                    new byte[8], List.of(AccountMeta.signerAndWritable(senderWallet)),
+                    new PublicKey(SOME_PROGRAM_ID));
+
+            given(escrowInstructionBuilder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthorityPubKey,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .willReturn(instruction);
+            given(walletRepository.findBySolanaAddress(SOME_SENDER_WALLET))
+                    .willReturn(Optional.of(wallet));
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(mpcWalletClient.signTransaction(
+                    ArgumentMatchers.<byte[]>notNull(),
+                    ArgumentMatchers.<byte[]>notNull()))
+                    .willReturn(new byte[64]);
+            given(solanaConnection.sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            var result = adapter.depositEscrow(
+                    SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP);
+
+            // then
+            assertThat(result).isEqualTo(SOME_TRANSACTION_SIGNATURE);
+            then(mpcWalletClient).should().signTransaction(
+                    ArgumentMatchers.<byte[]>notNull(),
+                    ArgumentMatchers.<byte[]>notNull());
+            then(solanaConnection).should().sendTransaction(ArgumentMatchers.<VersionedTransaction>notNull());
+        }
+
+        @Test
+        void shouldThrowWhenWalletNotFoundForDeposit() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+            var instruction = new BaseInstruction(
+                    new byte[8], List.of(AccountMeta.signerAndWritable(senderWallet)),
+                    new PublicKey(SOME_PROGRAM_ID));
+
+            given(escrowInstructionBuilder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthorityPubKey,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .willReturn(instruction);
+            given(walletRepository.findBySolanaAddress(SOME_SENDER_WALLET))
+                    .willReturn(Optional.empty());
+
+            // when / then
+            assertThatThrownBy(() -> adapter.depositEscrow(
+                    SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0010");
+        }
+
+        @Test
+        void shouldThrowWhenMpcSigningFails() {
+            // given
+            var adapter = new SolanaTransactionServiceAdapter(
+                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
+                    mpcWalletClient, walletRepository);
+            var senderWallet = new PublicKey(SOME_SENDER_WALLET);
+            var claimAuthorityPubKey = new PublicKey(SOME_CLAIM_AUTHORITY_PUBLIC_KEY);
+            var wallet = walletBuilder()
+                    .solanaAddress(SOME_SENDER_WALLET)
+                    .keyShareData(new byte[]{1, 2, 3})
+                    .build();
+            var instruction = new BaseInstruction(
+                    new byte[8], List.of(AccountMeta.signerAndWritable(senderWallet)),
+                    new PublicKey(SOME_PROGRAM_ID));
+
+            given(escrowInstructionBuilder.buildDepositInstruction(
+                    SOME_REMITTANCE_ID, senderWallet, claimAuthorityPubKey,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .willReturn(instruction);
+            given(walletRepository.findBySolanaAddress(SOME_SENDER_WALLET))
+                    .willReturn(Optional.of(wallet));
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(mpcWalletClient.signTransaction(
+                    ArgumentMatchers.<byte[]>notNull(),
+                    ArgumentMatchers.<byte[]>notNull()))
+                    .willThrow(new RuntimeException("MPC signing failed"));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.depositEscrow(
+                    SOME_REMITTANCE_ID, SOME_SENDER_WALLET,
+                    SOME_AMOUNT_USDC, SOME_EXPIRY_TIMESTAMP))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0010");
+        }
 
         @Test
         void shouldThrowWhenClaimAuthorityNotConfiguredForDeposit() {

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignalerTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceClaimSignalerTest.java
@@ -1,0 +1,81 @@
+package com.stablepay.infrastructure.temporal;
+
+import static com.stablepay.testutil.SolanaFixtures.SOME_CLAIM_AUTHORITY_PRIVATE_KEY;
+import static com.stablepay.testutil.SolanaFixtures.SOME_CLAIM_AUTHORITY_PUBLIC_KEY;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_CLAIM_TOKEN;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_UPI_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sol4k.PublicKey;
+
+import com.stablepay.infrastructure.solana.SolanaProperties;
+
+import io.temporal.client.WorkflowClient;
+
+@ExtendWith(MockitoExtension.class)
+class TemporalRemittanceClaimSignalerTest {
+
+    @Mock
+    private WorkflowClient workflowClient;
+
+    @Mock
+    private RemittanceLifecycleWorkflow workflowStub;
+
+    @Captor
+    private ArgumentCaptor<ClaimSignal> signalCaptor;
+
+    @Test
+    void shouldSignalClaimWithCorrectWorkflowIdAndSignal() {
+        // given
+        var solanaProperties = new SolanaProperties(
+                new PublicKey("EscrowProgram111111111111111111111111111111"),
+                new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+                SOME_CLAIM_AUTHORITY_PRIVATE_KEY);
+        var signaler = new TemporalRemittanceClaimSignaler(workflowClient, solanaProperties);
+
+        var expectedWorkflowId = RemittanceLifecycleWorkflow.workflowId(SOME_REMITTANCE_ID);
+        given(workflowClient.newWorkflowStub(RemittanceLifecycleWorkflow.class, expectedWorkflowId))
+                .willReturn(workflowStub);
+
+        // when
+        signaler.signalClaim(SOME_REMITTANCE_ID, SOME_CLAIM_TOKEN, SOME_UPI_ID);
+
+        // then
+        then(workflowClient).should().newWorkflowStub(RemittanceLifecycleWorkflow.class, expectedWorkflowId);
+        then(workflowStub).should().claimSubmitted(signalCaptor.capture());
+
+        var expected = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_CLAIM_AUTHORITY_PUBLIC_KEY)
+                .build();
+        assertThat(signalCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowWhenClaimAuthorityNotConfigured() {
+        // given
+        var solanaProperties = new SolanaProperties(
+                new PublicKey("EscrowProgram111111111111111111111111111111"),
+                new PublicKey("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+                "");
+        var signaler = new TemporalRemittanceClaimSignaler(workflowClient, solanaProperties);
+
+        // when / then
+        assertThatThrownBy(() -> signaler.signalClaim(SOME_REMITTANCE_ID, SOME_CLAIM_TOKEN, SOME_UPI_ID))
+                .isInstanceOf(com.stablepay.domain.remittance.exception.SolanaTransactionException.class)
+                .hasMessageContaining("SP-0014");
+    }
+}


### PR DESCRIPTION
## Summary
- **LoggingSmsAdapter** — fallback `SmsProvider` when Twilio disabled, prevents startup failure
- **RemittanceClaimSignaler** — new domain port + Temporal adapter to signal workflow on claim submission
- **CreateRemittanceHandler** — now creates `ClaimToken` record (48h expiry) and starts Temporal workflow
- **SubmitClaimHandler** — now signals Temporal workflow after DB update, triggering escrow release
- **SolanaTransactionServiceAdapter** — deposit transactions are now signed via MPC sidecar (`message.serialize()` → MPC sign → `addSignature`)
- **WalletRepository.findBySolanaAddress** — new query method for MPC key share lookup during signing

## Files changed
- 3 new files (LoggingSmsAdapter, RemittanceClaimSignaler, TemporalRemittanceClaimSignaler)
- 6 modified production files
- 3 modified test files
- All 183 tests pass, spotless clean

## Test plan
- [x] `./gradlew build` passes (compile + spotless + all tests)
- [ ] `docker compose up postgres redis temporal temporal-ui mpc-sidecar-0` starts infrastructure
- [ ] `./gradlew bootRun` starts backend connected to all services
- [ ] `POST /api/wallets` → MPC keygen → wallet created
- [ ] `POST /api/wallets/{id}/fund` → balance updated
- [ ] `POST /api/remittances` → ClaimToken created, Temporal workflow started
- [ ] `GET /api/claims/{token}` → claim details returned
- [ ] `POST /api/claims/{token}` → workflow signaled, escrow released
- [ ] `GET /api/remittances/{id}` → status progresses INITIATED → ESCROWED → CLAIMED → DELIVERED

Closes #125, closes #126, closes #127, closes #128, closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #125 126 127 128 129
Closes #126
Closes #127
Closes #128
Closes #129