### PR TITLE
STA-73: add funding domain models, ports, and exceptions

### DIFF
--- a/backend/src/main/java/com/stablepay/domain/funding/exception/FundingAlreadyInProgressException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/FundingAlreadyInProgressException.java
@@ -1,0 +1,13 @@
+package com.stablepay.domain.funding.exception;
+
+public class FundingAlreadyInProgressException extends RuntimeException {
+
+    public static FundingAlreadyInProgressException forWallet(Long walletId) {
+        return new FundingAlreadyInProgressException(
+                "SP-0022: Funding already in progress for wallet: " + walletId);
+    }
+
+    private FundingAlreadyInProgressException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
@@ -1,0 +1,16 @@
+package com.stablepay.domain.funding.exception;
+
+public class FundingFailedException extends RuntimeException {
+
+    private FundingFailedException(String message) {
+        super(message);
+    }
+
+    private FundingFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static FundingFailedException stripeError(String message, Throwable cause) {
+        return new FundingFailedException("SP-0021: Stripe payment failed: " + message, cause);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
@@ -2,15 +2,11 @@ package com.stablepay.domain.funding.exception;
 
 public class FundingFailedException extends RuntimeException {
 
-    private FundingFailedException(String message) {
-        super(message);
+    public static FundingFailedException stripeError(String message, Throwable cause) {
+        return new FundingFailedException("SP-0021: Stripe payment failed: " + message, cause);
     }
 
     private FundingFailedException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public static FundingFailedException stripeError(String message, Throwable cause) {
-        return new FundingFailedException("SP-0021: Stripe payment failed: " + message, cause);
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/FundingOrderNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/FundingOrderNotFoundException.java
@@ -1,0 +1,14 @@
+package com.stablepay.domain.funding.exception;
+
+import java.util.UUID;
+
+public class FundingOrderNotFoundException extends RuntimeException {
+
+    public static FundingOrderNotFoundException byFundingId(UUID fundingId) {
+        return new FundingOrderNotFoundException("SP-0020: Funding order not found: " + fundingId);
+    }
+
+    private FundingOrderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/InsufficientBalanceForRefundException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/InsufficientBalanceForRefundException.java
@@ -1,0 +1,15 @@
+package com.stablepay.domain.funding.exception;
+
+import java.math.BigDecimal;
+
+public class InsufficientBalanceForRefundException extends RuntimeException {
+
+    public static InsufficientBalanceForRefundException forAmount(BigDecimal requested, BigDecimal available) {
+        return new InsufficientBalanceForRefundException(
+                "SP-0025: Insufficient balance for refund. Requested: " + requested + ", Available: " + available);
+    }
+
+    private InsufficientBalanceForRefundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/RefundFailedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/RefundFailedException.java
@@ -2,16 +2,12 @@ package com.stablepay.domain.funding.exception;
 
 public class RefundFailedException extends RuntimeException {
 
-    private RefundFailedException(String message) {
-        super(message);
+    public static RefundFailedException stripeRefundFailed(String paymentIntentId, Throwable cause) {
+        return new RefundFailedException(
+                "SP-0024: Stripe refund failed for PaymentIntent: " + paymentIntentId, cause);
     }
 
     private RefundFailedException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public static RefundFailedException stripeRefundFailed(String paymentIntentId, Throwable cause) {
-        return new RefundFailedException(
-                "SP-0024: Stripe refund failed for PaymentIntent: " + paymentIntentId, cause);
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/RefundFailedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/RefundFailedException.java
@@ -1,0 +1,17 @@
+package com.stablepay.domain.funding.exception;
+
+public class RefundFailedException extends RuntimeException {
+
+    private RefundFailedException(String message) {
+        super(message);
+    }
+
+    private RefundFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static RefundFailedException stripeRefundFailed(String paymentIntentId, Throwable cause) {
+        return new RefundFailedException(
+                "SP-0024: Stripe refund failed for PaymentIntent: " + paymentIntentId, cause);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/RefundNotAllowedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/RefundNotAllowedException.java
@@ -1,0 +1,15 @@
+package com.stablepay.domain.funding.exception;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+
+public class RefundNotAllowedException extends RuntimeException {
+
+    public static RefundNotAllowedException forStatus(FundingStatus status) {
+        return new RefundNotAllowedException(
+                "SP-0023: Refund not allowed for funding order in status: " + status);
+    }
+
+    private RefundNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/FundingOrder.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/FundingOrder.java
@@ -1,0 +1,28 @@
+package com.stablepay.domain.funding.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record FundingOrder(
+    Long id,
+    UUID fundingId,
+    Long walletId,
+    BigDecimal amountUsdc,
+    String stripePaymentIntentId,
+    FundingStatus status,
+    Instant createdAt,
+    Instant updatedAt
+) {
+    public FundingOrder {
+        requireNonNull(fundingId, "fundingId cannot be null");
+        requireNonNull(walletId, "walletId cannot be null");
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        requireNonNull(status, "status cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/FundingStatus.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/FundingStatus.java
@@ -1,0 +1,10 @@
+package com.stablepay.domain.funding.model;
+
+public enum FundingStatus {
+    PAYMENT_CONFIRMED,
+    FUNDED,
+    FAILED,
+    REFUND_INITIATED,
+    REFUNDED,
+    REFUND_FAILED
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/PaymentRequest.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/PaymentRequest.java
@@ -1,0 +1,14 @@
+package com.stablepay.domain.funding.model;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record PaymentRequest(
+    UUID fundingId,
+    Long walletId,
+    BigDecimal amountUsdc,
+    String currency
+) {}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/PaymentResult.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/PaymentResult.java
@@ -1,0 +1,10 @@
+package com.stablepay.domain.funding.model;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record PaymentResult(
+    String pspReference,
+    String clientSecret,
+    String status
+) {}

--- a/backend/src/main/java/com/stablepay/domain/funding/port/FundingOrderRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/port/FundingOrderRepository.java
@@ -1,0 +1,15 @@
+package com.stablepay.domain.funding.port;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+
+public interface FundingOrderRepository {
+    FundingOrder save(FundingOrder order);
+    Optional<FundingOrder> findByFundingId(UUID fundingId);
+    Optional<FundingOrder> findByStripePaymentIntentId(String paymentIntentId);
+    List<FundingOrder> findByWalletIdAndStatusIn(Long walletId, List<FundingStatus> statuses);
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/port/FundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/port/FundingWorkflowStarter.java
@@ -1,0 +1,8 @@
+package com.stablepay.domain.funding.port;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public interface FundingWorkflowStarter {
+    void startFundingWorkflow(UUID fundingId, Long walletId, String senderSolanaAddress, BigDecimal amountUsdc);
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/port/PaymentGateway.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/port/PaymentGateway.java
@@ -1,0 +1,11 @@
+package com.stablepay.domain.funding.port;
+
+import java.math.BigDecimal;
+
+import com.stablepay.domain.funding.model.PaymentRequest;
+import com.stablepay.domain.funding.model.PaymentResult;
+
+public interface PaymentGateway {
+    PaymentResult initiatePayment(PaymentRequest request);
+    void refund(String paymentIntentId, BigDecimal amount);
+}

--- a/backend/src/test/java/com/stablepay/domain/funding/exception/FundingExceptionTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/exception/FundingExceptionTest.java
@@ -1,0 +1,96 @@
+package com.stablepay.domain.funding.exception;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+
+class FundingExceptionTest {
+
+    @Test
+    void shouldFormatFundingOrderNotFoundMessage() {
+        // given
+        var exception = FundingOrderNotFoundException.byFundingId(SOME_FUNDING_ID);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message).contains("SP-0020").contains(SOME_FUNDING_ID.toString());
+    }
+
+    @Test
+    void shouldFormatFundingFailedMessageAndAttachCause() {
+        // given
+        var cause = new RuntimeException("boom");
+        var exception = FundingFailedException.stripeError("card declined", cause);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message).contains("SP-0021").contains("card declined");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void shouldFormatFundingAlreadyInProgressMessage() {
+        // given
+        var exception = FundingAlreadyInProgressException.forWallet(SOME_WALLET_ID);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message).contains("SP-0022").contains(SOME_WALLET_ID.toString());
+    }
+
+    @Test
+    void shouldFormatRefundNotAllowedMessage() {
+        // given
+        var exception = RefundNotAllowedException.forStatus(FundingStatus.FUNDED);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message).contains("SP-0023").contains(FundingStatus.FUNDED.name());
+    }
+
+    @Test
+    void shouldFormatRefundFailedMessageAndAttachCause() {
+        // given
+        var cause = new RuntimeException("api down");
+        var exception = RefundFailedException.stripeRefundFailed(SOME_STRIPE_PAYMENT_INTENT_ID, cause);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message).contains("SP-0024").contains(SOME_STRIPE_PAYMENT_INTENT_ID);
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void shouldFormatInsufficientBalanceForRefundMessage() {
+        // given
+        var requested = new BigDecimal("100.00");
+        var available = new BigDecimal("25.00");
+        var exception = InsufficientBalanceForRefundException.forAmount(requested, available);
+
+        // when
+        var message = exception.getMessage();
+
+        // then
+        assertThat(message)
+                .contains("SP-0025")
+                .contains(requested.toString())
+                .contains(available.toString());
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/funding/model/FundingOrderTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/model/FundingOrderTest.java
@@ -9,14 +9,24 @@ import org.junit.jupiter.api.Test;
 class FundingOrderTest {
 
     @Test
-    void shouldBuildFundingOrderWithAllFields() {
+    void shouldAcceptNullForOptionalFields() {
         // given
-        var expected = fundingOrderBuilder().build();
+        var builder = fundingOrderBuilder()
+                .id(null)
+                .stripePaymentIntentId(null)
+                .createdAt(null)
+                .updatedAt(null);
 
         // when
-        var actual = expected.toBuilder().build();
+        var actual = builder.build();
 
         // then
+        var expected = fundingOrderBuilder()
+                .id(null)
+                .stripePaymentIntentId(null)
+                .createdAt(null)
+                .updatedAt(null)
+                .build();
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 

--- a/backend/src/test/java/com/stablepay/domain/funding/model/FundingOrderTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/model/FundingOrderTest.java
@@ -1,0 +1,79 @@
+package com.stablepay.domain.funding.model;
+
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class FundingOrderTest {
+
+    @Test
+    void shouldBuildFundingOrderWithAllFields() {
+        // given
+        var expected = fundingOrderBuilder().build();
+
+        // when
+        var actual = expected.toBuilder().build();
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnCopyWithUpdatedStatusViaToBuilder() {
+        // given
+        var original = fundingOrderBuilder().build();
+
+        // when
+        var actual = original.toBuilder().status(FundingStatus.FUNDED).build();
+
+        // then
+        var expected = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowWhenFundingIdIsNull() {
+        // given
+        var builder = fundingOrderBuilder().fundingId(null);
+
+        // when / then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("fundingId");
+    }
+
+    @Test
+    void shouldThrowWhenWalletIdIsNull() {
+        // given
+        var builder = fundingOrderBuilder().walletId(null);
+
+        // when / then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("walletId");
+    }
+
+    @Test
+    void shouldThrowWhenAmountUsdcIsNull() {
+        // given
+        var builder = fundingOrderBuilder().amountUsdc(null);
+
+        // when / then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("amountUsdc");
+    }
+
+    @Test
+    void shouldThrowWhenStatusIsNull() {
+        // given
+        var builder = fundingOrderBuilder().status(null);
+
+        // when / then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("status");
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/FundingOrderFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/FundingOrderFixtures.java
@@ -1,0 +1,33 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+
+public final class FundingOrderFixtures {
+
+    private FundingOrderFixtures() {}
+
+    public static final Long SOME_FUNDING_ORDER_DB_ID = 1L;
+    public static final UUID SOME_FUNDING_ID = UUID.fromString("11111111-2222-3333-4444-555555555555");
+    public static final Long SOME_WALLET_ID = 4L;
+    public static final BigDecimal SOME_AMOUNT_USDC = new BigDecimal("25.00");
+    public static final String SOME_STRIPE_PAYMENT_INTENT_ID = "pi_3MnTest0123456789";
+    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-16T15:00:00Z");
+    public static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-16T15:00:00Z");
+
+    public static FundingOrder.FundingOrderBuilder fundingOrderBuilder() {
+        return FundingOrder.builder()
+                .id(SOME_FUNDING_ORDER_DB_ID)
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .status(FundingStatus.PAYMENT_CONFIRMED)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT);
+    }
+}


### PR DESCRIPTION
## STA Issue
Closes #150

Parent epic: #149 (STA-72 Stripe On-Ramp Integration)
Spec: [docs/specs/2026-04-16-stripe-onramp-spec.md](docs/specs/2026-04-16-stripe-onramp-spec.md)

## Summary

Lays down the pure domain primitives for the new `funding` subdomain — models, outbound ports, and exceptions — following the same hexagonal pattern used by `wallet`, `remittance`, `claim`, and `fx`. No handlers, DB migration, adapters, or endpoints are included here; those are delivered in STA-74 through STA-81.

## Changes

**Domain models** (`domain/funding/model/`)
- `FundingOrder` — immutable record with `@Builder(toBuilder = true)` and `Objects.requireNonNull` compact-ctor on `fundingId`, `walletId`, `amountUsdc`, `status`
- `FundingStatus` enum: `PAYMENT_CONFIRMED`, `FUNDED`, `FAILED`, `REFUND_INITIATED`, `REFUNDED`, `REFUND_FAILED`
- `PaymentRequest`, `PaymentResult` — transport records for the payment gateway boundary

**Outbound ports** (`domain/funding/port/`)
- `PaymentGateway` — abstracts Stripe (`initiatePayment`, `refund`)
- `FundingOrderRepository` — `save`, `findByFundingId`, `findByStripePaymentIntentId`, `findByWalletIdAndStatusIn`
- `FundingWorkflowStarter` — abstracts Temporal workflow kickoff

**Domain exceptions** (`domain/funding/exception/`) — all private-ctor + static-factory, with `SP-XXXX` error codes. Codes SP-0020–SP-0025 confirmed unused before write. Pre-existing collisions at SP-0010/0011/0012/0013/0014 are known tech debt and **not** addressed here.
| Code | Exception | Trigger |
|---|---|---|
| SP-0020 | `FundingOrderNotFoundException` | Lookup miss |
| SP-0021 | `FundingFailedException` | Stripe PaymentIntent creation failed (with cause) |
| SP-0022 | `FundingAlreadyInProgressException` | In-flight PAYMENT_CONFIRMED order exists for wallet |
| SP-0023 | `RefundNotAllowedException` | Refund called on non-FUNDED order |
| SP-0024 | `RefundFailedException` | Stripe refund failure (with cause) |
| SP-0025 | `InsufficientBalanceForRefundException` | On-chain/DB balance insufficient for refund |

**Tests + fixtures**
- `FundingOrderTest` — 6 cases: toBuilder round-trip, status mutation, and null-rejection per required field (no coverage for nullable `id`, `stripePaymentIntentId`, `createdAt`, `updatedAt` per spec)
- `FundingExceptionTest` — 6 cases: each factory's message contains its `SP-00NN:` prefix and key fields; cause chaining verified for SP-0021/SP-0024
- `FundingOrderFixtures` in `src/testFixtures/` with `SOME_*` constants and a pre-populated `fundingOrderBuilder()` (matches `RemittanceFixtures` style)

## Acceptance Criteria

- [x] All models are Java records with `@Builder(toBuilder = true)`
- [x] No Spring imports in `model/` — Lombok only
- [x] Ports are plain interfaces — no annotations
- [x] All 6 exceptions created with `SP-XXXX` codes and static factory methods
- [x] Error codes SP-0020–SP-0025 don't conflict with existing codes
- [x] `./gradlew build` passes

## Checklist

- [x] `./gradlew build` passes (21 tasks, spotless clean, ArchUnit clean)
- [x] Unit tests added (`FundingOrderTest`, `FundingExceptionTest`)
- [ ] Integration tests added/updated — N/A for pure domain primitives
- [x] ArchUnit rules pass (domain has no Spring/jakarta.persistence imports; ports are interfaces)
- [x] Spotless formatting applied
- [x] Shared fixture placed in `src/testFixtures/` (not private methods)
- [x] BDD Mockito golden-rule assertions (`usingRecursiveComparison`) in domain tests

## Diff stats

16 files, +394 / -0

## Out of scope (follow-up issues)

- STA-74 — FundingOrder persistence (migration, entity, JPA repo, adapter)
- STA-75 — Stripe payment adapter implementing `PaymentGateway`
- STA-76 — Fund wallet endpoint
- STA-77 — Stripe webhook handler
- STA-78 — Real treasury adapter (SPL + SOL)
- STA-79 — `WalletFundingWorkflow` (Temporal)
- STA-80 — Refund funding endpoint
- STA-81 — Config + exception handler + Postman