### PR TITLE
STA-72: Stripe on-ramp integration spec (rev 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,90 +723,186 @@ pub struct Escrow {
 
 ## 🏦 Solana Accounting Model: Where Every Dollar Goes
 
-> A visual walkthrough of every wallet, PDA, and token account involved in a $25 remittance — from the moment the sender taps "Send" to the recipient receiving INR in their bank.
+> A visual walkthrough of every wallet, PDA, and token account involved in a $25 remittance — from program deployment to the recipient receiving INR in their bank.
 
 ### 🗝️ The Players
 
+On Solana, there are different kinds of accounts. Here's what each one is, with a real-world analogy:
+
+| | Solana Concept | Real-World Analogy | What It Does |
+|---|---|---|---|
+| 🔑 | **Wallet** (System Account) | Your **physical wallet** with cash | Holds SOL for tx fees. Has a private key you sign with. Cannot hold tokens directly — needs a Token Account for that. |
+| 🪙 | **Token Account** (ATA) | A **bank account** for one specific currency | Holds USDC (or any SPL token) on behalf of a wallet. One per currency — you have a separate USDC account, BONK account, etc. Address auto-derived from your wallet + token type. |
+| 📦 | **PDA** (Program Derived Address) | A **locked safety deposit box** at the bank | No one has the key — only the program's rules can open it. "Release funds when the authority says OK." Used for escrow vaults and trustless custody. |
+| 🏭 | **Mint** | The **US Treasury** / central bank that prints money | Defines a token type (like USDC). Has a "mint authority" — the only entity that can create new tokens. Circle is the mint authority for real USDC. |
+| ⚙️ | **Program** | The **rulebook** at an escrow company | Code deployed once to Solana, reused forever by all transactions. "Hold the buyer's money. Release when conditions met. Refund if timeout." Our escrow program handles every remittance with the same rules. |
+
+```
+Think of the whole system like this:
+
+  👤 You (wallet)  ──►  🏦 Your bank account (ATA)  ──►  📦 Escrow company (PDA)
+      │                         │                              │
+      has SOL                   has USDC                       has locked USDC
+      (cash for fees)           (your balance)                 (held until rules say release)
+      │                         │                              │
+      signs with                managed by                     controlled by
+      private key               Token Program                  Escrow Program
+```
+
+Now the actual wallets involved in StablePay:
+
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                        WALLETS & ACCOUNTS                                │
+│                        STABLEPAY WALLETS                                 │
 ├──────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
-│  👤 SENDER MPC WALLET                                                    │
-│  ├─ Address: DQoGcVse...  (Ed25519 — no one holds the full key)         │
-│  ├─ Type: System account (holds SOL for tx fees)                         │
-│  └─ Token Account (ATA): GuDuFKeX...  (holds USDC)                      │
-│                                                                          │
-│  🏛️ DEPLOYER WALLET                                                     │
+│  🏛️ DEPLOYER WALLET (one-time setup)                                    │
 │  ├─ Address: 58gFSCTW...                                                 │
-│  ├─ Role: Deployed the escrow program, pays for program storage          │
-│  └─ Not involved in transactions after deployment                        │
+│  ├─ Role: Deploys the escrow program to Solana (one-time operation)      │
+│  ├─ Becomes the "upgrade authority" — can update the program later       │
+│  ├─ Pays ~2 SOL for program storage rent                                 │
+│  ├─ In production: would be a multisig for security                      │
+│  └─ ⚠️ NOT involved in any remittance transaction after deployment       │
 │                                                                          │
-│  🔐 CLAIM AUTHORITY                                                      │
+│  👤 SENDER MPC WALLET (one per user)                                     │
+│  ├─ Address: DQoGcVse...  (Ed25519 — no one holds the full private key) │
+│  ├─ Created via MPC DKG — key split across 2 sidecars                    │
+│  ├─ SOL balance: pays for deposit tx fees + account rent                 │
+│  └─ Token Account (ATA): GuDuFKeX... — holds the user's USDC            │
+│                                                                          │
+│  🔐 CLAIM AUTHORITY (one per StablePay deployment)                       │
 │  ├─ Address: 3LZh792t...  (backend-controlled keypair)                   │
-│  ├─ Role: Authorizes claim & refund — the only key that can release USDC│
-│  ├─ Token Account (ATA): 2KKehH5e...  (receives USDC on claim)          │
-│  └─ Pays tx fees for claim/refund transactions                           │
+│  ├─ The ONLY key that can release USDC from escrow (via claim)           │
+│  ├─ Stored as CLAIM_AUTHORITY_PRIVATE_KEY in .env                        │
+│  ├─ Token Account (ATA): 2KKehH5e... — receives USDC when claims happen │
+│  ├─ Pays tx fees for claim/refund operations                             │
+│  └─ In production: would be a multisig or HSM-backed key                 │
 │                                                                          │
-│  📦 ESCROW PDA (per remittance)                                          │
-│  ├─ Address: derived from ["escrow", remittance_id]                      │
-│  ├─ Type: Program-owned account (data: sender, amount, deadline, etc.)   │
-│  └─ Created on deposit, closed on claim/refund (rent → sender)           │
+│  📦 ESCROW PDA + 🏦 VAULT PDA (one pair per remittance)                  │
+│  ├─ Escrow: stores metadata (sender, amount, deadline, status)           │
+│  ├─ Vault: SPL Token Account that holds the locked USDC                  │
+│  ├─ Both created on deposit, both closed on claim/refund                 │
+│  ├─ Rent SOL always returned to sender when accounts close               │
+│  └─ No private key exists — only the escrow program can move funds       │
 │                                                                          │
-│  🏦 VAULT PDA (per escrow)                                               │
-│  ├─ Address: derived from ["vault", escrow_pubkey]                       │
-│  ├─ Type: SPL Token Account — holds the locked USDC                      │
-│  ├─ Authority: escrow PDA (only the program can move funds)              │
-│  └─ Created on deposit, closed on claim/refund (rent → sender)           │
-│                                                                          │
-│  🪙 USDC MINT                                                            │
-│  ├─ Address: CAUBK3cr... (test mint) / 4zMMC9sr... (devnet USDC)        │
-│  └─ 6 decimals — $25.00 = 25,000,000 lamports                           │
-│                                                                          │
-│  ⚙️ ESCROW PROGRAM                                                       │
-│  ├─ Address: 7C2zsbhg...                                                 │
-│  └─ Custom Anchor program — deposit, claim, refund, cancel               │
+│  🏭 USDC MINT                                                            │
+│  ├─ Devnet: Circle's USDC (4zMMC9sr...) or test mint (CAUBK3cr...)      │
+│  ├─ Mint authority: whoever created the mint (Circle, or us for tests)   │
+│  └─ We use a test mint for E2E testing because we can't mint real USDC   │
 │                                                                          │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### 📖 The Story of a $25 Remittance
 
+#### Act 0: 🚀 Program Deployment (one-time — NOT per transaction)
+
+> The escrow program is deployed **once** to Solana. It's like publishing a smart contract. Every remittance reuses the same program code — only the data accounts (escrow + vault) are created per transaction.
+
+```
+  🏛️ Deployer Wallet                        Solana Network
+  58gFSCTW...
+  ┌─────────────┐     anchor deploy         ┌─────────────────────────┐
+  │ SOL: 5.0    │──────────────────────────►│ ⚙️ Program Account       │
+  │             │     ~2 SOL for rent       │ 7C2zsbhg...             │
+  │ Upgrade     │                           │ Code: deposit, claim,   │
+  │ Authority 🔑│                           │       refund, cancel    │
+  └─────────────┘                           │ Size: ~285 KB           │
+                                            │ Owner: BPF Loader       │
+       After deployment:                    └─────────────────────────┘
+       Deployer SOL: 5.0 → 3.0
+       Program lives on-chain permanently    ✅ Deployed once, used forever
+       Deployer is NOT involved in any
+       remittance transaction after this
+```
+
+**In production:**
+- Deploy once to mainnet (costs ~2 SOL ≈ $300 at current prices)
+- Transfer upgrade authority to a multisig
+- Program is immutable after authority is revoked (optional)
+
 #### Act 1: 🔑 Wallet Creation (MPC DKG)
 
-```
-  MPC Sidecar 0          MPC Sidecar 1
-  ┌──────────┐          ┌──────────┐
-  │ Party 0  │◄════════►│ Party 1  │    P2P DKG ceremony
-  │ (gRPC)   │  rounds  │ (gRPC)   │    over ports 7000↔7001
-  └────┬─────┘          └──────────┘
-       │
-       ▼
-  Key Share 0 ──► stored in DB       Key Share 1 ──► stored in DB
-  (primary)       (wallets table)    (peer)          (peer_key_share_data)
+> A sender signs up and gets a Solana wallet. But unlike MetaMask, **no one ever sees a seed phrase**. The private key is split across two MPC sidecars using a Distributed Key Generation ceremony.
 
-  Result: Solana address DQoGcVse... created
-          🔒 Full private key NEVER exists — not even in memory
+```
+  Backend                MPC Sidecar 0          MPC Sidecar 1
+  ┌──────────┐          ┌──────────┐          ┌──────────┐
+  │ POST     │─ gRPC ──►│ Party 0  │◄════════►│ Party 1  │
+  │ /api/    │          │ partyId=0│  P2P DKG │ partyId=1│
+  │ wallets  │          │          │  rounds   │          │
+  └──────────┘          └────┬─────┘  7000↔7001└────┬─────┘
+                             │                      │
+                             ▼                      ▼
+                        Key Share 0            Key Share 1
+                        (primary)              (peer)
+                             │                      │
+                             └──────┬───────────────┘
+                                    ▼
+                            ┌──────────────┐
+                            │  PostgreSQL   │
+                            │  wallets table│
+                            │              │
+                            │ key_share_data│ ◄── Party 0's share
+                            │ peer_key_     │
+                            │ share_data    │ ◄── Party 1's share
+                            │ solana_address│ ◄── DQoGcVse...
+                            └──────────────┘
+
+  🔒 The full Ed25519 private key NEVER exists anywhere
+  🔒 Each sidecar only sees its own share during the ceremony
+  🔒 Key shares persist in DB — survive app restarts
+  🔒 Both sidecars needed to sign (2-of-2 threshold)
 ```
 
-**What's created on Solana:** Nothing yet! The wallet is just a key — no on-chain account until someone sends SOL to it.
+**What's created on Solana:** Nothing! A Solana "wallet" is just a keypair. The address `DQoGcVse...` exists mathematically but has no on-chain account yet. It becomes a real account when someone sends SOL to it.
 
 #### Act 2: 💰 Funding the Wallet
 
-```
-  Deployer Wallet              Sender MPC Wallet
-  58gFSCTW...                  DQoGcVse...
-  ┌─────────────┐              ┌─────────────┐
-  │ SOL: 5.0    │──── 1 SOL ──►│ SOL: 1.0    │  For tx fees
-  └─────────────┘              └─────────────┘
+> Before the sender can make a remittance, their MPC wallet needs SOL (for transaction fees) and USDC (the stablecoin to send). In production, this happens via Stripe ACH on-ramp. For the hackathon, we use a pre-funded treasury.
 
-  Deployer (mint authority)    Sender Token Account (ATA)
-                               GuDuFKeX...
-  ┌─────────────┐              ┌─────────────┐
-  │ Test USDC   │── 100 USDC ─►│ USDC: 100   │  Sender's USDC
-  │ Mint        │              └─────────────┘
-  └─────────────┘
 ```
+  🏛️ Deployer / Treasury               👤 Sender MPC Wallet
+  58gFSCTW...                           DQoGcVse...
+
+  Step 1: Send SOL for tx fees
+  ┌─────────────┐                       ┌─────────────┐
+  │ SOL: 5.0    │───── 1 SOL ─────────►│ SOL: 1.0    │
+  └─────────────┘                       └─────────────┘
+  (This creates the sender's system account on-chain!)
+
+
+  Step 2: Create sender's USDC token account (ATA)
+  ┌────────────────────────────────────────────────────────────────┐
+  │  spl-token create-account USDC_MINT --owner DQoGcVse...       │
+  │                                                                │
+  │  Derives ATA address: GuDuFKeX... = PDA([DQoGcVse, TOKEN, MINT])│
+  │  Creates a new SPL Token Account on-chain                      │
+  │  Owner: DQoGcVse... (the MPC wallet)                           │
+  │  Mint: USDC                                                    │
+  │  Balance: 0                                                    │
+  └────────────────────────────────────────────────────────────────┘
+
+
+  Step 3: Mint/transfer USDC to sender
+  🏭 USDC Mint                          Sender ATA (GuDuFKeX...)
+  ┌─────────────┐                       ┌─────────────┐
+  │ Mint Auth:  │──── 100 USDC ────────►│ USDC: 100   │
+  │ (deployer   │   (mint or transfer)  │ Owner: DQo..│
+  │  for test)  │                       │ Mint: USDC  │
+  └─────────────┘                       └─────────────┘
+
+  Mint authority can create tokens out of thin air (test only!)
+  In production: USDC comes from Circle via Stripe on-ramp
+```
+
+**After funding:**
+
+| Account | SOL | USDC | Notes |
+|---------|-----|------|-------|
+| 👤 Sender wallet `DQoGcVse...` | 1.0 | — | System account (holds SOL) |
+| 🪙 Sender ATA `GuDuFKeX...` | — | 100 | Token account (holds USDC) |
+| 🏛️ Deployer `58gFSCTW...` | 3.0 | — | Paid for program + funding |
 
 #### Act 3: 📤 Escrow Deposit ($25 USDC)
 

--- a/docs/specs/2026-04-16-stripe-onramp-grill-session.md
+++ b/docs/specs/2026-04-16-stripe-onramp-grill-session.md
@@ -1,0 +1,243 @@
+---
+title: Grill Session — Stripe On-Ramp Integration
+date: 2026-04-16
+participants: Puneethkumar CK, Claude
+outcome: 16 decisions resolved → spec approved
+---
+
+# Grill Session: Stripe On-Ramp Integration
+
+16 design decisions resolved through structured interrogation before writing the spec.
+
+---
+
+## Q1: What exactly are we building?
+
+**Context:** The reference `stablecoin-payments/fiat-on-ramp` is a separate microservice with its own domain (CollectionOrder, Refund, Reconciliation), Kafka events, and a full state machine. StablePay is a monolith with a hackathon deadline (May 11).
+
+**Options:**
+- A: Full fiat-on-ramp microservice (like stablebridge)
+- B: Minimal Stripe integration inside the StablePay monolith
+
+**Decision: B — Minimal inside the monolith.** No separate microservice, no Kafka, no reconciliation jobs. Just Stripe PaymentIntent + webhook + on-chain USDC transfer.
+
+---
+
+## Q2: Stripe payment method — Checkout Session or PaymentIntent?
+
+**Options:**
+
+| | Checkout Session | PaymentIntent |
+|---|---|---|
+| UI | Stripe-hosted redirect | Your own card form |
+| Effort | Low (backend only) | High (backend + mobile + web) |
+| Time | ~1 day | ~3-4 days |
+
+**Decision: PaymentIntent.** User wanted Stripe integration consistent with the stablebridge reference project. However, after seeing the effort comparison...
+
+---
+
+## Q3: Actually, keep as-is or integrate Stripe?
+
+User considered keeping the treasury stub. After discussion, decided to continue the grill to understand the full scope before committing.
+
+**Decision: Continue — understand the work, then decide.**
+
+---
+
+## Q4 (resumed): What's the funding flow?
+
+**Context:** User clarified the intent: "Stripe for fiat on sender side → convert to USDC → transfer."
+
+**Decision: Stripe collects fiat USD → backend converts to USDC from pre-funded treasury → SPL transfer to sender's ATA.**
+
+---
+
+## Q5: Checkout Session vs PaymentIntent (revisited with full context)?
+
+User asked for the difference explained simply:
+- **Checkout Session:** Stripe builds the payment UI. You redirect. Zero frontend work.
+- **PaymentIntent:** You build the payment UI. Card form in your app. Full control.
+
+**Decision: Considered too much frontend work for hackathon. But then...**
+
+---
+
+## Q6: Keep as-is or proceed?
+
+After seeing both options require frontend work for the card form, user initially said "keep as is." Then asked to continue the grill to understand the full Checkout Session approach.
+
+**Decision: Continue grilling — Stripe Checkout Session path.**
+
+---
+
+## Q7: How does the stablebridge reference project do it?
+
+**Finding:** The stablebridge `fiat-on-ramp` uses **raw HTTP calls** (not Stripe SDK) to create PaymentIntents. No card UI — it's API-to-API. The `CollectionController` accepts bank account details in the request, creates a PaymentIntent, and the webhook confirms it.
+
+**Key insight:** No card form anywhere. The payment is initiated server-side with `payment_method_types: ["us_bank_account"]`.
+
+---
+
+## Q8: SDK or raw HTTP for Stripe?
+
+**Options:**
+
+| | Raw HTTP (like stablebridge) | Stripe Java SDK |
+|---|---|---|
+| Dependency | None | `com.stripe:stripe-java:28.x` |
+| Webhook verify | Manual HMAC | `client.constructEvent()` |
+| Type safety | Manual JSON parsing | Typed objects |
+
+**Decision: Stripe Java SDK.** Less code, type-safe, recognizable to judges.
+
+---
+
+## Q9: What triggers USDC transfer after Stripe succeeds?
+
+**Options:**
+- A: Webhook handler calls TreasuryServiceAdapter directly
+- B: Webhook starts a Temporal workflow
+
+**Decision: B — Temporal workflow.** Automatic retries, handles long-running Solana transfers, crash-resilient.
+
+---
+
+## Q10: New Temporal workflow or extend existing?
+
+**Options:**
+- A: New `WalletFundingWorkflow`
+- B: Add activity to existing `RemittanceLifecycleWorkflow`
+
+**Decision: A — New workflow.** Funding and remittance are independent lifecycles. Own task queue, own retry config, failure isolation.
+
+---
+
+## Q11: Treasury wallet — separate keypair or reuse claim authority?
+
+**Options:**
+
+| | Separate treasury keypair | Reuse claim authority |
+|---|---|---|
+| Security | Compromise one ≠ compromise other | One key = everything |
+| Accounting | Clear separation of roles | Muddied |
+| Production | Different access policies | Not acceptable |
+
+**Decision: Separate treasury keypair.** New `TREASURY_PRIVATE_KEY` env var. Clear accounting: treasury funds users, claim authority releases escrow.
+
+---
+
+## Q12: FundingOrder — new DB table or just update wallet?
+
+**Options:**
+- A: New `funding_orders` table with state machine
+- B: Just increment wallet balance directly
+
+**Decision: A — New FundingOrder.** Provides idempotency (no double-funding on webhook retry), audit trail, and refund tracking. Lightweight state machine: PENDING → PAYMENT_CONFIRMED → FUNDED → REFUND_INITIATED → REFUNDED.
+
+---
+
+## Q13: Replace existing fund endpoint or add new one?
+
+**Options:**
+- A: Replace `POST /api/wallets/{id}/fund` — returns FundingOrder instead of Wallet
+- B: New endpoint, keep existing as demo shortcut
+
+**Decision: A — Replace existing.** Response changes to `FundingOrderResponse` with Stripe PaymentIntent details.
+
+---
+
+## Q14: How to make the demo seamless in Stripe test mode?
+
+**Approach:** In test mode, PaymentIntent is created with `confirm: true` and test payment method `pm_card_visa`. Succeeds instantly, webhook fires within seconds. No card UI needed.
+
+**Decision: Configure via properties** (`stripe.test-mode`, `stripe.auto-confirm`, `stripe.test-payment-method`). Not hardcoded — configurable for production vs demo.
+
+---
+
+## Q15: How does Stripe reach local Docker stack for webhooks?
+
+**Options:**
+- A: Stripe CLI (`stripe listen --forward-to localhost:8080/webhooks/stripe`)
+- B: ngrok tunnel
+- C: Poll instead of webhook
+
+**Decision: A — Stripe CLI.** Official tool, stable webhook secret, real-time event logs. Added as Makefile target.
+
+---
+
+## Q16: Who pays for sender's first SOL transaction fee?
+
+**Options:**
+- A: Fund SOL in the WalletFundingWorkflow (automatic)
+- B: Keep SOL funding separate/manual
+
+**Decision: A — Workflow handles SOL.** Activity `ensureSolBalance` checks sender's SOL balance, tops up from treasury if < 0.005 SOL. Also creates ATA if needed. Demo is fully self-contained — one API call funds everything.
+
+---
+
+## Q17: Where does funding live in hexagonal architecture?
+
+**Options:**
+- A: New `domain/funding/` subdomain
+- B: Inside existing `domain/wallet/`
+
+**Decision: A — New subdomain.** FundingOrder has its own lifecycle, own port (`PaymentGateway`), and is a separate bounded context from wallet CRUD. Matches stablebridge pattern.
+
+---
+
+## Q18: PaymentGateway port — minimal or include refunds?
+
+**Options:**
+- A: Minimal — just `initiatePayment`
+- B: Include `refund` method
+
+**Decision: B — Include refunds.** Full flow: FUNDED → REFUND_INITIATED → REFUNDED. Explicit refund endpoint `POST /api/funding-orders/{fundingId}/refund`.
+
+---
+
+## Q19: When does refund happen?
+
+**Options:**
+- A: Automatic on remittance refund (cross-domain coupling)
+- B: Explicit refund endpoint (sender requests it)
+
+**Decision: B — Explicit.** Sender calls refund when they want fiat back. No coupling between funding and remittance lifecycles.
+
+---
+
+## Q20: Final scope confirmation
+
+All 16 decisions confirmed. Scope summary:
+
+- **26 new files, 7 modified**
+- **New domain:** `funding/` with FundingOrder, 3 handlers, 2 ports
+- **Stripe:** Java SDK, PaymentIntent, webhook with signature verification
+- **Temporal:** `WalletFundingWorkflow` with 5 activities
+- **Treasury:** Real SPL + SOL transfers replacing the stub
+- **State machine:** PENDING → PAYMENT_CONFIRMED → FUNDED (+ FAILED, REFUND path)
+- **Config:** All Stripe params via properties, test mode auto-confirm
+- **Refund:** Explicit endpoint, USDC return + Stripe refund
+
+**Outcome:** Spec written at `docs/specs/2026-04-16-stripe-onramp-spec.md`
+
+---
+
+## Decision Summary Table
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| 1 | Microservice or monolith? | Monolith | Hackathon deadline |
+| 2 | Checkout or PaymentIntent? | PaymentIntent | API-to-API like stablebridge |
+| 3 | SDK or raw HTTP? | Stripe Java SDK | Type-safe, less code |
+| 4 | Webhook trigger | Temporal workflow | Retries, crash-resilient |
+| 5 | New or existing workflow? | New WalletFundingWorkflow | Separate lifecycle |
+| 6 | Treasury keypair | Separate from claim authority | Security, clear accounting |
+| 7 | FundingOrder table? | Yes — with state machine | Idempotency, audit, refund |
+| 8 | New or existing endpoint? | Replace existing | Cleaner API |
+| 9 | Test mode approach | Auto-confirm via properties | Seamless demo |
+| 10 | Webhook delivery | Stripe CLI | Official, reliable |
+| 11 | SOL funding | Automatic in workflow | Self-contained demo |
+| 12 | Domain placement | New funding subdomain | Bounded context |
+| 13 | PaymentGateway scope | Include refunds | Full lifecycle |
+| 14 | Refund trigger | Explicit endpoint | No cross-domain coupling |

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -1,0 +1,488 @@
+---
+title: Stripe On-Ramp Integration for Wallet Funding
+status: approved
+created: 2026-04-16
+issue: STA-72
+---
+
+# Stripe On-Ramp Integration — Spec
+
+## 1. Objective
+
+Replace the treasury stub with a real fiat-to-USDC funding flow:
+
+1. Sender calls `POST /api/wallets/{id}/fund` with a USD amount
+2. Backend creates a Stripe PaymentIntent (auto-confirmed in test mode via configurable props)
+3. Stripe webhook `payment_intent.succeeded` triggers a Temporal `WalletFundingWorkflow`
+4. Workflow ensures the sender's MPC wallet has SOL for fees, creates an ATA if needed, and transfers USDC from the treasury wallet on-chain
+5. Wallet balance is updated in PostgreSQL
+
+This closes the gap where funding is currently a DB-only operation with no Stripe payment and no on-chain USDC transfer.
+
+## 2. User Stories
+
+### US-1: Fund wallet via Stripe
+**As a** sender,
+**I want to** fund my wallet with USD via the API,
+**So that** I receive USDC in my MPC wallet and can send remittances.
+
+**Acceptance criteria:**
+- `POST /api/wallets/{id}/fund {"amount": 25.00}` creates a Stripe PaymentIntent and returns a `FundingOrderResponse` with status `PENDING`
+- In test mode (configurable), PaymentIntent auto-confirms with test payment method
+- Stripe webhook `payment_intent.succeeded` starts `WalletFundingWorkflow`
+- Workflow transfers USDC from treasury ATA to sender ATA on Solana devnet
+- Wallet `available_balance` and `total_balance` updated in DB
+- FundingOrder transitions: PENDING → PAYMENT_CONFIRMED → FUNDED
+- Subsequent `GET /api/wallets/{id}` shows updated balance
+
+### US-2: Refund funding order
+**As a** sender,
+**I want to** refund a funding order,
+**So that** my USDC is returned to the treasury and my fiat is refunded via Stripe.
+
+**Acceptance criteria:**
+- `POST /api/funding-orders/{fundingId}/refund` initiates a refund
+- USDC transferred from sender ATA back to treasury ATA on-chain
+- Stripe refund API called for the original PaymentIntent
+- FundingOrder transitions: FUNDED → REFUND_INITIATED → REFUNDED
+- Wallet `available_balance` and `total_balance` decremented
+
+### US-3: Webhook idempotency
+**As the** system,
+**I want** duplicate webhooks to be safely ignored,
+**So that** a retry from Stripe doesn't double-fund a wallet.
+
+**Acceptance criteria:**
+- If FundingOrder is already `FUNDED`, webhook returns 200 without re-processing
+- FundingOrder status acts as the idempotency guard
+
+### US-4: SOL and ATA provisioning
+**As the** system,
+**I want** the funding workflow to ensure the sender has SOL and a USDC ATA,
+**So that** the sender can transact immediately after funding without manual setup.
+
+**Acceptance criteria:**
+- If sender SOL balance < 0.005, transfer 0.01 SOL from treasury
+- If sender USDC ATA does not exist, create it (treasury pays rent)
+- Both checks happen before the USDC transfer
+
+## 3. Architecture
+
+### 3.1 Domain Model
+
+```
+domain/funding/
+├── model/
+│   ├── FundingOrder.java          # Immutable record with @Builder
+│   └── FundingStatus.java         # Enum: PENDING, PAYMENT_CONFIRMED, FUNDED, FAILED,
+│                                  #        REFUND_INITIATED, REFUNDED
+├── handler/
+│   ├── InitiateFundingHandler.java    # Creates FundingOrder + Stripe PaymentIntent
+│   ├── CompleteFundingHandler.java    # Called by webhook → starts Temporal workflow
+│   └── RefundFundingHandler.java      # Refund USDC + Stripe refund
+├── port/
+│   ├── PaymentGateway.java            # Abstracts Stripe (initiatePayment, refund)
+│   └── FundingOrderRepository.java    # CRUD for FundingOrder
+└── exception/
+    ├── FundingOrderNotFoundException.java
+    └── FundingFailedException.java
+```
+
+### 3.2 Infrastructure
+
+```
+infrastructure/stripe/
+├── StripePaymentAdapter.java      # Implements PaymentGateway via Stripe Java SDK
+├── StripeProperties.java          # apiKey, webhookSecret, testMode, autoConfirm,
+│                                  # testPaymentMethod — all configurable via props
+└── StripeConfig.java              # @Configuration: StripeClient bean
+
+infrastructure/temporal/
+├── WalletFundingWorkflow.java         # Workflow interface
+├── WalletFundingWorkflowImpl.java     # Orchestrates 5 activities
+├── WalletFundingActivities.java       # Activity interface
+└── WalletFundingActivitiesImpl.java   # Activity implementations
+
+infrastructure/db/funding/
+├── FundingOrderEntity.java
+├── FundingOrderEntityMapper.java      # MapStruct
+├── FundingOrderJpaRepository.java
+└── FundingOrderRepositoryAdapter.java
+
+infrastructure/solana/
+└── TreasuryServiceAdapter.java        # REPLACE stub with real:
+    ├── transferUsdc()                 #   SPL Transfer: treasury ATA → sender ATA
+    ├── transferSol()                  #   SOL Transfer: treasury → sender
+    ├── getUsdcBalance()               #   Query on-chain token balance
+    ├── getSolBalance()                #   Query on-chain SOL balance
+    └── createAtaIfNeeded()            #   Create ATA with CreateAssociatedTokenAccountInstruction
+```
+
+### 3.3 Application Layer
+
+```
+application/controller/webhook/
+└── StripeWebhookController.java       # POST /webhooks/stripe
+                                       # Raw body + Stripe-Signature header
+                                       # Verifies signature, parses event, calls handler
+
+application/controller/funding/
+���── FundingController.java             # POST /api/wallets/{id}/fund (modified)
+│                                      # POST /api/funding-orders/{fundingId}/refund
+└── mapper/
+    └── FundingApiMapper.java          # MapStruct: domain → response DTO
+
+application/dto/
+├── FundingOrderResponse.java          # fundingId, walletId, amountUsdc, status,
+│                                      # stripePaymentIntentId, stripeClientSecret
+└── FundWalletRequest.java             # amount (existing, reused)
+```
+
+### 3.4 State Machine
+
+```
+PENDING ──────────────────► PAYMENT_CONFIRMED ──────► FUNDED
+   │                              │                      │
+   └──► FAILED                    └──► FAILED            ���──► REFUND_INITIATED ──► REFUNDED
+```
+
+| From | Trigger | To |
+|---|---|---|
+| PENDING | Stripe PaymentIntent created successfully | PAYMENT_CONFIRMED |
+| PENDING | Stripe PaymentIntent creation failed | FAILED |
+| PAYMENT_CONFIRMED | Webhook `payment_intent.succeeded` + USDC transferred | FUNDED |
+| PAYMENT_CONFIRMED | Webhook `payment_intent.payment_failed` or USDC transfer failed | FAILED |
+| FUNDED | Refund requested | REFUND_INITIATED |
+| REFUND_INITIATED | USDC returned + Stripe refund completed | REFUNDED |
+
+## 4. API Contracts
+
+### 4.1 Fund Wallet (Modified)
+
+```
+POST /api/wallets/{id}/fund
+Content-Type: application/json
+
+{"amount": 25.00}
+```
+
+**Response 201:**
+```json
+{
+    "fundingId": "a1b2c3d4-uuid",
+    "walletId": 4,
+    "amountUsdc": 25.00,
+    "status": "PENDING",
+    "stripePaymentIntentId": "pi_3Mn...",
+    "stripeClientSecret": "pi_3Mn..._secret_...",
+    "createdAt": "2026-04-16T15:00:00Z"
+}
+```
+
+### 4.2 Refund Funding Order
+
+```
+POST /api/funding-orders/{fundingId}/refund
+```
+
+**Response 200:**
+```json
+{
+    "fundingId": "a1b2c3d4-uuid",
+    "walletId": 4,
+    "amountUsdc": 25.00,
+    "status": "REFUND_INITIATED",
+    "stripePaymentIntentId": "pi_3Mn...",
+    "createdAt": "2026-04-16T15:00:00Z"
+}
+```
+
+### 4.3 Stripe Webhook
+
+```
+POST /webhooks/stripe
+Stripe-Signature: t=...,v1=...
+Content-Type: application/json
+
+{raw Stripe event body}
+```
+
+**Response:** 200 (always, to prevent Stripe retries on processing errors)
+
+## 5. Temporal Workflows
+
+### 5.1 WalletFundingWorkflow
+
+**Task queue:** `stablepay-wallet-funding`
+
+```
+WalletFundingWorkflow.execute(WalletFundingRequest)
+    │
+    ├─ Activity 1: ensureSolBalance          (30s timeout, 3 retries)
+    │   ├─ Query sender SOL balance via RPC
+    │   └─ If < 0.005 SOL → transfer 0.01 SOL from treasury
+    │
+    ├─ Activity 2: createAtaIfNeeded         (30s timeout, 3 retries)
+    │   ├─ Check if sender USDC ATA exists via getAccountInfo
+    │   └─ If not → CreateAssociatedTokenAccountInstruction (treasury pays)
+    │
+    ├─ Activity 3: transferUsdc              (60s timeout, 3 retries)
+    │   ├─ Build SPL Transfer instruction
+    │   ├─ Sign with treasury keypair
+    │   └─ Submit to Solana RPC
+    │
+    ├�� Activity 4: updateWalletBalance       (10s timeout, 3 retries)
+    │   └─ DB: available_balance += amount, total_balance += amount
+    │
+    └─ Activity 5: updateFundingOrderStatus  (10s timeout, 3 retries)
+        └─ PAYMENT_CONFIRMED → FUNDED
+```
+
+**Input:**
+```java
+@Builder(toBuilder = true)
+public record WalletFundingRequest(
+    UUID fundingId,
+    Long walletId,
+    String senderSolanaAddress,
+    BigDecimal amountUsdc
+) {}
+```
+
+## 6. Database Migration
+
+### V5__create_funding_orders.sql
+
+```sql
+CREATE TABLE funding_orders (
+    id                         BIGSERIAL PRIMARY KEY,
+    funding_id                 UUID UNIQUE NOT NULL,
+    wallet_id                  BIGINT NOT NULL REFERENCES wallets(id),
+    amount_usdc                NUMERIC(19, 6) NOT NULL,
+    stripe_payment_intent_id   VARCHAR(255),
+    stripe_client_secret       VARCHAR(255),
+    status                     VARCHAR(50) NOT NULL,
+    created_at                 TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at                 TIMESTAMP
+);
+
+CREATE INDEX idx_funding_orders_wallet_id ON funding_orders(wallet_id);
+CREATE INDEX idx_funding_orders_stripe_pi ON funding_orders(stripe_payment_intent_id);
+CREATE INDEX idx_funding_orders_status ON funding_orders(status);
+```
+
+## 7. Configuration
+
+### application.yml (new properties)
+
+```yaml
+stablepay:
+  stripe:
+    api-key: ${STRIPE_API_KEY:}
+    webhook-secret: ${STRIPE_WEBHOOK_SECRET:}
+    test-mode: ${STRIPE_TEST_MODE:true}
+    auto-confirm: ${STRIPE_AUTO_CONFIRM:true}
+    test-payment-method: ${STRIPE_TEST_PAYMENT_METHOD:pm_card_visa}
+    currency: ${STRIPE_CURRENCY:usd}
+  treasury:
+    private-key: ${TREASURY_PRIVATE_KEY:}
+```
+
+### .env.example additions
+
+```
+STRIPE_API_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+TREASURY_PRIVATE_KEY=<base58 secret key>
+```
+
+### docker-compose.yml additions
+
+```yaml
+STRIPE_API_KEY: ${STRIPE_API_KEY}
+STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+TREASURY_PRIVATE_KEY: ${TREASURY_PRIVATE_KEY}
+```
+
+### build.gradle.kts addition
+
+```kotlin
+implementation("com.stripe:stripe-java:28.2.0")
+```
+
+## 8. Environment Setup (Devnet)
+
+```bash
+# 1. Generate treasury keypair
+solana-keygen new -o treasury-keypair.json
+
+# 2. Fund treasury with SOL (for tx fees + user SOL top-ups)
+solana airdrop 5 <treasury-address> --url devnet
+
+# 3. Create treasury USDC ATA and mint test tokens
+spl-token create-account <USDC_MINT> --owner <treasury-address> --url devnet
+spl-token mint <USDC_MINT> 10000 --recipient-owner <treasury-address> --url devnet
+
+# 4. Export treasury private key as base58
+# Add to .env as TREASURY_PRIVATE_KEY=<base58>
+
+# 5. Start Stripe CLI for webhook forwarding
+stripe listen --forward-to localhost:8080/webhooks/stripe
+# Copy whsec_... to .env as STRIPE_WEBHOOK_SECRET
+```
+
+## 9. Sequence Diagram
+
+```
+Sender              API              Stripe           Webhook          Temporal          Solana
+  │                  │                 │                 │                │                │
+  │ POST /fund       │                 │                 │                │                │
+  │ {amount: 25}     │                 │                 │                │                │
+  │─────────────────►��                 │                 │                │                │
+  │                  │ PaymentIntent    │                 │                │                │
+  │                  │ create(2500,usd) │                 │                │                │
+  │                  │────────────────►│                 │                │                │
+  │                  │   pi_... + secret│                 │                │                │
+  │                  │◄────────────────│                 │                │                │
+  │                  │                 │                 │                │                │
+  │                  │ Save FundingOrder│                 │                │                │
+  │                  │ (PENDING)        │                 │                │                │
+  │  201 {fundingId, │                 │                 │                │                │
+  │   status:PENDING}│                 │                 │                │                │
+  │◄─────────────────│                 │                 │                │                │
+  │                  │                 │                 │                │                │
+  │                  │                 │  pi.succeeded    │                │                │
+  │                  │                 │────────────────►│                │                │
+  │                  │                 │                 │ Verify sig     │                │
+  │                  │                 │                 │ Parse event    │                │
+  │                  │                 │                 │ Update:CONFIRMED                │
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │ Start workflow │                │
+  │                  │                 │                 │───────────────►│                │
+  │                  │                 │                 │                │                │
+  │                  │                 │    200 OK       │                │                │
+  │                  │                 │◄────────────────│                │                │
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  ensureSol     │                │
+  │                  │                 │                 │                │ check balance  │
+  │                  │                 │                 │                │───────────────►│
+  │                  │                 │                 │                │  transfer SOL  │
+  │                  │                 │                 │                │─────────���─────►│
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  createATA     │                │
+  │                  │                 ��                 │                │ getAccountInfo │
+  │                  │                 │                 ���                │─��─────────────►│
+  │                  │                 │                 │                │ createATA tx   │
+  │                  │                 │                 │                │───────────────►│
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  transferUSDC  │                ��
+  │                  │                 │                 │                │ SPL Transfer   │
+  │                  │                 │                 │                │───────────────►│
+  │                  │                 │                 │                │   finalized    │
+  │                  │                 │                 │                │◄───────────────│
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  updateBalance │                │
+  │                  │                 │                 │  DB: +25 USDC  │                │
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  status: FUNDED│                │
+  │                  │                 │                 │                │                │
+```
+
+## 10. Error Handling
+
+| Error Code | HTTP | Exception | Description |
+|---|---|---|---|
+| SP-0020 | 404 | FundingOrderNotFoundException | Funding order not found |
+| SP-0021 | 502 | FundingFailedException | Stripe PaymentIntent creation failed |
+| SP-0022 | 409 | FundingAlreadyCompletedException | Attempting to re-fund an already funded order |
+| SP-0023 | 409 | RefundNotAllowedException | Refund on non-FUNDED order |
+| SP-0024 | 502 | RefundFailedException | Stripe refund API or on-chain USDC return failed |
+
+## 11. Testing Strategy
+
+### Unit Tests
+- `InitiateFundingHandlerTest` — creates FundingOrder, calls PaymentGateway, returns response
+- `CompleteFundingHandlerTest` — transitions PAYMENT_CONFIRMED, starts Temporal workflow
+- `RefundFundingHandlerTest` — transitions FUNDED → REFUND_INITIATED, calls PaymentGateway.refund
+- `StripePaymentAdapterTest` — mocks StripeClient, verifies PaymentIntent params
+- `WalletFundingActivitiesImplTest` — mocks TreasuryService, verifies on-chain calls
+- `StripeWebhookControllerTest` — signature validation, event parsing, handler invocation
+
+### Integration Tests
+- `WalletFundingWorkflowIntegrationTest` — Temporal TestWorkflowEnvironment, mocked activities
+- `FundingOrderRepositoryIntegrationTest` — TestContainers PostgreSQL
+
+### E2E Test (Devnet)
+- Full flow: fund API → Stripe test PaymentIntent → webhook → Temporal → on-chain USDC transfer → balance update
+
+## 12. Files to Create/Modify
+
+### New Files (19)
+| Layer | File |
+|---|---|
+| Domain | `domain/funding/model/FundingOrder.java` |
+| Domain | `domain/funding/model/FundingStatus.java` |
+| Domain | `domain/funding/model/PaymentRequest.java` |
+| Domain | `domain/funding/model/PaymentResult.java` |
+| Domain | `domain/funding/handler/InitiateFundingHandler.java` |
+| Domain | `domain/funding/handler/CompleteFundingHandler.java` |
+| Domain | `domain/funding/handler/RefundFundingHandler.java` |
+| Domain | `domain/funding/port/PaymentGateway.java` |
+| Domain | `domain/funding/port/FundingOrderRepository.java` |
+| Domain | `domain/funding/exception/FundingOrderNotFoundException.java` |
+| Domain | `domain/funding/exception/FundingFailedException.java` |
+| Infra | `infrastructure/stripe/StripePaymentAdapter.java` |
+| Infra | `infrastructure/stripe/StripeProperties.java` |
+| Infra | `infrastructure/stripe/StripeConfig.java` |
+| Infra | `infrastructure/temporal/WalletFundingWorkflow.java` |
+| Infra | `infrastructure/temporal/WalletFundingWorkflowImpl.java` |
+| Infra | `infrastructure/temporal/WalletFundingActivities.java` |
+| Infra | `infrastructure/temporal/WalletFundingActivitiesImpl.java` |
+| Infra | `infrastructure/db/funding/FundingOrderEntity.java` |
+| Infra | `infrastructure/db/funding/FundingOrderEntityMapper.java` |
+| Infra | `infrastructure/db/funding/FundingOrderJpaRepository.java` |
+| Infra | `infrastructure/db/funding/FundingOrderRepositoryAdapter.java` |
+| App | `application/controller/webhook/StripeWebhookController.java` |
+| App | `application/controller/funding/FundingController.java` |
+| App | `application/controller/funding/mapper/FundingApiMapper.java` |
+| App | `application/dto/FundingOrderResponse.java` |
+| DB | `db/migration/V5__create_funding_orders.sql` |
+
+### Modified Files (7)
+| File | Change |
+|---|---|
+| `application/controller/wallet/WalletController.java` | Remove `fundWallet` — moved to `FundingController` |
+| `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers |
+| `domain/wallet/port/TreasuryService.java` | Add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded` |
+| `infrastructure/temporal/TaskQueue.java` | Add `WALLET_FUNDING` task queue |
+| `infrastructure/temporal/TemporalConfig.java` | Register new worker + workflow + activities |
+| `build.gradle.kts` | Add `com.stripe:stripe-java:28.2.0` |
+| `application.yml` | Add `stablepay.stripe.*` and `stablepay.treasury.*` properties |
+
+## 13. Implementation Order
+
+| # | Task | Dependencies | Est. Size |
+|---|---|---|---|
+| 1 | Domain models: FundingOrder, FundingStatus, PaymentRequest, PaymentResult | None | S |
+| 2 | Domain ports: PaymentGateway, FundingOrderRepository | Task 1 | S |
+| 3 | Domain exceptions: FundingOrderNotFoundException, FundingFailedException | None | S |
+| 4 | DB migration V5 + FundingOrderEntity + JpaRepo + Mapper + Adapter | Task 1, 2 | M |
+| 5 | StripeProperties + StripeConfig + StripePaymentAdapter | Task 2 | M |
+| 6 | InitiateFundingHandler + FundingController + FundingOrderResponse | Task 2, 4, 5 | M |
+| 7 | StripeWebhookController + CompleteFundingHandler | Task 4, 5, 6 | M |
+| 8 | TreasuryServiceAdapter: real SPL + SOL transfers | None (can parallel) | L |
+| 9 | WalletFundingWorkflow + Activities (5 activities) | Task 7, 8 | L |
+| 10 | RefundFundingHandler + refund endpoint | Task 5, 6, 8 | M |
+| 11 | Tests: unit + integration + E2E devnet | Task 1-10 | L |
+| 12 | Config: .env.example, docker-compose, Makefile stripe-listen | Task 5, 7 | S |
+
+## 14. Out of Scope
+
+- Stripe Customer objects (no persistent customer-to-Stripe mapping)
+- Saved payment methods / recurring payments
+- KYC/AML verification
+- Reconciliation jobs (production concern)
+- Kafka event publishing (no Kafka in StablePay)
+- Partial refunds (full refund only)
+- Multiple currency support (USD only)
+- Rate limiting on fund endpoint

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -2,7 +2,9 @@
 title: Stripe On-Ramp Integration for Wallet Funding
 status: approved
 created: 2026-04-16
+updated: 2026-04-16
 issue: STA-72
+revision: 2 (edge case fixes from spec review)
 ---
 
 # Stripe On-Ramp Integration — Spec
@@ -27,13 +29,16 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 **So that** I receive USDC in my MPC wallet and can send remittances.
 
 **Acceptance criteria:**
-- `POST /api/wallets/{id}/fund {"amount": 25.00}` creates a Stripe PaymentIntent and returns a `FundingOrderResponse` with status `PENDING`
+- `POST /api/wallets/{id}/fund {"amount": 25.00}` creates a Stripe PaymentIntent and returns a `FundingOrderResponse`
+- If PaymentIntent creation succeeds: FundingOrder saved as `PAYMENT_CONFIRMED`, response status `PAYMENT_CONFIRMED`
+- If PaymentIntent creation fails: FundingOrder saved as `FAILED`, error SP-0021 returned
 - In test mode (configurable), PaymentIntent auto-confirms with test payment method
 - Stripe webhook `payment_intent.succeeded` starts `WalletFundingWorkflow`
 - Workflow transfers USDC from treasury ATA to sender ATA on Solana devnet
 - Wallet `available_balance` and `total_balance` updated in DB
-- FundingOrder transitions: PENDING → PAYMENT_CONFIRMED → FUNDED
-- Subsequent `GET /api/wallets/{id}` shows updated balance
+- FundingOrder transitions: PAYMENT_CONFIRMED → FUNDED
+- Subsequent `GET /api/funding-orders/{fundingId}` shows current status
+- Amount must be between 1.00 and 10,000.00 USDC with max 6 decimal places
 
 ### US-2: Refund funding order
 **As a** sender,
@@ -42,19 +47,27 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 
 **Acceptance criteria:**
 - `POST /api/funding-orders/{fundingId}/refund` initiates a refund
+- Validates sender has sufficient USDC: checks both on-chain ATA balance and DB `available_balance`
+- If insufficient USDC (already spent on remittances): rejects with SP-0025 `InsufficientBalanceForRefundException`
 - USDC transferred from sender ATA back to treasury ATA on-chain
 - Stripe refund API called for the original PaymentIntent
 - FundingOrder transitions: FUNDED → REFUND_INITIATED → REFUNDED
+- If on-chain USDC return or Stripe refund fails: REFUND_INITIATED → REFUND_FAILED
 - Wallet `available_balance` and `total_balance` decremented
 
-### US-3: Webhook idempotency
+### US-3: Webhook idempotency and failure handling
 **As the** system,
-**I want** duplicate webhooks to be safely ignored,
-**So that** a retry from Stripe doesn't double-fund a wallet.
+**I want** duplicate webhooks to be safely ignored and payment failures to be recorded,
+**So that** a retry from Stripe doesn't double-fund a wallet and failed payments are tracked.
 
 **Acceptance criteria:**
 - If FundingOrder is already `FUNDED`, webhook returns 200 without re-processing
+- If FundingOrder is already `FAILED`, webhook returns 200 without re-processing
 - FundingOrder status acts as the idempotency guard
+- `payment_intent.succeeded`: transitions PAYMENT_CONFIRMED → starts workflow → eventually FUNDED
+- `payment_intent.payment_failed`: transitions PAYMENT_CONFIRMED → FAILED, no workflow started
+- Unknown event types: logged and ignored, return 200 (prevent Stripe retries)
+- Webhook always returns 200 — errors logged internally, never surfaced to Stripe
 
 ### US-4: SOL and ATA provisioning
 **As the** system,
@@ -66,6 +79,15 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 - If sender USDC ATA does not exist, create it (treasury pays rent)
 - Both checks happen before the USDC transfer
 
+### US-5: Query funding order status
+**As a** sender,
+**I want to** check the status of my funding order,
+**So that** I know when USDC is available in my wallet.
+
+**Acceptance criteria:**
+- `GET /api/funding-orders/{fundingId}` returns current FundingOrder status
+- Returns 404 (SP-0020) if not found
+
 ## 3. Architecture
 
 ### 3.1 Domain Model
@@ -74,18 +96,24 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 domain/funding/
 ├── model/
 │   ├── FundingOrder.java          # Immutable record with @Builder
-│   └── FundingStatus.java         # Enum: PENDING, PAYMENT_CONFIRMED, FUNDED, FAILED,
-│                                  #        REFUND_INITIATED, REFUNDED
+│   └── FundingStatus.java         # Enum: PAYMENT_CONFIRMED, FUNDED, FAILED,
+│                                  #        REFUND_INITIATED, REFUNDED, REFUND_FAILED
 ├── handler/
 │   ├── InitiateFundingHandler.java    # Creates FundingOrder + Stripe PaymentIntent
 │   ├── CompleteFundingHandler.java    # Called by webhook → starts Temporal workflow
+│   ├── FailFundingHandler.java        # Called by webhook on payment_failed
+│   ├── GetFundingOrderHandler.java    # Query funding order by ID
 │   └── RefundFundingHandler.java      # Refund USDC + Stripe refund
 ├── port/
 │   ├── PaymentGateway.java            # Abstracts Stripe (initiatePayment, refund)
-│   └── FundingOrderRepository.java    # CRUD for FundingOrder
+│   ├── FundingOrderRepository.java    # CRUD for FundingOrder
+│   └── FundingWorkflowStarter.java    # Starts WalletFundingWorkflow (abstracts Temporal)
 └── exception/
     ├── FundingOrderNotFoundException.java
-    └── FundingFailedException.java
+    ├── FundingFailedException.java
+    ├── FundingAlreadyCompletedException.java
+    ├── RefundNotAllowedException.java
+    └── InsufficientBalanceForRefundException.java
 ```
 
 ### 3.2 Infrastructure
@@ -99,9 +127,10 @@ infrastructure/stripe/
 
 infrastructure/temporal/
 ├── WalletFundingWorkflow.java         # Workflow interface
-├── WalletFundingWorkflowImpl.java     # Orchestrates 5 activities
+├── WalletFundingWorkflowImpl.java     # Orchestrates 6 activities
 ├── WalletFundingActivities.java       # Activity interface
-└── WalletFundingActivitiesImpl.java   # Activity implementations
+├── WalletFundingActivitiesImpl.java   # Activity implementations
+└── TemporalFundingWorkflowStarter.java # Implements FundingWorkflowStarter
 
 infrastructure/db/funding/
 ├── FundingOrderEntity.java
@@ -127,7 +156,8 @@ application/controller/webhook/
                                        # Verifies signature, parses event, calls handler
 
 application/controller/funding/
-���── FundingController.java             # POST /api/wallets/{id}/fund (modified)
+├── FundingController.java             # POST /api/wallets/{id}/fund
+│                                      # GET /api/funding-orders/{fundingId}
 │                                      # POST /api/funding-orders/{fundingId}/refund
 └── mapper/
     └── FundingApiMapper.java          # MapStruct: domain → response DTO
@@ -135,29 +165,39 @@ application/controller/funding/
 application/dto/
 ├── FundingOrderResponse.java          # fundingId, walletId, amountUsdc, status,
 │                                      # stripePaymentIntentId, stripeClientSecret
-└── FundWalletRequest.java             # amount (existing, reused)
+└── FundWalletRequest.java             # amount (existing — add min/max/scale validation)
 ```
 
 ### 3.4 State Machine
 
 ```
-PENDING ──────────────────► PAYMENT_CONFIRMED ──────► FUNDED
-   │                              │                      │
-   └──► FAILED                    └──► FAILED            ���──► REFUND_INITIATED ──► REFUNDED
+                              PAYMENT_CONFIRMED ──────────────► FUNDED
+                                │                                 │
+                                └──► FAILED                       ├──► REFUND_INITIATED ──► REFUNDED
+                                                                  │              │
+                                                                  │              └──► REFUND_FAILED
+                                                                  │
+                              (InitiateFundingHandler sets        │
+                               PAYMENT_CONFIRMED on success,     │
+                               FAILED on Stripe API error)       │
 ```
 
 | From | Trigger | To |
 |---|---|---|
-| PENDING | Stripe PaymentIntent created successfully | PAYMENT_CONFIRMED |
-| PENDING | Stripe PaymentIntent creation failed | FAILED |
-| PAYMENT_CONFIRMED | Webhook `payment_intent.succeeded` + USDC transferred | FUNDED |
-| PAYMENT_CONFIRMED | Webhook `payment_intent.payment_failed` or USDC transfer failed | FAILED |
+| — | Stripe PaymentIntent created successfully | PAYMENT_CONFIRMED |
+| — | Stripe PaymentIntent creation failed | FAILED |
+| PAYMENT_CONFIRMED | Webhook `payment_intent.succeeded` + workflow completes | FUNDED |
+| PAYMENT_CONFIRMED | Webhook `payment_intent.payment_failed` | FAILED |
+| PAYMENT_CONFIRMED | Workflow fails (on-chain transfer failed after retries) | FAILED |
 | FUNDED | Refund requested | REFUND_INITIATED |
 | REFUND_INITIATED | USDC returned + Stripe refund completed | REFUNDED |
+| REFUND_INITIATED | USDC return or Stripe refund failed | REFUND_FAILED |
+
+**Note:** There is no `PENDING` state. `InitiateFundingHandler` creates the Stripe PaymentIntent and saves the FundingOrder atomically — if Stripe succeeds, status is `PAYMENT_CONFIRMED`; if Stripe fails, status is `FAILED`. This eliminates the gap where a webhook arrives for a `PENDING` order that hasn't been confirmed yet.
 
 ## 4. API Contracts
 
-### 4.1 Fund Wallet (Modified)
+### 4.1 Fund Wallet
 
 ```
 POST /api/wallets/{id}/fund
@@ -166,20 +206,50 @@ Content-Type: application/json
 {"amount": 25.00}
 ```
 
+**Validation:**
+- `amount`: required, positive, min 1.00, max 10000.00, max 6 decimal places
+
 **Response 201:**
 ```json
 {
     "fundingId": "a1b2c3d4-uuid",
     "walletId": 4,
     "amountUsdc": 25.00,
-    "status": "PENDING",
+    "status": "PAYMENT_CONFIRMED",
     "stripePaymentIntentId": "pi_3Mn...",
     "stripeClientSecret": "pi_3Mn..._secret_...",
     "createdAt": "2026-04-16T15:00:00Z"
 }
 ```
 
-### 4.2 Refund Funding Order
+**Error responses:**
+| HTTP | Code | Condition |
+|---|---|---|
+| 404 | SP-0006 | Wallet not found |
+| 400 | SP-0003 | Amount validation failed |
+| 502 | SP-0021 | Stripe PaymentIntent creation failed |
+
+### 4.2 Get Funding Order Status
+
+```
+GET /api/funding-orders/{fundingId}
+```
+
+**Response 200:**
+```json
+{
+    "fundingId": "a1b2c3d4-uuid",
+    "walletId": 4,
+    "amountUsdc": 25.00,
+    "status": "FUNDED",
+    "stripePaymentIntentId": "pi_3Mn...",
+    "createdAt": "2026-04-16T15:00:00Z"
+}
+```
+
+**Note:** `stripeClientSecret` is NOT returned on GET — only on the initial POST response. It is sensitive and should not be re-exposed.
+
+### 4.3 Refund Funding Order
 
 ```
 POST /api/funding-orders/{fundingId}/refund
@@ -197,7 +267,15 @@ POST /api/funding-orders/{fundingId}/refund
 }
 ```
 
-### 4.3 Stripe Webhook
+**Error responses:**
+| HTTP | Code | Condition |
+|---|---|---|
+| 404 | SP-0020 | Funding order not found |
+| 409 | SP-0023 | Refund on non-FUNDED order |
+| 400 | SP-0025 | Insufficient USDC balance (already spent on remittances) |
+| 502 | SP-0024 | Stripe refund or on-chain return failed |
+
+### 4.4 Stripe Webhook
 
 ```
 POST /webhooks/stripe
@@ -207,7 +285,14 @@ Content-Type: application/json
 {raw Stripe event body}
 ```
 
-**Response:** 200 (always, to prevent Stripe retries on processing errors)
+**Response:** Always 200. Internal errors logged but never surfaced to Stripe.
+
+**Handled event types:**
+| Event | Action |
+|---|---|
+| `payment_intent.succeeded` | Lookup FundingOrder by `metadata.funding_id`, transition to FUNDED via workflow |
+| `payment_intent.payment_failed` | Lookup FundingOrder by `metadata.funding_id`, transition to FAILED |
+| Any other | Log at DEBUG level, ignore |
 
 ## 5. Temporal Workflows
 
@@ -218,25 +303,38 @@ Content-Type: application/json
 ```
 WalletFundingWorkflow.execute(WalletFundingRequest)
     │
-    ├─ Activity 1: ensureSolBalance          (30s timeout, 3 retries)
+    ├─ Activity 1: checkTreasuryBalance          (10s timeout, 1 attempt)
+    │   ├─ Query treasury USDC balance via RPC
+    │   └─ If < requested amount → fail workflow (transition to FAILED)
+    │
+    ├─ Activity 2: ensureSolBalance              (30s timeout, 3 retries)
     │   ├─ Query sender SOL balance via RPC
     │   └─ If < 0.005 SOL → transfer 0.01 SOL from treasury
     │
-    ├─ Activity 2: createAtaIfNeeded         (30s timeout, 3 retries)
+    ├─ Activity 3: createAtaIfNeeded             (30s timeout, 3 retries)
     │   ├─ Check if sender USDC ATA exists via getAccountInfo
     │   └─ If not → CreateAssociatedTokenAccountInstruction (treasury pays)
     │
-    ├─ Activity 3: transferUsdc              (60s timeout, 3 retries)
+    ├─ Activity 4: transferUsdc                  (60s timeout, 3 retries)
     │   ├─ Build SPL Transfer instruction
     │   ├─ Sign with treasury keypair
     │   └─ Submit to Solana RPC
     │
-    ├�� Activity 4: updateWalletBalance       (10s timeout, 3 retries)
+    ├─ Activity 5: updateWalletBalance           (10s timeout, 3 retries)
+    │   ├─ Load wallet with pessimistic lock
+    │   ├─ Check if balance already incremented (idempotency guard)
     │   └─ DB: available_balance += amount, total_balance += amount
     │
-    └─ Activity 5: updateFundingOrderStatus  (10s timeout, 3 retries)
+    └─ Activity 6: updateFundingOrderStatus      (10s timeout, 3 retries)
         └─ PAYMENT_CONFIRMED → FUNDED
 ```
+
+**Failure handling:**
+- If any activity exhausts retries, the workflow fails
+- `CompleteFundingHandler` catches workflow failure and transitions FundingOrder to `FAILED`
+- The on-chain state is the source of truth — if USDC was transferred but DB update failed, Temporal retries the DB update
+
+**Activity 5 idempotency:** `updateWalletBalance` must check whether this specific funding order was already applied (e.g., via a query for the FundingOrder status) before incrementing balance, to prevent double-increment on Temporal retry.
 
 **Input:**
 ```java
@@ -260,8 +358,7 @@ CREATE TABLE funding_orders (
     wallet_id                  BIGINT NOT NULL REFERENCES wallets(id),
     amount_usdc                NUMERIC(19, 6) NOT NULL,
     stripe_payment_intent_id   VARCHAR(255),
-    stripe_client_secret       VARCHAR(255),
-    status                     VARCHAR(50) NOT NULL,
+    status                     VARCHAR(50) NOT NULL DEFAULT 'PAYMENT_CONFIRMED',
     created_at                 TIMESTAMP NOT NULL DEFAULT now(),
     updated_at                 TIMESTAMP
 );
@@ -270,6 +367,8 @@ CREATE INDEX idx_funding_orders_wallet_id ON funding_orders(wallet_id);
 CREATE INDEX idx_funding_orders_stripe_pi ON funding_orders(stripe_payment_intent_id);
 CREATE INDEX idx_funding_orders_status ON funding_orders(status);
 ```
+
+**Note:** `stripe_client_secret` is NOT persisted. It is returned only in the initial POST response and discarded. Storing it would be a security risk — it allows anyone to confirm the payment.
 
 ## 7. Configuration
 
@@ -331,14 +430,16 @@ stripe listen --forward-to localhost:8080/webhooks/stripe
 # Copy whsec_... to .env as STRIPE_WEBHOOK_SECRET
 ```
 
-## 9. Sequence Diagram
+## 9. Sequence Diagrams
+
+### 9.1 Happy Path: Fund → Webhook → USDC Transfer
 
 ```
 Sender              API              Stripe           Webhook          Temporal          Solana
   │                  │                 │                 │                │                │
   │ POST /fund       │                 │                 │                │                │
   │ {amount: 25}     │                 │                 │                │                │
-  │─────────────────►��                 │                 │                │                │
+  │─────────────────►│                 │                 │                │                │
   │                  │ PaymentIntent    │                 │                │                │
   │                  │ create(2500,usd) │                 │                │                │
   │                  │────────────────►│                 │                │                │
@@ -346,16 +447,16 @@ Sender              API              Stripe           Webhook          Temporal 
   │                  │◄────────────────│                 │                │                │
   │                  │                 │                 │                │                │
   │                  │ Save FundingOrder│                 │                │                │
-  │                  │ (PENDING)        │                 │                │                │
+  │                  │ (PAYMENT_CONFIRMED)               │                │                │
   │  201 {fundingId, │                 │                 │                │                │
-  │   status:PENDING}│                 │                 │                │                │
+  │   status:CONFIRMED}               │                 │                │                │
   │◄─────────────────│                 │                 │                │                │
   │                  │                 │                 │                │                │
   │                  │                 │  pi.succeeded    │                │                │
   │                  │                 │────────────────►│                │                │
   │                  │                 │                 │ Verify sig     │                │
-  │                  │                 │                 │ Parse event    │                │
-  │                  │                 │                 │ Update:CONFIRMED                │
+  │                  │                 │                 │ Check status   │                │
+  │                  │                 │                 │ (idempotent)   │                │
   │                  │                 │                 │                │                │
   │                  │                 │                 │ Start workflow │                │
   │                  │                 │                 │───────────────►│                │
@@ -363,61 +464,125 @@ Sender              API              Stripe           Webhook          Temporal 
   │                  │                 │    200 OK       │                │                │
   │                  │                 │◄────────────────│                │                │
   │                  │                 │                 │                │                │
-  │                  │                 │                 │  ensureSol     │                │
-  │                  │                 │                 │                │ check balance  │
+  │                  │                 │                 │ checkTreasury  │                │
+  │                  │                 │                 │                │ query balance  │
   │                  │                 │                 │                │───────────────►│
-  │                  │                 │                 │                │  transfer SOL  │
-  │                  │                 │                 │                │─────────���─────►│
+  │                  │                 │                 │                │                │
+  │                  │                 │                 │  ensureSol     │                │
+  │                  │                 │                 │                │ check + send   │
+  │                  │                 │                 │                │───────────────►│
   │                  │                 │                 │                │                │
   │                  │                 │                 │  createATA     │                │
-  │                  │                 ��                 │                │ getAccountInfo │
-  │                  │                 │                 ���                │─��─────────────►│
-  │                  │                 │                 │                │ createATA tx   │
+  │                  │                 │                 │                │ check + create │
   │                  │                 │                 │                │───────────────►│
   │                  │                 │                 │                │                │
-  │                  │                 │                 │  transferUSDC  │                ��
+  │                  │                 │                 │  transferUSDC  │                │
   │                  │                 │                 │                │ SPL Transfer   │
   │                  │                 │                 │                │───────────────►│
   │                  │                 │                 │                │   finalized    │
   │                  │                 │                 │                │◄───────────────│
   │                  │                 │                 │                │                │
-  │                  │                 │                 │  updateBalance │                │
+  │                  │                 │                 │ updateBalance  │                │
+  │                  │                 │                 │ (idempotent)   │                │
   │                  │                 │                 │  DB: +25 USDC  │                │
   │                  │                 │                 │                │                │
-  │                  │                 │                 │  status: FUNDED│                │
+  │                  │                 │                 │ status: FUNDED │                │
   │                  │                 │                 │                │                │
+  │                  │                 │                 │                │                │
+  │ GET /funding-orders/{id}           │                 │                │                │
+  │─────────────────►│                 │                 │                │                │
+  │  {status: FUNDED}│                 │                 │                │                │
+  │◄─────────────────│                 │                 │                │                │
+```
+
+### 9.2 Failure Path: Stripe Payment Failed
+
+```
+Sender              API              Stripe           Webhook
+  │ POST /fund       │                 │                 │
+  │─────────────────►│                 │                 │
+  │                  │ create PI       │                 │
+  │                  │────────────────►│                 │
+  │                  │◄────────────────│                 │
+  │  201 {CONFIRMED} │                 │                 │
+  │◄─────────────────│                 │                 │
+  │                  │                 │  pi.failed      │
+  │                  │                 │────────────────►│
+  │                  │                 │                 │ Transition →   │
+  │                  │                 │                 │ FAILED         │
+  │                  │                 │    200 OK       │ (no workflow)  │
+  │                  │                 │◄────────────────│                │
+```
+
+### 9.3 Refund Path
+
+```
+Sender              API              Solana           Stripe
+  │ POST /refund     │                 │                 │
+  │─────────────────►│                 │                 │
+  │                  │ Check ATA       │                 │
+  │                  │ balance >= amt   │                 │
+  │                  │────────────────►│                 │
+  │                  │ USDC return     │                 │
+  │                  │ sender → treasury                 │
+  │                  │────────────────►│                 │
+  │                  │                 │                 │
+  │                  │ Stripe refund(pi_...)              │
+  │                  │──────────────────────────────────►│
+  │                  │                 │                 │
+  │                  │ REFUND_INITIATED│                 │
+  │  {status:        │ → REFUNDED     │                 │
+  │   REFUND_INITIATED}               │                 │
+  │◄─────────────────│                 │                 │
 ```
 
 ## 10. Error Handling
 
-| Error Code | HTTP | Exception | Description |
+| Error Code | HTTP | Exception | When Thrown |
 |---|---|---|---|
-| SP-0020 | 404 | FundingOrderNotFoundException | Funding order not found |
-| SP-0021 | 502 | FundingFailedException | Stripe PaymentIntent creation failed |
-| SP-0022 | 409 | FundingAlreadyCompletedException | Attempting to re-fund an already funded order |
-| SP-0023 | 409 | RefundNotAllowedException | Refund on non-FUNDED order |
+| SP-0020 | 404 | FundingOrderNotFoundException | `GET /funding-orders/{id}` or `POST /refund` — order not found |
+| SP-0021 | 502 | FundingFailedException | Stripe PaymentIntent creation failed in `InitiateFundingHandler` |
+| SP-0022 | 409 | FundingAlreadyCompletedException | `POST /fund` called for a wallet that already has a PAYMENT_CONFIRMED or FUNDED order for the same request (idempotency) |
+| SP-0023 | 409 | RefundNotAllowedException | `POST /refund` on a FundingOrder not in FUNDED status |
 | SP-0024 | 502 | RefundFailedException | Stripe refund API or on-chain USDC return failed |
+| SP-0025 | 400 | InsufficientBalanceForRefundException | Refund requested but sender's on-chain ATA or DB balance is less than refund amount (USDC already spent on remittances) |
+
+**GlobalExceptionHandler additions:**
+- `FundingOrderNotFoundException` → 404
+- `FundingFailedException` → 502
+- `FundingAlreadyCompletedException` → 409
+- `RefundNotAllowedException` → 409
+- `RefundFailedException` → 502
+- `InsufficientBalanceForRefundException` → 400
 
 ## 11. Testing Strategy
 
-### Unit Tests
-- `InitiateFundingHandlerTest` — creates FundingOrder, calls PaymentGateway, returns response
-- `CompleteFundingHandlerTest` — transitions PAYMENT_CONFIRMED, starts Temporal workflow
-- `RefundFundingHandlerTest` — transitions FUNDED → REFUND_INITIATED, calls PaymentGateway.refund
-- `StripePaymentAdapterTest` — mocks StripeClient, verifies PaymentIntent params
-- `WalletFundingActivitiesImplTest` — mocks TreasuryService, verifies on-chain calls
-- `StripeWebhookControllerTest` — signature validation, event parsing, handler invocation
+### Unit Tests (new)
+- `InitiateFundingHandlerTest` — creates FundingOrder, calls PaymentGateway, handles Stripe failure
+- `CompleteFundingHandlerTest` — transitions PAYMENT_CONFIRMED, starts workflow, handles idempotent calls
+- `FailFundingHandlerTest` — transitions PAYMENT_CONFIRMED → FAILED
+- `GetFundingOrderHandlerTest` — returns order, handles not found
+- `RefundFundingHandlerTest` — validates balance, transitions FUNDED → REFUND_INITIATED, handles insufficient balance
+- `StripePaymentAdapterTest` — mocks StripeClient, verifies PaymentIntent params, tests test-mode config
+- `WalletFundingActivitiesImplTest` — mocks TreasuryService, verifies on-chain calls, tests idempotency of balance update
+- `StripeWebhookControllerTest` — signature validation, event parsing, succeeded/failed/unknown events, handler invocation
 
-### Integration Tests
+### Modified Tests
+- `WalletControllerTest` — remove fund endpoint tests (moved to FundingController)
+- `WalletApiIntegrationTest` — update fund tests to use new FundingController response format
+- `FundWalletHandlerTest` — delete (handler is replaced by InitiateFundingHandler)
+- `TreasuryServiceAdapterTest` — rewrite for real SPL/SOL transfer logic
+
+### Integration Tests (new)
 - `WalletFundingWorkflowIntegrationTest` — Temporal TestWorkflowEnvironment, mocked activities
 - `FundingOrderRepositoryIntegrationTest` — TestContainers PostgreSQL
 
 ### E2E Test (Devnet)
-- Full flow: fund API → Stripe test PaymentIntent → webhook → Temporal → on-chain USDC transfer → balance update
+- Full flow: fund API → Stripe test PaymentIntent → webhook → Temporal → on-chain USDC transfer → balance update → query status
 
 ## 12. Files to Create/Modify
 
-### New Files (19)
+### New Files (23)
 | Layer | File |
 |---|---|
 | Domain | `domain/funding/model/FundingOrder.java` |
@@ -426,11 +591,17 @@ Sender              API              Stripe           Webhook          Temporal 
 | Domain | `domain/funding/model/PaymentResult.java` |
 | Domain | `domain/funding/handler/InitiateFundingHandler.java` |
 | Domain | `domain/funding/handler/CompleteFundingHandler.java` |
+| Domain | `domain/funding/handler/FailFundingHandler.java` |
+| Domain | `domain/funding/handler/GetFundingOrderHandler.java` |
 | Domain | `domain/funding/handler/RefundFundingHandler.java` |
 | Domain | `domain/funding/port/PaymentGateway.java` |
 | Domain | `domain/funding/port/FundingOrderRepository.java` |
+| Domain | `domain/funding/port/FundingWorkflowStarter.java` |
 | Domain | `domain/funding/exception/FundingOrderNotFoundException.java` |
 | Domain | `domain/funding/exception/FundingFailedException.java` |
+| Domain | `domain/funding/exception/FundingAlreadyCompletedException.java` |
+| Domain | `domain/funding/exception/RefundNotAllowedException.java` |
+| Domain | `domain/funding/exception/InsufficientBalanceForRefundException.java` |
 | Infra | `infrastructure/stripe/StripePaymentAdapter.java` |
 | Infra | `infrastructure/stripe/StripeProperties.java` |
 | Infra | `infrastructure/stripe/StripeConfig.java` |
@@ -438,6 +609,7 @@ Sender              API              Stripe           Webhook          Temporal 
 | Infra | `infrastructure/temporal/WalletFundingWorkflowImpl.java` |
 | Infra | `infrastructure/temporal/WalletFundingActivities.java` |
 | Infra | `infrastructure/temporal/WalletFundingActivitiesImpl.java` |
+| Infra | `infrastructure/temporal/TemporalFundingWorkflowStarter.java` |
 | Infra | `infrastructure/db/funding/FundingOrderEntity.java` |
 | Infra | `infrastructure/db/funding/FundingOrderEntityMapper.java` |
 | Infra | `infrastructure/db/funding/FundingOrderJpaRepository.java` |
@@ -448,10 +620,12 @@ Sender              API              Stripe           Webhook          Temporal 
 | App | `application/dto/FundingOrderResponse.java` |
 | DB | `db/migration/V5__create_funding_orders.sql` |
 
-### Modified Files (7)
+### Modified Files (9)
 | File | Change |
 |---|---|
 | `application/controller/wallet/WalletController.java` | Remove `fundWallet` — moved to `FundingController` |
+| `application/dto/FundWalletRequest.java` | Add `@Min(1)`, `@Max(10000)`, `@Digits(integer=5, fraction=6)` |
+| `application/config/GlobalExceptionHandler.java` | Add handlers for 5 new funding exceptions |
 | `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers |
 | `domain/wallet/port/TreasuryService.java` | Add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded` |
 | `infrastructure/temporal/TaskQueue.java` | Add `WALLET_FUNDING` task queue |
@@ -459,22 +633,37 @@ Sender              API              Stripe           Webhook          Temporal 
 | `build.gradle.kts` | Add `com.stripe:stripe-java:28.2.0` |
 | `application.yml` | Add `stablepay.stripe.*` and `stablepay.treasury.*` properties |
 
+### Modified Test Files (4)
+| File | Change |
+|---|---|
+| `WalletControllerTest.java` | Remove fund endpoint test methods |
+| `WalletApiIntegrationTest.java` | Update fund tests for new response format |
+| `FundWalletHandlerTest.java` | Delete (replaced by InitiateFundingHandlerTest) |
+| `TreasuryServiceAdapterTest.java` | Rewrite for real SPL/SOL transfer logic |
+
+### Postman Collection
+| File | Change |
+|---|---|
+| `docs/StablePay.postman_collection.json` | Update fund request to expect `FundingOrderResponse`, add GET funding order, add refund |
+
 ## 13. Implementation Order
 
 | # | Task | Dependencies | Est. Size |
 |---|---|---|---|
 | 1 | Domain models: FundingOrder, FundingStatus, PaymentRequest, PaymentResult | None | S |
-| 2 | Domain ports: PaymentGateway, FundingOrderRepository | Task 1 | S |
-| 3 | Domain exceptions: FundingOrderNotFoundException, FundingFailedException | None | S |
+| 2 | Domain ports: PaymentGateway, FundingOrderRepository, FundingWorkflowStarter | Task 1 | S |
+| 3 | Domain exceptions (5 exception classes) | None | S |
 | 4 | DB migration V5 + FundingOrderEntity + JpaRepo + Mapper + Adapter | Task 1, 2 | M |
 | 5 | StripeProperties + StripeConfig + StripePaymentAdapter | Task 2 | M |
-| 6 | InitiateFundingHandler + FundingController + FundingOrderResponse | Task 2, 4, 5 | M |
-| 7 | StripeWebhookController + CompleteFundingHandler | Task 4, 5, 6 | M |
+| 6 | InitiateFundingHandler + GetFundingOrderHandler + FundingController + FundingOrderResponse | Task 2, 3, 4, 5 | M |
+| 7 | StripeWebhookController + CompleteFundingHandler + FailFundingHandler | Task 4, 6 | M |
 | 8 | TreasuryServiceAdapter: real SPL + SOL transfers | None (can parallel) | L |
-| 9 | WalletFundingWorkflow + Activities (5 activities) | Task 7, 8 | L |
-| 10 | RefundFundingHandler + refund endpoint | Task 5, 6, 8 | M |
-| 11 | Tests: unit + integration + E2E devnet | Task 1-10 | L |
-| 12 | Config: .env.example, docker-compose, Makefile stripe-listen | Task 5, 7 | S |
+| 9 | WalletFundingWorkflow + Activities (6 activities, idempotent balance update) | Task 7, 8 | L |
+| 10 | RefundFundingHandler + refund endpoint (with balance validation) | Task 5, 6, 8 | M |
+| 11 | Update existing tests + new tests (unit + integration) | Task 1-10 | L |
+| 12 | GlobalExceptionHandler + FundWalletRequest validation + Postman collection | Task 6, 10 | S |
+| 13 | Config: .env.example, docker-compose, Makefile stripe-listen | Task 5, 7 | S |
+| 14 | E2E devnet test | Task 1-13 | M |
 
 ## 14. Out of Scope
 
@@ -486,3 +675,22 @@ Sender              API              Stripe           Webhook          Temporal 
 - Partial refunds (full refund only)
 - Multiple currency support (USD only)
 - Rate limiting on fund endpoint
+- Storing `stripe_client_secret` in DB (returned once on POST, then discarded)
+
+## Appendix: Edge Cases Addressed in Rev 2
+
+| # | Issue | Resolution |
+|---|---|---|
+| 1 | State machine gap: PENDING never transitions to PAYMENT_CONFIRMED | Removed PENDING state. InitiateFundingHandler saves as PAYMENT_CONFIRMED directly after Stripe succeeds. |
+| 2 | Refund when sender already spent USDC | Added balance validation: check on-chain ATA + DB balance before refund. SP-0025 error. |
+| 3 | payment_intent.payment_failed not handled | Added FailFundingHandler + webhook routing for failed events. |
+| 4 | Existing tests break when fund moves to FundingController | Listed WalletControllerTest, WalletApiIntegrationTest, FundWalletHandlerTest as modified/deleted. |
+| 5 | Unknown webhook events not handled | Spec: log at DEBUG, return 200. Never surface errors to Stripe. |
+| 6 | No way to poll funding status | Added GET /api/funding-orders/{fundingId} + GetFundingOrderHandler. |
+| 7 | Treasury depletion not checked in workflow | Added Activity 1: checkTreasuryBalance before any transfers. |
+| 8 | SP-0022 never defined when thrown | Clarified: thrown when duplicate fund request for same wallet with existing active order. |
+| 9 | REFUND_INITIATED stuck if refund fails | Added REFUND_FAILED status and transition. |
+| 10 | Migration missing default for status column | Added DEFAULT 'PAYMENT_CONFIRMED'. |
+| 11 | stripe_client_secret stored in DB | Removed from migration. Returned only on POST, never persisted. |
+| 12 | Amount validation missing | Added @Min(1), @Max(10000), @Digits(integer=5, fraction=6) to FundWalletRequest. |
+| 13 | updateWalletBalance not idempotent on retry | Added idempotency guard: check FundingOrder status before incrementing balance. |

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -4,7 +4,7 @@ status: approved
 created: 2026-04-16
 updated: 2026-04-16
 issue: STA-72
-revision: 2 (edge case fixes from spec review)
+revision: 3 (second review pass — 5 additional fixes)
 ---
 
 # Stripe On-Ramp Integration — Spec
@@ -107,6 +107,11 @@ domain/funding/
 ├── port/
 │   ├── PaymentGateway.java            # Abstracts Stripe (initiatePayment, refund)
 │   ├── FundingOrderRepository.java    # CRUD for FundingOrder
+│   │     Methods:
+│   │       save(FundingOrder) → FundingOrder
+│   │       findByFundingId(UUID) → Optional<FundingOrder>
+│   │       findByStripePaymentIntentId(String) → Optional<FundingOrder>
+│   │       findByWalletIdAndStatusIn(Long, List<FundingStatus>) → List<FundingOrder>
 │   └── FundingWorkflowStarter.java    # Starts WalletFundingWorkflow (abstracts Temporal)
 └── exception/
     ├── FundingOrderNotFoundException.java
@@ -626,10 +631,10 @@ Sender              API              Solana           Stripe
 | `application/controller/wallet/WalletController.java` | Remove `fundWallet` — moved to `FundingController` |
 | `application/dto/FundWalletRequest.java` | Add `@Min(1)`, `@Max(10000)`, `@Digits(integer=5, fraction=6)` |
 | `application/config/GlobalExceptionHandler.java` | Add handlers for 5 new funding exceptions |
-| `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers |
+| `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers. Depends on `SolanaProperties` (for USDC mint address), `Connection` (for RPC). Uses `SplTransferInstruction(from, to, owner, mint, amount, decimals=6)` for USDC and `TransferInstruction(from, to, lamports)` for SOL. Treasury keypair loaded from `stablepay.treasury.private-key`. |
 | `domain/wallet/port/TreasuryService.java` | Add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded` |
 | `infrastructure/temporal/TaskQueue.java` | Add `WALLET_FUNDING` task queue |
-| `infrastructure/temporal/TemporalConfig.java` | Register new worker + workflow + activities |
+| `infrastructure/temporal/TemporalConfig.java` | Refactor to register BOTH workers (remittance + funding) before calling `workerFactory.start()` once. Current code calls `start()` in the remittance worker bean — must be moved to a separate `@Bean` that depends on both workers. |
 | `build.gradle.kts` | Add `com.stripe:stripe-java:28.2.0` |
 | `application.yml` | Add `stablepay.stripe.*` and `stablepay.treasury.*` properties |
 
@@ -694,3 +699,8 @@ Sender              API              Solana           Stripe
 | 11 | stripe_client_secret stored in DB | Removed from migration. Returned only on POST, never persisted. |
 | 12 | Amount validation missing | Added @Min(1), @Max(10000), @Digits(integer=5, fraction=6) to FundWalletRequest. |
 | 13 | updateWalletBalance not idempotent on retry | Added idempotency guard: check FundingOrder status before incrementing balance. |
+| 14 | WorkerFactory.start() called twice for two task queues | Refactor TemporalConfig: register both workers before single start() call. |
+| 15 | Remittance refund doesn't release wallet DB balance (pre-existing bug) | Noted as known issue. Refund balance check uses on-chain ATA balance as primary source of truth, DB balance as secondary. On-chain balance is accurate even if DB is stale. |
+| 16 | FundingOrderRepository port methods not specified | Added explicit method signatures: findByFundingId, findByStripePaymentIntentId, findByWalletIdAndStatusIn. |
+| 17 | TreasuryServiceAdapter needs SolanaProperties for mint + decimals | Documented dependency: SplTransferInstruction needs (from, to, owner, mint, amount, decimals=6). |
+| 18 | Webhook looks up by PaymentIntent ID but repo method not listed | Added findByStripePaymentIntentId to FundingOrderRepository port. Webhook extracts PI ID from event, not from metadata. |

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -4,7 +4,7 @@ status: approved
 created: 2026-04-16
 updated: 2026-04-16
 issue: STA-72
-revision: 3 (second review pass — 5 additional fixes)
+revision: 4 (third review pass — race conditions, money precision, refund ordering)
 ---
 
 # Stripe On-Ramp Integration — Spec
@@ -49,8 +49,10 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 - `POST /api/funding-orders/{fundingId}/refund` initiates a refund
 - Validates sender has sufficient USDC: checks both on-chain ATA balance and DB `available_balance`
 - If insufficient USDC (already spent on remittances): rejects with SP-0025 `InsufficientBalanceForRefundException`
+- **Order matters:** Stripe refund FIRST, then USDC return on-chain
+  - If Stripe refund fails → abort, user still has USDC (no loss)
+  - If Stripe refund succeeds but USDC return fails → REFUND_FAILED (platform risk, manual resolution)
 - USDC transferred from sender ATA back to treasury ATA on-chain
-- Stripe refund API called for the original PaymentIntent
 - FundingOrder transitions: FUNDED → REFUND_INITIATED → REFUNDED
 - If on-chain USDC return or Stripe refund fails: REFUND_INITIATED → REFUND_FAILED
 - Wallet `available_balance` and `total_balance` decremented
@@ -198,7 +200,15 @@ application/dto/
 | REFUND_INITIATED | USDC returned + Stripe refund completed | REFUNDED |
 | REFUND_INITIATED | USDC return or Stripe refund failed | REFUND_FAILED |
 
-**Note:** There is no `PENDING` state. `InitiateFundingHandler` creates the Stripe PaymentIntent and saves the FundingOrder atomically — if Stripe succeeds, status is `PAYMENT_CONFIRMED`; if Stripe fails, status is `FAILED`. This eliminates the gap where a webhook arrives for a `PENDING` order that hasn't been confirmed yet.
+**Ordering in `InitiateFundingHandler`:**
+1. Save FundingOrder with status `PAYMENT_CONFIRMED` to DB **first**
+2. Then call Stripe to create PaymentIntent
+3. Update FundingOrder with `stripePaymentIntentId`
+4. If Stripe call fails: transition to `FAILED`
+
+This ordering is critical because with `confirm: true`, Stripe may fire the webhook **before** the fund endpoint returns. If the FundingOrder isn't saved yet, the webhook can't find it. Saving first guarantees the record exists when the webhook arrives.
+
+**USD to USDC conversion:** 1 USD = 1 USDC (hackathon assumption). Stripe amount in cents = `amountUsdc × 100`. Conversion done in `StripePaymentAdapter`.
 
 ## 4. API Contracts
 
@@ -292,6 +302,8 @@ Content-Type: application/json
 
 **Response:** Always 200. Internal errors logged but never surfaced to Stripe.
 
+**Implementation note:** The controller MUST read the raw request body (`HttpServletRequest.getInputStream()` or `@RequestBody String payload`) — not a typed DTO. Stripe's `constructEvent(payload, sigHeader, secret)` requires the exact bytes for HMAC signature verification. Jackson deserialization would alter the payload and break the signature.
+
 **Handled event types:**
 | Event | Action |
 |---|---|
@@ -362,7 +374,7 @@ CREATE TABLE funding_orders (
     funding_id                 UUID UNIQUE NOT NULL,
     wallet_id                  BIGINT NOT NULL REFERENCES wallets(id),
     amount_usdc                NUMERIC(19, 6) NOT NULL,
-    stripe_payment_intent_id   VARCHAR(255),
+    stripe_payment_intent_id   VARCHAR(255) UNIQUE,
     status                     VARCHAR(50) NOT NULL DEFAULT 'PAYMENT_CONFIRMED',
     created_at                 TIMESTAMP NOT NULL DEFAULT now(),
     updated_at                 TIMESTAMP
@@ -628,7 +640,8 @@ Sender              API              Solana           Stripe
 ### Modified Files (9)
 | File | Change |
 |---|---|
-| `application/controller/wallet/WalletController.java` | Remove `fundWallet` — moved to `FundingController` |
+| `application/controller/wallet/WalletController.java` | Remove `fundWallet` method + `FundWalletHandler` import — funding moved to `FundingController` |
+| `domain/wallet/handler/FundWalletHandler.java` | Delete — replaced by `InitiateFundingHandler` in funding subdomain |
 | `application/dto/FundWalletRequest.java` | Add `@Min(1)`, `@Max(10000)`, `@Digits(integer=5, fraction=6)` |
 | `application/config/GlobalExceptionHandler.java` | Add handlers for 5 new funding exceptions |
 | `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers. Depends on `SolanaProperties` (for USDC mint address), `Connection` (for RPC). Uses `SplTransferInstruction(from, to, owner, mint, amount, decimals=6)` for USDC and `TransferInstruction(from, to, lamports)` for SOL. Treasury keypair loaded from `stablepay.treasury.private-key`. |
@@ -704,3 +717,9 @@ Sender              API              Solana           Stripe
 | 16 | FundingOrderRepository port methods not specified | Added explicit method signatures: findByFundingId, findByStripePaymentIntentId, findByWalletIdAndStatusIn. |
 | 17 | TreasuryServiceAdapter needs SolanaProperties for mint + decimals | Documented dependency: SplTransferInstruction needs (from, to, owner, mint, amount, decimals=6). |
 | 18 | Webhook looks up by PaymentIntent ID but repo method not listed | Added findByStripePaymentIntentId to FundingOrderRepository port. Webhook extracts PI ID from event, not from metadata. |
+| 19 | Race: webhook arrives before InitiateFundingHandler saves FundingOrder | Save FundingOrder to DB FIRST (status PAYMENT_CONFIRMED), then call Stripe API, then update with PI ID. Record exists when webhook arrives. |
+| 20 | Refund ordering: USDC return vs Stripe refund — who goes first? | Stripe refund first. If Stripe fails → abort (user keeps USDC, no loss). If USDC return fails after Stripe refund → REFUND_FAILED (platform risk, manual resolution). |
+| 21 | USD-to-USDC conversion not specified | 1 USD = 1 USDC (hackathon). Stripe amount = amountUsdc × 100 cents. Conversion in StripePaymentAdapter. |
+| 22 | FundWalletHandler.java not in delete list | Added to modified files: delete FundWalletHandler (replaced by InitiateFundingHandler). |
+| 23 | Webhook controller needs raw body for signature verification | Documented: must use HttpServletRequest.getInputStream() or @RequestBody String, not typed DTO. Jackson would break HMAC. |
+| 24 | stripe_payment_intent_id missing UNIQUE constraint | Added UNIQUE to migration column definition. |

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -4,7 +4,7 @@ status: approved
 created: 2026-04-16
 updated: 2026-04-16
 issue: STA-72
-revision: 4 (third review pass — race conditions, money precision, refund ordering)
+revision: 5 (fourth review pass — Option C refund, webhook lookup by funding_id, merged finalize activity, tighter amount validation)
 ---
 
 # Stripe On-Ramp Integration — Spec
@@ -43,19 +43,16 @@ This closes the gap where funding is currently a DB-only operation with no Strip
 ### US-2: Refund funding order
 **As a** sender,
 **I want to** refund a funding order,
-**So that** my USDC is returned to the treasury and my fiat is refunded via Stripe.
+**So that** my fiat is refunded via Stripe.
 
 **Acceptance criteria:**
 - `POST /api/funding-orders/{fundingId}/refund` initiates a refund
-- Validates sender has sufficient USDC: checks both on-chain ATA balance and DB `available_balance`
+- Validates sender still holds the USDC on-chain: sender ATA balance >= refund amount AND DB `available_balance` >= refund amount
 - If insufficient USDC (already spent on remittances): rejects with SP-0025 `InsufficientBalanceForRefundException`
-- **Order matters:** Stripe refund FIRST, then USDC return on-chain
-  - If Stripe refund fails → abort, user still has USDC (no loss)
-  - If Stripe refund succeeds but USDC return fails → REFUND_FAILED (platform risk, manual resolution)
-- USDC transferred from sender ATA back to treasury ATA on-chain
-- FundingOrder transitions: FUNDED → REFUND_INITIATED → REFUNDED
-- If on-chain USDC return or Stripe refund fails: REFUND_INITIATED → REFUND_FAILED
-- Wallet `available_balance` and `total_balance` decremented
+- Stripe refund executed via `PaymentGateway.refund`
+- On Stripe success: FundingOrder transitions FUNDED → REFUND_INITIATED → REFUNDED; wallet `available_balance` and `total_balance` decremented in the same transaction as the REFUNDED status flip
+- On Stripe failure: FundingOrder transitions FUNDED → REFUND_INITIATED → REFUND_FAILED (manual resolution)
+- **On-chain USDC is NOT returned to treasury.** Sender's ATA is owned by sender's MPC wallet, so only the MPC key can authorize a debit. Hackathon accepts that devnet test-USDC remains in the sender's ATA post-refund; the on-chain balance check acts as a gate to prevent refunding USDC already spent on remittances. See §9.3 and appendix #20.
 
 ### US-3: Webhook idempotency and failure handling
 **As the** system,
@@ -201,14 +198,16 @@ application/dto/
 | REFUND_INITIATED | USDC return or Stripe refund failed | REFUND_FAILED |
 
 **Ordering in `InitiateFundingHandler`:**
-1. Save FundingOrder with status `PAYMENT_CONFIRMED` to DB **first**
-2. Then call Stripe to create PaymentIntent
+1. Save FundingOrder with status `PAYMENT_CONFIRMED` to DB **first** (fundingId is the durable key)
+2. Then call Stripe to create PaymentIntent with `metadata.funding_id = fundingId.toString()` and `metadata.wallet_id = walletId.toString()`
 3. Update FundingOrder with `stripePaymentIntentId`
 4. If Stripe call fails: transition to `FAILED`
 
-This ordering is critical because with `confirm: true`, Stripe may fire the webhook **before** the fund endpoint returns. If the FundingOrder isn't saved yet, the webhook can't find it. Saving first guarantees the record exists when the webhook arrives.
+This ordering is critical because with `confirm: true`, Stripe may fire the webhook **before** the fund endpoint returns. **The webhook looks up FundingOrder by `metadata.funding_id` (echoed back by Stripe in the event), NOT by PaymentIntent ID** — because PI ID isn't persisted until step 3. Looking up by funding_id guarantees the record is found regardless of timing.
 
-**USD to USDC conversion:** 1 USD = 1 USDC (hackathon assumption). Stripe amount in cents = `amountUsdc × 100`. Conversion done in `StripePaymentAdapter`.
+**Concurrent fund requests:** the duplicate-order check (`findByWalletIdAndStatusIn(walletId, [PAYMENT_CONFIRMED])`) is not atomic with the insert. Two simultaneous fund calls for the same wallet can both pass the check. The DB backstop is a partial unique index `UNIQUE(wallet_id) WHERE status = 'PAYMENT_CONFIRMED'` (see §6). The handler catches `DataIntegrityViolationException` and maps it to SP-0022.
+
+**USD to USDC conversion:** 1 USD = 1 USDC (hackathon assumption). Stripe amount in cents = `amountUsdc × 100`. Amount is validated to **2 decimal places max** (Stripe requires whole cents); sub-cent amounts rejected at the API layer by `@Digits(integer=5, fraction=2)`. Conversion done in `StripePaymentAdapter` via `amount.movePointRight(2).longValueExact()`.
 
 ## 4. API Contracts
 
@@ -222,7 +221,7 @@ Content-Type: application/json
 ```
 
 **Validation:**
-- `amount`: required, positive, min 1.00, max 10000.00, max 6 decimal places
+- `amount`: required, positive, min 1.00, max 10000.00, **max 2 decimal places** (Stripe requires whole cents; sub-cent amounts rejected as `@Digits(integer=5, fraction=2)` violation → SP-0003)
 
 **Response 201:**
 ```json
@@ -337,21 +336,21 @@ WalletFundingWorkflow.execute(WalletFundingRequest)
     │   ├─ Sign with treasury keypair
     │   └─ Submit to Solana RPC
     │
-    ├─ Activity 5: updateWalletBalance           (10s timeout, 3 retries)
-    │   ├─ Load wallet with pessimistic lock
-    │   ├─ Check if balance already incremented (idempotency guard)
-    │   └─ DB: available_balance += amount, total_balance += amount
-    │
-    └─ Activity 6: updateFundingOrderStatus      (10s timeout, 3 retries)
-        └─ PAYMENT_CONFIRMED → FUNDED
+    └─ Activity 5: finalizeFunding                (15s timeout, 3 retries, @Transactional)
+        ├─ Load wallet with pessimistic lock (SELECT ... FOR UPDATE)
+        ├─ Load FundingOrder by fundingId
+        ├─ Idempotency guard: if FundingOrder.status == FUNDED → return (no-op)
+        ├─ DB: available_balance += amount, total_balance += amount
+        ├─ FundingOrder.status = FUNDED, updated_at = now()
+        └─ Commit (status flip + balance increment in ONE transaction)
 ```
 
 **Failure handling:**
 - If any activity exhausts retries, the workflow fails
 - `CompleteFundingHandler` catches workflow failure and transitions FundingOrder to `FAILED`
-- The on-chain state is the source of truth — if USDC was transferred but DB update failed, Temporal retries the DB update
+- The on-chain state is the source of truth — if USDC was transferred but DB update failed, Temporal retries `finalizeFunding`
 
-**Activity 5 idempotency:** `updateWalletBalance` must check whether this specific funding order was already applied (e.g., via a query for the FundingOrder status) before incrementing balance, to prevent double-increment on Temporal retry.
+**Why activities 5 and 6 are merged (rev 5 fix):** previously `updateWalletBalance` and `updateFundingOrderStatus` were separate activities with a status-based idempotency guard. That guard was broken: status stayed `PAYMENT_CONFIRMED` until the *second* activity, so a retry of activity 5 (commit succeeded, ack failed) would re-read `PAYMENT_CONFIRMED` and increment again. Merging them makes the status flip and the increment atomic; the first successful commit sets `FUNDED`, and any retry finds `FUNDED` on re-read and short-circuits.
 
 **Input:**
 ```java
@@ -383,6 +382,14 @@ CREATE TABLE funding_orders (
 CREATE INDEX idx_funding_orders_wallet_id ON funding_orders(wallet_id);
 CREATE INDEX idx_funding_orders_stripe_pi ON funding_orders(stripe_payment_intent_id);
 CREATE INDEX idx_funding_orders_status ON funding_orders(status);
+
+-- At most one in-flight PAYMENT_CONFIRMED order per wallet. DB-level backstop
+-- for the non-atomic read-then-insert in InitiateFundingHandler. A race past
+-- the handler check surfaces as DataIntegrityViolationException, which is
+-- translated to SP-0022 FundingAlreadyInProgressException.
+CREATE UNIQUE INDEX idx_funding_orders_one_active_per_wallet
+    ON funding_orders(wallet_id)
+    WHERE status = 'PAYMENT_CONFIRMED';
 ```
 
 **Note:** `stripe_client_secret` is NOT persisted. It is returned only in the initial POST response and discarded. Storing it would be a security risk — it allows anyone to confirm the payment.
@@ -531,27 +538,41 @@ Sender              API              Stripe           Webhook
   │                  │                 │◄────────────────│                │
 ```
 
-### 9.3 Refund Path
+### 9.3 Refund Path (Stripe-only with on-chain balance gate)
 
 ```
 Sender              API              Solana           Stripe
   │ POST /refund     │                 │                 │
   │─────────────────►│                 │                 │
-  │                  │ Check ATA       │                 │
-  │                  │ balance >= amt   │                 │
-  │                  │────────────────►│                 │
-  │                  │ USDC return     │                 │
-  │                  │ sender → treasury                 │
-  │                  │────────────────►│                 │
+  │                  │ Load FundingOrder                 │
+  │                  │ must be FUNDED  │                 │
+  │                  │ (else SP-0023)  │                 │
   │                  │                 │                 │
-  │                  │ Stripe refund(pi_...)              │
+  │                  │ Check sender ATA│                 │
+  │                  │ balance >= amt  │                 │
+  │                  │────────────────►│                 │
+  │                  │◄───────────────│                 │
+  │                  │ (else SP-0025)  │                 │
+  │                  │                 │                 │
+  │                  │ status: FUNDED  │                 │
+  │                  │ → REFUND_INITIATED                │
+  │                  │                 │                 │
+  │                  │ Stripe refund(pi_...)             │
   │                  │──────────────────────────────────►│
+  │                  │                 │    success      │
+  │                  │◄──────────────────────────────────│
   │                  │                 │                 │
-  │                  │ REFUND_INITIATED│                 │
-  │  {status:        │ → REFUNDED     │                 │
-  │   REFUND_INITIATED}               │                 │
+  │                  │ In ONE tx:      │                 │
+  │                  │  wallet.balance -= amt            │
+  │                  │  status: REFUNDED                 │
+  │  {status:        │                 │                 │
+  │   REFUND_INITIATED}                │                 │
   │◄─────────────────│                 │                 │
 ```
+
+**On Stripe failure:** `status: REFUND_INITIATED → REFUND_FAILED`. Wallet balance not decremented. Manual resolution.
+
+**Why no on-chain USDC return:** Sender's ATA is owned by the sender's MPC wallet, not the treasury. Only the MPC key can authorize a debit. Adding MPC-signed return would require wiring `MpcWalletClient` into the refund path plus a full signing ceremony — out of scope for the hackathon. On devnet the USDC is a test token with no monetary value, so it remaining in the sender ATA is acceptable. The on-chain balance check prevents refunding USDC that's already been spent on a remittance (which would be a real platform loss). See appendix #20.
 
 ## 10. Error Handling
 
@@ -559,7 +580,7 @@ Sender              API              Solana           Stripe
 |---|---|---|---|
 | SP-0020 | 404 | FundingOrderNotFoundException | `GET /funding-orders/{id}` or `POST /refund` — order not found |
 | SP-0021 | 502 | FundingFailedException | Stripe PaymentIntent creation failed in `InitiateFundingHandler` |
-| SP-0022 | 409 | FundingAlreadyCompletedException | `POST /fund` called for a wallet that already has a PAYMENT_CONFIRMED or FUNDED order for the same request (idempotency) |
+| SP-0022 | 409 | FundingAlreadyInProgressException | `POST /fund` called for a wallet that already has a `PAYMENT_CONFIRMED` (in-flight) order. Thrown by the handler's pre-check OR mapped from `DataIntegrityViolationException` on the partial unique index race. |
 | SP-0023 | 409 | RefundNotAllowedException | `POST /refund` on a FundingOrder not in FUNDED status |
 | SP-0024 | 502 | RefundFailedException | Stripe refund API or on-chain USDC return failed |
 | SP-0025 | 400 | InsufficientBalanceForRefundException | Refund requested but sender's on-chain ATA or DB balance is less than refund amount (USDC already spent on remittances) |
@@ -567,10 +588,11 @@ Sender              API              Solana           Stripe
 **GlobalExceptionHandler additions:**
 - `FundingOrderNotFoundException` → 404
 - `FundingFailedException` → 502
-- `FundingAlreadyCompletedException` → 409
+- `FundingAlreadyInProgressException` → 409
 - `RefundNotAllowedException` → 409
 - `RefundFailedException` → 502
 - `InsufficientBalanceForRefundException` → 400
+- `DataIntegrityViolationException` (scoped to funding_orders wallet_id unique violation) → translate to 409 SP-0022
 
 ## 11. Testing Strategy
 
@@ -616,9 +638,10 @@ Sender              API              Solana           Stripe
 | Domain | `domain/funding/port/FundingWorkflowStarter.java` |
 | Domain | `domain/funding/exception/FundingOrderNotFoundException.java` |
 | Domain | `domain/funding/exception/FundingFailedException.java` |
-| Domain | `domain/funding/exception/FundingAlreadyCompletedException.java` |
+| Domain | `domain/funding/exception/FundingAlreadyInProgressException.java` |
 | Domain | `domain/funding/exception/RefundNotAllowedException.java` |
 | Domain | `domain/funding/exception/InsufficientBalanceForRefundException.java` |
+| Domain | `domain/funding/exception/RefundFailedException.java` |
 | Infra | `infrastructure/stripe/StripePaymentAdapter.java` |
 | Infra | `infrastructure/stripe/StripeProperties.java` |
 | Infra | `infrastructure/stripe/StripeConfig.java` |
@@ -645,7 +668,7 @@ Sender              API              Solana           Stripe
 | `application/dto/FundWalletRequest.java` | Add `@Min(1)`, `@Max(10000)`, `@Digits(integer=5, fraction=6)` |
 | `application/config/GlobalExceptionHandler.java` | Add handlers for 5 new funding exceptions |
 | `infrastructure/solana/TreasuryServiceAdapter.java` | Replace stub with real SPL + SOL transfers. Depends on `SolanaProperties` (for USDC mint address), `Connection` (for RPC). Uses `SplTransferInstruction(from, to, owner, mint, amount, decimals=6)` for USDC and `TransferInstruction(from, to, lamports)` for SOL. Treasury keypair loaded from `stablepay.treasury.private-key`. |
-| `domain/wallet/port/TreasuryService.java` | Add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded` |
+| `domain/wallet/port/TreasuryService.java` | Rename `transferFromTreasury` → `transferUsdc`. Add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded`. (The sole existing caller `FundWalletHandler` is being deleted; no backwards-compat alias needed.) |
 | `infrastructure/temporal/TaskQueue.java` | Add `WALLET_FUNDING` task queue |
 | `infrastructure/temporal/TemporalConfig.java` | Refactor to register BOTH workers (remittance + funding) before calling `workerFactory.start()` once. Current code calls `start()` in the remittance worker bean — must be moved to a separate `@Bean` that depends on both workers. |
 | `build.gradle.kts` | Add `com.stripe:stripe-java:28.2.0` |
@@ -716,10 +739,21 @@ Sender              API              Solana           Stripe
 | 15 | Remittance refund doesn't release wallet DB balance (pre-existing bug) | Noted as known issue. Refund balance check uses on-chain ATA balance as primary source of truth, DB balance as secondary. On-chain balance is accurate even if DB is stale. |
 | 16 | FundingOrderRepository port methods not specified | Added explicit method signatures: findByFundingId, findByStripePaymentIntentId, findByWalletIdAndStatusIn. |
 | 17 | TreasuryServiceAdapter needs SolanaProperties for mint + decimals | Documented dependency: SplTransferInstruction needs (from, to, owner, mint, amount, decimals=6). |
-| 18 | Webhook looks up by PaymentIntent ID but repo method not listed | Added findByStripePaymentIntentId to FundingOrderRepository port. Webhook extracts PI ID from event, not from metadata. |
+| 18 | Webhook lookup race against save→Stripe ordering | **Revised (rev 5):** Webhook looks up FundingOrder by `metadata.funding_id` (set on PaymentIntent create, echoed in event), NOT by PaymentIntent ID. PI ID is only persisted after Stripe returns, so a webhook arriving in the save→Stripe window would miss on a PI-ID lookup. `funding_id` is the durable key. `findByStripePaymentIntentId` remains on the port for duplicate-PI detection and refund handler lookup. |
 | 19 | Race: webhook arrives before InitiateFundingHandler saves FundingOrder | Save FundingOrder to DB FIRST (status PAYMENT_CONFIRMED), then call Stripe API, then update with PI ID. Record exists when webhook arrives. |
-| 20 | Refund ordering: USDC return vs Stripe refund — who goes first? | Stripe refund first. If Stripe fails → abort (user keeps USDC, no loss). If USDC return fails after Stripe refund → REFUND_FAILED (platform risk, manual resolution). |
+| 20 | Refund ordering: USDC return vs Stripe refund | **Revised (rev 5):** On-chain USDC return removed entirely. Sender's ATA is owned by the sender's MPC wallet; treasury cannot sign a debit. Refund is Stripe-only, gated by an on-chain balance check (SP-0025) that blocks refunds once USDC has been spent on a remittance. USDC remains in the sender ATA after refund — acceptable on devnet (test tokens). Production would require MPC-signed return. State machine: FUNDED → REFUND_INITIATED → (Stripe ok → REFUNDED; Stripe fail → REFUND_FAILED). |
 | 21 | USD-to-USDC conversion not specified | 1 USD = 1 USDC (hackathon). Stripe amount = amountUsdc × 100 cents. Conversion in StripePaymentAdapter. |
 | 22 | FundWalletHandler.java not in delete list | Added to modified files: delete FundWalletHandler (replaced by InitiateFundingHandler). |
 | 23 | Webhook controller needs raw body for signature verification | Documented: must use HttpServletRequest.getInputStream() or @RequestBody String, not typed DTO. Jackson would break HMAC. |
 | 24 | stripe_payment_intent_id missing UNIQUE constraint | Added UNIQUE to migration column definition. |
+
+## Appendix: Edge Cases Addressed in Rev 5
+
+| # | Issue | Resolution |
+|---|---|---|
+| 25 | Activity-5 status-based idempotency guard was broken | Merged `updateWalletBalance` + `updateFundingOrderStatus` into a single transactional activity `finalizeFunding`. Status flip and balance increment commit atomically, so any retry after a successful commit finds status=FUNDED and short-circuits. |
+| 26 | Amount validation (6 decimal places) would crash Stripe conversion | Tightened `FundWalletRequest.amount` to `@Digits(integer=5, fraction=2)`. Stripe requires whole cents; `amount.movePointRight(2).longValueExact()` would throw `ArithmeticException` on sub-cent values. |
+| 27 | SP-0022 exception name misleading | Renamed `FundingAlreadyCompletedException` → `FundingAlreadyInProgressException`. Thrown when a `PAYMENT_CONFIRMED` (in-flight) order exists — not a completed one. |
+| 28 | CompleteFundingHandler idempotency missed refund terminal states | Added REFUND_INITIATED, REFUNDED, REFUND_FAILED to the "ignore silently" list. A stale webhook replay after a refund must not re-start the funding workflow. |
+| 29 | Concurrent fund requests can race past the duplicate-order check | Added partial unique index `UNIQUE(wallet_id) WHERE status = 'PAYMENT_CONFIRMED'`. Handler catches `DataIntegrityViolationException` and maps to SP-0022. |
+| 30 | Webhook endpoint security config not specified | `/webhooks/stripe` must be permitted without auth and excluded from CSRF. Signature verification via `Webhook.constructEvent(payload, sig, secret, 300)` is the authentication mechanism. |


### PR DESCRIPTION
## Summary

Adds the Stripe on-ramp integration spec (and its grill session notes) for epic **STA-72**. Iterated through 5 revisions; this PR lands the final approved version.

- `docs/specs/2026-04-16-stripe-onramp-spec.md` — full design (API, state machine, Temporal workflow, migrations, error handling, testing strategy)
- `docs/specs/2026-04-16-stripe-onramp-grill-session.md` — design decisions captured during the grill session

Related issues: [STA-72](https://github.com/Puneethkumarck/stablepay-hackathon/issues/149) (epic) and [STA-73](https://github.com/Puneethkumarck/stablepay-hackathon/issues/150) through [STA-82](https://github.com/Puneethkumarck/stablepay-hackathon/issues/159) (implementation tickets).

## Rev 5 decisions (this commit)

- **Refund:** Stripe-only with on-chain USDC balance gate. Sender's ATA is owned by their MPC wallet — treasury can't sign a debit. On-chain return deferred to post-hackathon when MPC-signed refund transfers are wired in. The balance gate (SP-0025) prevents refunding USDC that's been spent on a remittance.
- **Webhook lookup:** by `metadata.funding_id` (durable from Stripe create call), not by PaymentIntent ID (not persisted until after Stripe returns — race with save-first ordering).
- **Temporal workflow:** activities 5 + 6 merged into one transactional `finalizeFunding` so the status flip and balance increment commit atomically. The separate-activity design had a broken idempotency guard that could double-increment on retry.
- **Amount validation:** `@Digits(fraction=2)` — Stripe requires whole cents; `fraction=6` would crash `movePointRight(2).longValueExact()` on sub-cent amounts.
- **Concurrency:** partial unique index `UNIQUE(wallet_id) WHERE status='PAYMENT_CONFIRMED'` as DB backstop for concurrent fund requests.
- **Exception rename:** `FundingAlreadyCompletedException` → `FundingAlreadyInProgressException` (the exception is for in-flight, not completed, orders).
- **Added `RefundFailedException` (SP-0024)** to the exceptions file list (previously referenced but not created).
- Documented webhook CSRF/auth exemption.
- Corrected TreasuryService baseline: `getBalance` does not currently exist; `transferFromTreasury` → `transferUsdc` rename.

## History

- **rev 1:** initial spec
- **rev 2:** 13 edge cases (state machine, idempotency, refund status, migration defaults)
- **rev 3:** 5 additional edge cases (repository ports, SolanaProperties deps, webhook lookup)
- **rev 4:** 6 more edge cases (race conditions, money precision, refund ordering)
- **rev 5:** Option C refund + 6 more (webhook lookup fix, merged finalize activity, tighter amount validation, missing `RefundFailedException`, concurrency backstop, exception rename, security config)

See the spec's appendix sections for the full edge-case history.

## Test plan

- [ ] Spec read end-to-end — no contradictions between sections
- [ ] State machine in §3.4 matches the table in §2 (US-1 through US-5)
- [ ] Migration in §6 matches the entity fields in §3.1
- [ ] Error table in §10 lists all 6 exceptions with HTTP codes matching issue bodies
- [ ] Files list in §12 matches the issue assignments (STA-73 through STA-82)
- [ ] Note: this PR is spec-only. Implementation PRs (STA-73 through STA-82) will land against the resulting design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)