### PR TITLE
STA-74: add funding order persistence layer

### DIFF
--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.stablepay.infrastructure.db.funding;
 
-import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -47,16 +47,6 @@ class FundingOrderRepositoryIntegrationTest {
         return walletRepository.save(wallet).id();
     }
 
-    private FundingOrder buildOrder(Long walletId, FundingStatus status, String paymentIntentId) {
-        return FundingOrder.builder()
-                .fundingId(UUID.randomUUID())
-                .walletId(walletId)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .stripePaymentIntentId(paymentIntentId)
-                .status(status)
-                .build();
-    }
-
     @Nested
     class Save {
 
@@ -64,7 +54,9 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldSaveAndAssignId() {
             // given
             var walletId = createWalletAndReturnId();
-            var order = buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_save_" + System.nanoTime());
+            var order = fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_save_" + System.nanoTime())
+                    .build();
 
             // when
             var saved = fundingOrderRepository.save(order);
@@ -81,8 +73,9 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldPersistStatusUpdates() {
             // given
             var walletId = createWalletAndReturnId();
-            var saved = fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_status_" + System.nanoTime()));
+            var saved = fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_status_" + System.nanoTime())
+                    .build());
 
             // when
             fundingOrderRepository.save(saved.toBuilder().status(FundingStatus.FUNDED).build());
@@ -101,8 +94,9 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldFindOrderByFundingId() {
             // given
             var walletId = createWalletAndReturnId();
-            var order = buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_findfid_" + System.nanoTime());
-            var saved = fundingOrderRepository.save(order);
+            var saved = fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_findfid_" + System.nanoTime())
+                    .build());
 
             // when
             var found = fundingOrderRepository.findByFundingId(saved.fundingId());
@@ -133,8 +127,9 @@ class FundingOrderRepositoryIntegrationTest {
             // given
             var walletId = createWalletAndReturnId();
             var paymentIntentId = "pi_findpi_" + System.nanoTime();
-            var saved = fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, paymentIntentId));
+            var saved = fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId(paymentIntentId)
+                    .build());
 
             // when
             var found = fundingOrderRepository.findByStripePaymentIntentId(paymentIntentId);
