### PR TITLE
STA-50: Makefile for full-stack Docker Compose orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: up down restart logs ps infra urls clean build-backend help
+
+COMPOSE := docker compose
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+build-backend: ## Build backend JAR (required before 'make up')
+	@echo "Building backend JAR..."
+	@cd backend && ./gradlew assemble -q
+
+up: build-backend ## Start the full stack (build + docker compose up)
+	@echo "Starting StablePay stack..."
+	@$(COMPOSE) up -d --build
+	@echo ""
+	@echo "Waiting for services to become healthy..."
+	@$(COMPOSE) up -d --wait 2>/dev/null || true
+	@$(MAKE) --no-print-directory urls
+
+down: ## Stop all services
+	@$(COMPOSE) down
+	@echo "StablePay stack stopped."
+
+restart: down up ## Restart the full stack
+
+logs: ## Follow logs from all services
+	@$(COMPOSE) logs -f
+
+ps: ## Show running services
+	@$(COMPOSE) ps
+
+infra: ## Start infrastructure only (for local backend dev via ./gradlew bootRun)
+	@echo "Starting infrastructure services..."
+	@$(COMPOSE) up -d postgres redis temporal temporal-ui mpc-sidecar-0 mpc-sidecar-1
+	@echo ""
+	@echo "Waiting for services..."
+	@sleep 5
+	@$(MAKE) --no-print-directory urls-infra
+	@echo ""
+	@echo "Run the backend locally:"
+	@echo "  cd backend && ./gradlew bootRun"
+
+urls: ## Print all service URLs
+	@echo ""
+	@echo "============================================"
+	@echo "  StablePay Dev Stack"
+	@echo "============================================"
+	@echo "  Backend API:    http://localhost:8080"
+	@echo "  Swagger UI:     http://localhost:8080/swagger-ui.html"
+	@echo "  Health:         http://localhost:8080/actuator/health"
+	@echo "  Temporal UI:    http://localhost:8088"
+	@echo "  PostgreSQL:     localhost:5432"
+	@echo "  Redis:          localhost:6379"
+	@echo "  MPC Sidecar 0:  localhost:50051 (gRPC)"
+	@echo "  MPC Sidecar 1:  localhost:50052 (gRPC)"
+	@echo "============================================"
+	@echo ""
+
+urls-infra: ## Print infrastructure URLs (no backend)
+	@echo ""
+	@echo "============================================"
+	@echo "  StablePay Infrastructure"
+	@echo "============================================"
+	@echo "  Temporal UI:    http://localhost:8088"
+	@echo "  PostgreSQL:     localhost:5432"
+	@echo "  Redis:          localhost:6379"
+	@echo "  MPC Sidecar 0:  localhost:50051 (gRPC)"
+	@echo "  MPC Sidecar 1:  localhost:50052 (gRPC)"
+	@echo "============================================"
+	@echo ""
+
+clean: ## Stop all services and remove volumes
+	@$(COMPOSE) down -v
+	@echo "StablePay stack stopped and volumes removed."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,40 @@ services:
       timeout: 5s
       retries: 5
 
+  mpc-sidecar-0:
+    build:
+      context: ./mpc-sidecar
+      dockerfile: Dockerfile
+    ports:
+      - "50051:50051"
+      - "7000:7000"
+    environment:
+      PARTY_ID: 0
+      GRPC_PORT: 50051
+      P2P_PORT: 7000
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 50051 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  mpc-sidecar-1:
+    build:
+      context: ./mpc-sidecar
+      dockerfile: Dockerfile
+    ports:
+      - "50052:50051"
+      - "7001:7000"
+    environment:
+      PARTY_ID: 1
+      GRPC_PORT: 50051
+      P2P_PORT: 7000
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 50051 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   backend:
     image: stablepay-backend:latest
     build:
@@ -63,6 +97,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       TEMPORAL_ADDRESS: temporal:7233
+      MPC_SIDECAR_HOST: mpc-sidecar-0
+      MPC_SIDECAR_PORT: 50051
     depends_on:
       postgres:
         condition: service_healthy
@@ -70,6 +106,8 @@ services:
         condition: service_healthy
       temporal:
         condition: service_started
+      mpc-sidecar-0:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary
- **Makefile** with targets: `up`, `down`, `restart`, `logs`, `ps`, `infra`, `urls`, `clean`
- `make infra` starts only infrastructure (postgres, redis, temporal, mpc-sidecars) for local backend dev
- `make up` builds backend JAR, starts all services, prints URLs
- Adds MPC sidecar services (party-0, party-1) to `docker-compose.yml`

## Usage
```bash
# Start everything
make up

# Start infra only (run backend locally)
make infra
cd backend && ./gradlew bootRun

# See URLs
make urls

# Stop
make down

# Stop and remove volumes
make clean
```

## Test plan
- [x] `make help` shows all targets
- [x] `make urls` prints service endpoints
- [x] `docker compose config` validates successfully
- [ ] `make infra` starts infrastructure services
- [ ] `make up` starts full stack with backend

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)