### PR TITLE
docs: remove Documentation section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,22 +1326,6 @@ stablepay-hackathon/
 
 ---
 
-## Documentation
-
-| Document | Description |
-|---|---|
-| [CODING_STANDARDS.md](docs/CODING_STANDARDS.md) | Java/Spring Boot conventions |
-| [TESTING_STANDARDS.md](docs/TESTING_STANDARDS.md) | BDDMockito, recursive comparison, no generic matchers |
-| [SOLANA_CODING_STANDARDS.md](docs/SOLANA_CODING_STANDARDS.md) | Anchor program standards |
-| [ADR.md](docs/ADR.md) | Architecture decision records |
-| [E2E_FLOW.md](docs/E2E_FLOW.md) | End-to-end user journey |
-| [ROADMAP.md](docs/ROADMAP.md) | Implementation timeline |
-| [BRAINSTORM.md](docs/BRAINSTORM.md) | Market research and strategy |
-| [COMPETITIVE_ANALYSIS.md](docs/COMPETITIVE_ANALYSIS.md) | Market positioning analysis |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow |
-
----
-
 ## Contributing
 
 All work goes through feature branches and pull requests. Never commit directly to `main`.


### PR DESCRIPTION
## Summary

The README's `## Documentation` section duplicated links already present in the canonical docs table inside `CLAUDE.md`. Keeping the same link list in two places is drift-prone — one copy inevitably falls out of sync. `CLAUDE.md` is the single source of truth that coding agents and contributors are already directed to.

## Changes

- Remove `## Documentation` section from `README.md` (the 10-row table pointing at `docs/CODING_STANDARDS.md`, `docs/TESTING_STANDARDS.md`, `docs/ADR.md`, etc.)
- Remove the adjacent `---` separator so the `## Contributing` section flows cleanly after the preceding content block

## Checklist

- [x] No code changes — pure docs edit
- [x] Preserves section spacing around `## Contributing`
- [x] `CLAUDE.md` still surfaces all doc links via its own docs table

## Diff stats

1 file changed, -16 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Documentation" section from the README file, which previously contained references to documentation files and related resources, along with associated formatting elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->