@@ -164,12 +159,17 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldReturnOrdersMatchingWalletAndStatuses() {
             // given
             var walletId = createWalletAndReturnId();
-            var confirmed = fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_in_confirmed_" + System.nanoTime()));
-            var funded = fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.FUNDED, "pi_in_funded_" + System.nanoTime()));
-            fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.FAILED, "pi_in_failed_" + System.nanoTime()));
+            var confirmed = fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_in_confirmed_" + System.nanoTime())
+                    .build());
+            var funded = fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .status(FundingStatus.FUNDED)
+                    .stripePaymentIntentId("pi_in_funded_" + System.nanoTime())
+                    .build());
+            fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .status(FundingStatus.FAILED)
+                    .stripePaymentIntentId("pi_in_failed_" + System.nanoTime())
+                    .build());
 
             // when
             var found = fundingOrderRepository.findByWalletIdAndStatusIn(
@@ -186,8 +186,9 @@ class FundingOrderRepositoryIntegrationTest {
             // given
             var walletId = createWalletAndReturnId();
             var otherWalletId = createWalletAndReturnId();
-            fundingOrderRepository.save(
-                    buildOrder(otherWalletId, FundingStatus.PAYMENT_CONFIRMED, "pi_other_" + System.nanoTime()));
+            fundingOrderRepository.save(fundingOrderBuilder(otherWalletId)
+                    .stripePaymentIntentId("pi_other_" + System.nanoTime())
+                    .build());
 
             // when
             var found = fundingOrderRepository.findByWalletIdAndStatusIn(
@@ -205,11 +206,13 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldRejectSecondActiveOrderForSameWallet() {
             // given
             var walletId = createWalletAndReturnId();
-            fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_active_a_" + System.nanoTime()));
+            fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_active_a_" + System.nanoTime())
+                    .build());
             entityManager.flush();
-            var duplicate = buildOrder(
-                    walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_active_b_" + System.nanoTime());
+            var duplicate = fundingOrderBuilder(walletId)
+                    .stripePaymentIntentId("pi_active_b_" + System.nanoTime())
+                    .build();
 
             // when / then
             assertThatThrownBy(() -> {
@@ -222,12 +225,18 @@ class FundingOrderRepositoryIntegrationTest {
         void shouldAllowMultipleNonActiveOrdersForSameWallet() {
             // given
             var walletId = createWalletAndReturnId();
-            fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.FUNDED, "pi_inactive_a_" + System.nanoTime()));
-            fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.FAILED, "pi_inactive_b_" + System.nanoTime()));
-            fundingOrderRepository.save(
-                    buildOrder(walletId, FundingStatus.REFUNDED, "pi_inactive_c_" + System.nanoTime()));
+            fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .status(FundingStatus.FUNDED)
+                    .stripePaymentIntentId("pi_inactive_a_" + System.nanoTime())
+                    .build());
+            fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .status(FundingStatus.FAILED)
+                    .stripePaymentIntentId("pi_inactive_b_" + System.nanoTime())
+                    .build());
+            fundingOrderRepository.save(fundingOrderBuilder(walletId)
+                    .status(FundingStatus.REFUNDED)
+                    .stripePaymentIntentId("pi_inactive_c_" + System.nanoTime())
+                    .build());
 
             // when
             entityManager.flush();

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.stablepay.infrastructure.db.funding;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.test.PgTest;
+
+@PgTest
+@Transactional
+class FundingOrderRepositoryIntegrationTest {
+
+    @Autowired
+    private FundingOrderRepository fundingOrderRepository;
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Long createWalletAndReturnId() {
+        var unique = String.valueOf(System.nanoTime());
+        var wallet = Wallet.builder()
+                .userId("funding-user-" + unique)
+                .solanaAddress("funding-addr-" + unique)
+                .availableBalance(BigDecimal.ZERO)
+                .totalBalance(BigDecimal.ZERO)
+                .build();
+        return walletRepository.save(wallet).id();
+    }
+
+    private FundingOrder buildOrder(Long walletId, FundingStatus status, String paymentIntentId) {
+        return FundingOrder.builder()
+                .fundingId(UUID.randomUUID())
+                .walletId(walletId)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .stripePaymentIntentId(paymentIntentId)
+                .status(status)
+                .build();
+    }
+
+    @Nested
+    class Save {
+
+        @Test
+        void shouldSaveAndAssignId() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var order = buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_save_" + System.nanoTime());
+
+            // when
+            var saved = fundingOrderRepository.save(order);
+
+            // then
+            assertThat(saved.id()).isNotNull();
+            assertThat(saved)
+                    .usingRecursiveComparison()
+                    .ignoringFields("id", "createdAt", "updatedAt")
+                    .isEqualTo(order);
+        }
+
+        @Test
+        void shouldPersistStatusUpdates() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var saved = fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_status_" + System.nanoTime()));
+
+            // when
+            fundingOrderRepository.save(saved.toBuilder().status(FundingStatus.FUNDED).build());
+
+            // then
+            var found = fundingOrderRepository.findByFundingId(saved.fundingId());
+            assertThat(found).isPresent();
+            assertThat(found.get().status()).isEqualTo(FundingStatus.FUNDED);
+        }
+    }
+
+    @Nested
+    class FindByFundingId {
+
+        @Test
+        void shouldFindOrderByFundingId() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var order = buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_findfid_" + System.nanoTime());
+            var saved = fundingOrderRepository.save(order);
+
+            // when
+            var found = fundingOrderRepository.findByFundingId(saved.fundingId());
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get())
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt", "updatedAt")
+                    .isEqualTo(saved);
+        }
+
+        @Test
+        void shouldReturnEmptyWhenFundingIdNotFound() {
+            // when
+            var found = fundingOrderRepository.findByFundingId(UUID.randomUUID());
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    class FindByStripePaymentIntentId {
+
+        @Test
+        void shouldFindOrderByStripePaymentIntentId() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var paymentIntentId = "pi_findpi_" + System.nanoTime();
+            var saved = fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, paymentIntentId));
+
+            // when
+            var found = fundingOrderRepository.findByStripePaymentIntentId(paymentIntentId);
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get())
+                    .usingRecursiveComparison()
+                    .ignoringFields("createdAt", "updatedAt")
+                    .isEqualTo(saved);
+        }
+
+        @Test
+        void shouldReturnEmptyWhenPaymentIntentIdNotFound() {
+            // when
+            var found = fundingOrderRepository.findByStripePaymentIntentId("pi_nonexistent");
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    class FindByWalletIdAndStatusIn {
+
+        @Test
+        void shouldReturnOrdersMatchingWalletAndStatuses() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var confirmed = fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_in_confirmed_" + System.nanoTime()));
+            var funded = fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.FUNDED, "pi_in_funded_" + System.nanoTime()));
+            fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.FAILED, "pi_in_failed_" + System.nanoTime()));
+
+            // when
+            var found = fundingOrderRepository.findByWalletIdAndStatusIn(
+                    walletId, List.of(FundingStatus.PAYMENT_CONFIRMED, FundingStatus.FUNDED));
+
+            // then
+            assertThat(found)
+                    .extracting(FundingOrder::id)
+                    .containsExactlyInAnyOrder(confirmed.id(), funded.id());
+        }
+
+        @Test
+        void shouldNotReturnOrdersFromOtherWallets() {
+            // given
+            var walletId = createWalletAndReturnId();
+            var otherWalletId = createWalletAndReturnId();
+            fundingOrderRepository.save(
+                    buildOrder(otherWalletId, FundingStatus.PAYMENT_CONFIRMED, "pi_other_" + System.nanoTime()));
+
+            // when
+            var found = fundingOrderRepository.findByWalletIdAndStatusIn(
+                    walletId, List.of(FundingStatus.PAYMENT_CONFIRMED));
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    class PartialUniqueIndex {
+
+        @Test
+        void shouldRejectSecondActiveOrderForSameWallet() {
+            // given
+            var walletId = createWalletAndReturnId();
+            fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_active_a_" + System.nanoTime()));
+            entityManager.flush();
+            var duplicate = buildOrder(
+                    walletId, FundingStatus.PAYMENT_CONFIRMED, "pi_active_b_" + System.nanoTime());
+
+            // when / then
+            assertThatThrownBy(() -> {
+                fundingOrderRepository.save(duplicate);
+                entityManager.flush();
+            }).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        void shouldAllowMultipleNonActiveOrdersForSameWallet() {
+            // given
+            var walletId = createWalletAndReturnId();
+            fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.FUNDED, "pi_inactive_a_" + System.nanoTime()));
+            fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.FAILED, "pi_inactive_b_" + System.nanoTime()));
+            fundingOrderRepository.save(
+                    buildOrder(walletId, FundingStatus.REFUNDED, "pi_inactive_c_" + System.nanoTime()));
+
+            // when
+            entityManager.flush();
+            var found = fundingOrderRepository.findByWalletIdAndStatusIn(
+                    walletId, List.of(FundingStatus.FUNDED, FundingStatus.FAILED, FundingStatus.REFUNDED));
+
+            // then
+            assertThat(found).hasSize(3);
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderEntity.java
@@ -1,0 +1,59 @@
+package com.stablepay.infrastructure.db.funding;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "funding_orders")
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FundingOrderEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "funding_id", nullable = false, unique = true)
+    private UUID fundingId;
+
+    @Column(name = "wallet_id", nullable = false)
+    private Long walletId;
+
+    @Column(name = "amount_usdc", nullable = false, precision = 19, scale = 6)
+    private BigDecimal amountUsdc;
+
+    @Column(name = "stripe_payment_intent_id", unique = true)
+    private String stripePaymentIntentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private FundingStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderEntityMapper.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderEntityMapper.java
@@ -1,0 +1,11 @@
+package com.stablepay.infrastructure.db.funding;
+
+import org.mapstruct.Mapper;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+
+@Mapper
+public interface FundingOrderEntityMapper {
+    FundingOrder toDomain(FundingOrderEntity entity);
+    FundingOrderEntity toEntity(FundingOrder domain);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderJpaRepository.java
@@ -1,0 +1,15 @@
+package com.stablepay.infrastructure.db.funding;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+
+interface FundingOrderJpaRepository extends JpaRepository<FundingOrderEntity, Long> {
+    Optional<FundingOrderEntity> findByFundingId(UUID fundingId);
+    Optional<FundingOrderEntity> findByStripePaymentIntentId(String stripePaymentIntentId);
+    List<FundingOrderEntity> findByWalletIdAndStatusIn(Long walletId, List<FundingStatus> statuses);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryAdapter.java
@@ -1,0 +1,51 @@
+package com.stablepay.infrastructure.db.funding;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class FundingOrderRepositoryAdapter implements FundingOrderRepository {
+
+    private final FundingOrderJpaRepository jpaRepository;
+    private final FundingOrderEntityMapper mapper;
+
+    @Override
+    public FundingOrder save(FundingOrder order) {
+        var entity = mapper.toEntity(order);
+        var now = Instant.now();
+        if (entity.getCreatedAt() == null) {
+            entity.setCreatedAt(now);
+        }
+        entity.setUpdatedAt(now);
+        var saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<FundingOrder> findByFundingId(UUID fundingId) {
+        return jpaRepository.findByFundingId(fundingId).map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<FundingOrder> findByStripePaymentIntentId(String paymentIntentId) {
+        return jpaRepository.findByStripePaymentIntentId(paymentIntentId).map(mapper::toDomain);
+    }
+
+    @Override
+    public List<FundingOrder> findByWalletIdAndStatusIn(Long walletId, List<FundingStatus> statuses) {
+        return jpaRepository.findByWalletIdAndStatusIn(walletId, statuses).stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+}

--- a/backend/src/main/resources/db/migration/V5__create_funding_orders.sql
+++ b/backend/src/main/resources/db/migration/V5__create_funding_orders.sql
@@ -1,0 +1,18 @@
+CREATE TABLE funding_orders (
+    id                         BIGSERIAL PRIMARY KEY,
+    funding_id                 UUID UNIQUE NOT NULL,
+    wallet_id                  BIGINT NOT NULL REFERENCES wallets(id),
+    amount_usdc                NUMERIC(19, 6) NOT NULL,
+    stripe_payment_intent_id   VARCHAR(255) UNIQUE,
+    status                     VARCHAR(50) NOT NULL DEFAULT 'PAYMENT_CONFIRMED',
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                 TIMESTAMPTZ
+);
+
+CREATE INDEX idx_funding_orders_wallet_id ON funding_orders(wallet_id);
+CREATE INDEX idx_funding_orders_stripe_pi ON funding_orders(stripe_payment_intent_id);
+CREATE INDEX idx_funding_orders_status ON funding_orders(status);
+
+CREATE UNIQUE INDEX idx_funding_orders_one_active_per_wallet
+    ON funding_orders(wallet_id)
+    WHERE status = 'PAYMENT_CONFIRMED';

--- a/backend/src/test/java/com/stablepay/infrastructure/db/funding/FundingOrderEntityMapperTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/funding/FundingOrderEntityMapperTest.java
@@ -1,0 +1,59 @@
+package com.stablepay.infrastructure.db.funding;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ORDER_DB_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_UPDATED_AT;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+
+class FundingOrderEntityMapperTest {
+
+    private final FundingOrderEntityMapper mapper = new FundingOrderEntityMapperImpl();
+
+    @Test
+    void shouldMapDomainToEntityAndBack() {
+        // given
+        var domain = fundingOrderBuilder().build();
+
+        // when
+        var entity = mapper.toEntity(domain);
+        var backToDomain = mapper.toDomain(entity);
+
+        // then
+        assertThat(backToDomain)
+                .usingRecursiveComparison()
+                .isEqualTo(domain);
+    }
+
+    @Test
+    void shouldMapEntityToDomainWithAllFields() {
+        // given
+        var entity = FundingOrderEntity.builder()
+                .id(SOME_FUNDING_ORDER_DB_ID)
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .status(FundingStatus.PAYMENT_CONFIRMED)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        // when
+        var domain = mapper.toDomain(entity);
+
+        // then
+        var expected = fundingOrderBuilder().build();
+        assertThat(domain)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/FundingOrderFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/FundingOrderFixtures.java
@@ -30,4 +30,12 @@ public final class FundingOrderFixtures {
                 .createdAt(SOME_CREATED_AT)
                 .updatedAt(SOME_UPDATED_AT);
     }
+
+    public static FundingOrder.FundingOrderBuilder fundingOrderBuilder(Long walletId) {
+        return FundingOrder.builder()
+                .fundingId(UUID.randomUUID())
+                .walletId(walletId)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .status(FundingStatus.PAYMENT_CONFIRMED);
+    }
 }

--- a/docs/specs/2026-04-16-stripe-onramp-spec.md
+++ b/docs/specs/2026-04-16-stripe-onramp-spec.md
@@ -375,8 +375,8 @@ CREATE TABLE funding_orders (
     amount_usdc                NUMERIC(19, 6) NOT NULL,
     stripe_payment_intent_id   VARCHAR(255) UNIQUE,
     status                     VARCHAR(50) NOT NULL DEFAULT 'PAYMENT_CONFIRMED',
-    created_at                 TIMESTAMP NOT NULL DEFAULT now(),
-    updated_at                 TIMESTAMP
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                 TIMESTAMPTZ
 );
 
 CREATE INDEX idx_funding_orders_wallet_id ON funding_orders(wallet_id);
@@ -757,3 +757,4 @@ Sender              API              Solana           Stripe
 | 28 | CompleteFundingHandler idempotency missed refund terminal states | Added REFUND_INITIATED, REFUNDED, REFUND_FAILED to the "ignore silently" list. A stale webhook replay after a refund must not re-start the funding workflow. |
 | 29 | Concurrent fund requests can race past the duplicate-order check | Added partial unique index `UNIQUE(wallet_id) WHERE status = 'PAYMENT_CONFIRMED'`. Handler catches `DataIntegrityViolationException` and maps to SP-0022. |
 | 30 | Webhook endpoint security config not specified | `/webhooks/stripe` must be permitted without auth and excluded from CSRF. Signature verification via `Webhook.constructEvent(payload, sig, secret, 300)` is the authentication mechanism. |
+| 31 | `funding_orders.created_at`/`updated_at` typed as `TIMESTAMP` would lose timezone info | Switched to `TIMESTAMPTZ` in V5 migration to match V1–V4 (`wallets`, `remittances`, `claim_tokens`) and round-trip cleanly with Java `Instant`. Same 8-byte storage; normalizes to UTC on write. |


### PR DESCRIPTION
## STA Issue
Closes #151

## Changes
- Add Flyway `V5__create_funding_orders.sql` migration: `funding_orders` table, FK to `wallets(id)`, indexes on `wallet_id` / `stripe_payment_intent_id` / `status`, plus partial unique index `idx_funding_orders_one_active_per_wallet` enforcing a single in-flight `PAYMENT_CONFIRMED` order per wallet (DB-level backstop for the race past the handler check, surfaces as `DataIntegrityViolationException`).
- Add `FundingOrderEntity` JPA mapping with `@Enumerated(STRING)` for status and `updatable = false` on `created_at`.
- Add `FundingOrderEntityMapper` (MapStruct, Spring component model from global compiler arg).
- Add package-private `FundingOrderJpaRepository` with `findByFundingId`, `findByStripePaymentIntentId`, and `findByWalletIdAndStatusIn`.
- Add `FundingOrderRepositoryAdapter` implementing the `FundingOrderRepository` domain port; sets `createdAt`/`updatedAt` on save.
- Add `FundingOrderEntityMapperTest` (round-trip + entity→domain field mapping).
- Add `FundingOrderRepositoryIntegrationTest` covering save, status updates, all three finders, partial unique index enforcement (`DataIntegrityViolationException`), and negative case for non-active statuses.

## Checklist
- [x] `./gradlew build` passes (spotless + unit + ArchUnit)
- [x] Unit tests added (mapper round trip)
- [x] Integration tests added (`./gradlew integrationTest` passes)
- [x] ArchUnit rules pass (no `domain` → `infrastructure` imports introduced)
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)