### PR TITLE
STA-75: Stripe payment adapter (PaymentIntent + refund via Java SDK)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -186,6 +186,9 @@ dependencies {
     // Twilio SMS
     implementation("com.twilio.sdk:twilio:11.3.6")
 
+    // Stripe
+    implementation("com.stripe:stripe-java:28.2.0")
+
     // Test
     testCompileOnly("org.projectlombok:lombok:1.18.44")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.44")

--- a/backend/src/integration-test/resources/application-test.yml
+++ b/backend/src/integration-test/resources/application-test.yml
@@ -4,3 +4,7 @@ stablepay:
     workflow-run-timeout: PT2H
     claim-expiry-timeout: PT48H
     claim-base-url: https://claim.stablepay.app/
+  stripe:
+    api-key: sk_test_stablepay
+    test-mode: true
+    auto-confirm: true

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/FundingFailedException.java
@@ -6,6 +6,10 @@ public class FundingFailedException extends RuntimeException {
         return new FundingFailedException("SP-0021: Stripe payment failed: " + message, cause);
     }
 
+    public static FundingFailedException invalidRequest(String message) {
+        return new FundingFailedException("SP-0022: Invalid funding request: " + message, null);
+    }
+
     private FundingFailedException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeConfig.java
@@ -6,13 +6,11 @@ import org.springframework.context.annotation.Configuration;
 
 import com.stripe.StripeClient;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
 @EnableConfigurationProperties(StripeProperties.class)
-@RequiredArgsConstructor
 public class StripeConfig {
 
     @Bean

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeConfig.java
@@ -1,0 +1,24 @@
+package com.stablepay.infrastructure.stripe;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.stripe.StripeClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(StripeProperties.class)
+@RequiredArgsConstructor
+public class StripeConfig {
+
+    @Bean
+    public StripeClient stripeClient(StripeProperties properties) {
+        log.info("Initializing Stripe client (testMode={}, autoConfirm={})",
+                properties.testMode(), properties.autoConfirm());
+        return new StripeClient(properties.apiKey());
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
@@ -1,7 +1,6 @@
 package com.stablepay.infrastructure.stripe;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 
@@ -27,6 +26,7 @@ public class StripePaymentAdapter implements PaymentGateway {
 
     @Override
     public PaymentResult initiatePayment(PaymentRequest request) {
+        validateAmount(request.amountUsdc(), "amountUsdc");
         log.info("Initiating Stripe PaymentIntent fundingId={} walletId={}",
                 request.fundingId(), request.walletId());
         try {
@@ -38,7 +38,9 @@ public class StripePaymentAdapter implements PaymentGateway {
                     .status(intent.getStatus())
                     .build();
         } catch (StripeException e) {
-            throw FundingFailedException.stripeError(e.getMessage(), e);
+            log.warn("Stripe PaymentIntent creation failed fundingId={} code={} status={} requestId={}",
+                    request.fundingId(), e.getCode(), e.getStatusCode(), e.getRequestId(), e);
+            throw FundingFailedException.stripeError("[" + e.getCode() + "] " + e.getMessage(), e);
         } catch (ArithmeticException e) {
             throw FundingFailedException.stripeError(
                     "Amount precision exceeds Stripe's cent granularity", e);
@@ -47,14 +49,18 @@ public class StripePaymentAdapter implements PaymentGateway {
 
     @Override
     public void refund(String paymentIntentId, BigDecimal amount) {
-        Objects.requireNonNull(paymentIntentId, "paymentIntentId");
-        Objects.requireNonNull(amount, "amount");
+        if (paymentIntentId == null || paymentIntentId.isBlank()) {
+            throw FundingFailedException.invalidRequest("paymentIntentId is required for refund");
+        }
+        validateAmount(amount, "refund amount");
         log.info("Initiating Stripe refund paymentIntentId={}", paymentIntentId);
         try {
             var params = buildRefundParams(paymentIntentId, amount);
             stripeClient.refunds().create(params);
         } catch (StripeException e) {
-            throw FundingFailedException.stripeError(e.getMessage(), e);
+            log.warn("Stripe refund failed paymentIntentId={} code={} status={} requestId={}",
+                    paymentIntentId, e.getCode(), e.getStatusCode(), e.getRequestId(), e);
+            throw FundingFailedException.stripeError("[" + e.getCode() + "] " + e.getMessage(), e);
         } catch (ArithmeticException e) {
             throw FundingFailedException.stripeError(
                     "Amount precision exceeds Stripe's cent granularity", e);
@@ -82,5 +88,14 @@ public class StripePaymentAdapter implements PaymentGateway {
                 .setPaymentIntent(paymentIntentId)
                 .setAmount(cents)
                 .build();
+    }
+
+    private void validateAmount(BigDecimal amount, String fieldName) {
+        if (amount == null) {
+            throw FundingFailedException.invalidRequest(fieldName + " is required");
+        }
+        if (amount.signum() <= 0) {
+            throw FundingFailedException.invalidRequest(fieldName + " must be positive");
+        }
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
@@ -1,0 +1,82 @@
+package com.stablepay.infrastructure.stripe;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.funding.exception.FundingFailedException;
+import com.stablepay.domain.funding.model.PaymentRequest;
+import com.stablepay.domain.funding.model.PaymentResult;
+import com.stablepay.domain.funding.port.PaymentGateway;
+import com.stripe.StripeClient;
+import com.stripe.exception.StripeException;
+import com.stripe.param.PaymentIntentCreateParams;
+import com.stripe.param.RefundCreateParams;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StripePaymentAdapter implements PaymentGateway {
+
+    private final StripeClient stripeClient;
+    private final StripeProperties stripeProperties;
+
+    @Override
+    public PaymentResult initiatePayment(PaymentRequest request) {
+        log.info("Initiating Stripe PaymentIntent fundingId={} walletId={}",
+                request.fundingId(), request.walletId());
+        try {
+            var params = buildPaymentIntentParams(request);
+            var intent = stripeClient.paymentIntents().create(params);
+            return PaymentResult.builder()
+                    .pspReference(intent.getId())
+                    .clientSecret(intent.getClientSecret())
+                    .status(intent.getStatus())
+                    .build();
+        } catch (StripeException e) {
+            throw FundingFailedException.stripeError(e.getMessage(), e);
+        } catch (ArithmeticException e) {
+            throw FundingFailedException.stripeError(
+                    "Amount precision exceeds Stripe's cent granularity", e);
+        }
+    }
+
+    @Override
+    public void refund(String paymentIntentId, BigDecimal amount) {
+        log.info("Initiating Stripe refund paymentIntentId={}", paymentIntentId);
+        try {
+            var params = buildRefundParams(paymentIntentId, amount);
+            stripeClient.refunds().create(params);
+        } catch (StripeException e) {
+            throw FundingFailedException.stripeError(e.getMessage(), e);
+        } catch (ArithmeticException e) {
+            throw FundingFailedException.stripeError(
+                    "Amount precision exceeds Stripe's cent granularity", e);
+        }
+    }
+
+    private PaymentIntentCreateParams buildPaymentIntentParams(PaymentRequest request) {
+        var cents = request.amountUsdc().movePointRight(2).longValueExact();
+        var builder = PaymentIntentCreateParams.builder()
+                .setAmount(cents)
+                .setCurrency(stripeProperties.currency())
+                .putMetadata("funding_id", request.fundingId().toString())
+                .putMetadata("wallet_id", request.walletId().toString());
+        if (stripeProperties.testMode() && stripeProperties.autoConfirm()) {
+            builder.setConfirm(true);
+            builder.setPaymentMethod(stripeProperties.testPaymentMethod());
+        }
+        return builder.build();
+    }
+
+    private RefundCreateParams buildRefundParams(String paymentIntentId, BigDecimal amount) {
+        var cents = amount.movePointRight(2).longValueExact();
+        return RefundCreateParams.builder()
+                .setPaymentIntent(paymentIntentId)
+                .setAmount(cents)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.stripe;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 
@@ -46,6 +47,8 @@ public class StripePaymentAdapter implements PaymentGateway {
 
     @Override
     public void refund(String paymentIntentId, BigDecimal amount) {
+        Objects.requireNonNull(paymentIntentId, "paymentIntentId");
+        Objects.requireNonNull(amount, "amount");
         log.info("Initiating Stripe refund paymentIntentId={}", paymentIntentId);
         try {
             var params = buildRefundParams(paymentIntentId, amount);
@@ -60,9 +63,10 @@ public class StripePaymentAdapter implements PaymentGateway {
 
     private PaymentIntentCreateParams buildPaymentIntentParams(PaymentRequest request) {
         var cents = request.amountUsdc().movePointRight(2).longValueExact();
+        var currency = request.currency() != null ? request.currency() : stripeProperties.currency();
         var builder = PaymentIntentCreateParams.builder()
                 .setAmount(cents)
-                .setCurrency(stripeProperties.currency())
+                .setCurrency(currency)
                 .putMetadata("funding_id", request.fundingId().toString())
                 .putMetadata("wallet_id", request.walletId().toString());
         if (stripeProperties.testMode() && stripeProperties.autoConfirm()) {

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
@@ -1,0 +1,18 @@
+package com.stablepay.infrastructure.stripe;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Builder;
+
+@ConfigurationProperties(prefix = "stablepay.stripe")
+@Validated
+@Builder(toBuilder = true)
+public record StripeProperties(
+    String apiKey,
+    String webhookSecret,
+    boolean testMode,
+    boolean autoConfirm,
+    String testPaymentMethod,
+    String currency
+) {}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
@@ -1,12 +1,10 @@
 package com.stablepay.infrastructure.stripe;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
 
 import lombok.Builder;
 
 @ConfigurationProperties(prefix = "stablepay.stripe")
-@Validated
 @Builder(toBuilder = true)
 public record StripeProperties(
     String apiKey,

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
@@ -1,16 +1,21 @@
 package com.stablepay.infrastructure.stripe;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import lombok.Builder;
 
 @ConfigurationProperties(prefix = "stablepay.stripe")
+@Validated
 @Builder(toBuilder = true)
 public record StripeProperties(
-    String apiKey,
+    @NotBlank @Pattern(regexp = "^sk_.+", message = "apiKey must start with sk_") String apiKey,
     String webhookSecret,
     boolean testMode,
     boolean autoConfirm,
     String testPaymentMethod,
-    String currency
+    @NotBlank String currency
 ) {}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -15,3 +15,7 @@ spring:
 stablepay:
   mpc:
     enabled: false
+  stripe:
+    api-key: sk_test_stablepay
+    test-mode: true
+    auto-confirm: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -51,6 +51,13 @@ stablepay:
     escrow-program-id: ${STABLEPAY_ESCROW_PROGRAM_ID:7C2zsbhgDnxQuC1Nd2rzXQfsfnKazQWFpoUJNqS8zWij}
     usdc-mint: ${USDC_MINT:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU}
     claim-authority-private-key: ${CLAIM_AUTHORITY_PRIVATE_KEY:}
+  stripe:
+    api-key: ${STRIPE_API_KEY:}
+    webhook-secret: ${STRIPE_WEBHOOK_SECRET:}
+    test-mode: ${STRIPE_TEST_MODE:true}
+    auto-confirm: ${STRIPE_AUTO_CONFIRM:true}
+    test-payment-method: ${STRIPE_TEST_PAYMENT_METHOD:pm_card_visa}
+    currency: ${STRIPE_CURRENCY:usd}
   transak:
     enabled: ${TRANSAK_ENABLED:false}
     api-key: ${TRANSAK_API_KEY:}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,8 +54,8 @@ stablepay:
   stripe:
     api-key: ${STRIPE_API_KEY:}
     webhook-secret: ${STRIPE_WEBHOOK_SECRET:}
-    test-mode: ${STRIPE_TEST_MODE:true}
-    auto-confirm: ${STRIPE_AUTO_CONFIRM:true}
+    test-mode: ${STRIPE_TEST_MODE:false}
+    auto-confirm: ${STRIPE_AUTO_CONFIRM:false}
     test-payment-method: ${STRIPE_TEST_PAYMENT_METHOD:pm_card_visa}
     currency: ${STRIPE_CURRENCY:usd}
   transak:

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
@@ -1,0 +1,257 @@
+package com.stablepay.infrastructure.stripe;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_API_KEY;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_CLIENT_SECRET;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_CURRENCY;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_PAYMENT_INTENT_STATUS;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_TEST_PAYMENT_METHOD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.exception.FundingFailedException;
+import com.stablepay.domain.funding.model.PaymentRequest;
+import com.stablepay.domain.funding.model.PaymentResult;
+import com.stripe.StripeClient;
+import com.stripe.exception.ApiException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.PaymentIntent;
+import com.stripe.model.Refund;
+import com.stripe.param.PaymentIntentCreateParams;
+import com.stripe.param.RefundCreateParams;
+import com.stripe.service.PaymentIntentService;
+import com.stripe.service.RefundService;
+
+@ExtendWith(MockitoExtension.class)
+class StripePaymentAdapterTest {
+
+    @Mock
+    private StripeClient stripeClient;
+
+    @Mock
+    private PaymentIntentService paymentIntentService;
+
+    @Mock
+    private RefundService refundService;
+
+    @Mock
+    private PaymentIntent paymentIntent;
+
+    @Mock
+    private Refund refund;
+
+    @Captor
+    private ArgumentCaptor<PaymentIntentCreateParams> paymentIntentParamsCaptor;
+
+    @Captor
+    private ArgumentCaptor<RefundCreateParams> refundParamsCaptor;
+
+    private StripeProperties testModeProperties;
+    private StripeProperties autoConfirmDisabledProperties;
+    private StripePaymentAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        testModeProperties = StripeProperties.builder()
+                .apiKey(SOME_STRIPE_API_KEY)
+                .webhookSecret("")
+                .testMode(true)
+                .autoConfirm(true)
+                .testPaymentMethod(SOME_STRIPE_TEST_PAYMENT_METHOD)
+                .currency(SOME_STRIPE_CURRENCY)
+                .build();
+        autoConfirmDisabledProperties = testModeProperties.toBuilder()
+                .autoConfirm(false)
+                .build();
+        adapter = new StripePaymentAdapter(stripeClient, testModeProperties);
+    }
+
+    @Test
+    void shouldCreatePaymentIntentWithConfirmAndPaymentMethodWhenTestModeAndAutoConfirm() throws StripeException {
+        // given
+        var request = paymentRequest();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        adapter.initiatePayment(request);
+
+        // then
+        var expected = PaymentIntentCreateParams.builder()
+                .setAmount(2500L)
+                .setCurrency(SOME_STRIPE_CURRENCY)
+                .putMetadata("funding_id", SOME_FUNDING_ID.toString())
+                .putMetadata("wallet_id", SOME_WALLET_ID.toString())
+                .setConfirm(true)
+                .setPaymentMethod(SOME_STRIPE_TEST_PAYMENT_METHOD)
+                .build();
+        assertThat(paymentIntentParamsCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldCreatePaymentIntentWithoutConfirmWhenAutoConfirmDisabled() throws StripeException {
+        // given
+        adapter = new StripePaymentAdapter(stripeClient, autoConfirmDisabledProperties);
+        var request = paymentRequest();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        adapter.initiatePayment(request);
+
+        // then
+        var expected = PaymentIntentCreateParams.builder()
+                .setAmount(2500L)
+                .setCurrency(SOME_STRIPE_CURRENCY)
+                .putMetadata("funding_id", SOME_FUNDING_ID.toString())
+                .putMetadata("wallet_id", SOME_WALLET_ID.toString())
+                .build();
+        assertThat(paymentIntentParamsCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldIncludeFundingIdAndWalletIdInMetadata() throws StripeException {
+        // given
+        var request = paymentRequest();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        adapter.initiatePayment(request);
+
+        // then
+        var expectedMetadata = Map.of(
+                "funding_id", SOME_FUNDING_ID.toString(),
+                "wallet_id", SOME_WALLET_ID.toString());
+        assertThat(paymentIntentParamsCaptor.getValue().getMetadata())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedMetadata);
+    }
+
+    @Test
+    void shouldReturnPaymentResultFromPaymentIntent() throws StripeException {
+        // given
+        var request = paymentRequest();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        var result = adapter.initiatePayment(request);
+
+        // then
+        var expected = PaymentResult.builder()
+                .pspReference(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .clientSecret(SOME_STRIPE_CLIENT_SECRET)
+                .status(SOME_STRIPE_PAYMENT_INTENT_STATUS)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldWrapStripeExceptionInFundingFailedException() throws StripeException {
+        // given
+        var request = paymentRequest();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        var stripeException = new ApiException(
+                "card_declined", "req_abc", "card_error", 402, null);
+        willThrow(stripeException).given(paymentIntentService).create(paymentIntentParamsCaptor.capture());
+
+        // when / then
+        assertThatThrownBy(() -> adapter.initiatePayment(request))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0021")
+                .hasCause(stripeException);
+    }
+
+    @Test
+    void shouldWrapArithmeticExceptionInFundingFailedException() {
+        // given
+        var overflowingAmount = new BigDecimal("92233720368547758.08");
+        var request = PaymentRequest.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(overflowingAmount)
+                .currency(SOME_STRIPE_CURRENCY)
+                .build();
+
+        // when / then
+        assertThatThrownBy(() -> adapter.initiatePayment(request))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0021")
+                .hasMessageContaining("Amount precision")
+                .hasCauseInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    void shouldRefundViaStripe() throws StripeException {
+        // given
+        given(stripeClient.refunds()).willReturn(refundService);
+        given(refundService.create(refundParamsCaptor.capture())).willReturn(refund);
+
+        // when
+        adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC);
+
+        // then
+        var expected = RefundCreateParams.builder()
+                .setPaymentIntent(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .setAmount(2500L)
+                .build();
+        assertThat(refundParamsCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldWrapStripeExceptionOnRefund() throws StripeException {
+        // given
+        given(stripeClient.refunds()).willReturn(refundService);
+        var stripeException = new ApiException(
+                "charge_already_refunded", "req_xyz", "invalid_request_error", 400, null);
+        willThrow(stripeException).given(refundService).create(refundParamsCaptor.capture());
+
+        // when / then
+        assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0021")
+                .hasCause(stripeException);
+    }
+
+    private PaymentRequest paymentRequest() {
+        return PaymentRequest.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .currency(SOME_STRIPE_CURRENCY)
+                .build();
+    }
+
+    private void stubPaymentIntentGetters() {
+        given(paymentIntent.getId()).willReturn(SOME_STRIPE_PAYMENT_INTENT_ID);
+        given(paymentIntent.getClientSecret()).willReturn(SOME_STRIPE_CLIENT_SECRET);
+        given(paymentIntent.getStatus()).willReturn(SOME_STRIPE_PAYMENT_INTENT_STATUS);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
@@ -184,6 +184,7 @@ class StripePaymentAdapterTest {
         assertThatThrownBy(() -> adapter.initiatePayment(request))
                 .isInstanceOf(FundingFailedException.class)
                 .hasMessageContaining("SP-0021")
+                .hasMessageContaining("[card_error]")
                 .hasCause(stripeException);
     }
 
@@ -254,16 +255,77 @@ class StripePaymentAdapterTest {
     void shouldRejectNullAmountOnRefund() {
         // when / then
         assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("amount");
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("refund amount is required");
     }
 
     @Test
     void shouldRejectNullPaymentIntentIdOnRefund() {
         // when / then
         assertThatThrownBy(() -> adapter.refund(null, SOME_AMOUNT_USDC))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("paymentIntentId");
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("paymentIntentId is required");
+    }
+
+    @Test
+    void shouldRejectBlankPaymentIntentIdOnRefund() {
+        // when / then
+        assertThatThrownBy(() -> adapter.refund("   ", SOME_AMOUNT_USDC))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("paymentIntentId is required");
+    }
+
+    @Test
+    void shouldRejectNonPositiveAmountOnRefund() {
+        // when / then
+        assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, BigDecimal.ZERO))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("refund amount must be positive");
+    }
+
+    @Test
+    void shouldRejectNullAmountOnInitiatePayment() {
+        // given
+        var request = PaymentRequest.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .currency(SOME_STRIPE_CURRENCY)
+                .build();
+
+        // when / then
+        assertThatThrownBy(() -> adapter.initiatePayment(request))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("amountUsdc is required");
+    }
+
+    @Test
+    void shouldRejectNonPositiveAmountOnInitiatePayment() {
+        // given
+        var request = paymentRequest().toBuilder().amountUsdc(BigDecimal.ZERO).build();
+
+        // when / then
+        assertThatThrownBy(() -> adapter.initiatePayment(request))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0022")
+                .hasMessageContaining("amountUsdc must be positive");
+    }
+
+    @Test
+    void shouldWrapArithmeticExceptionOnRefund() {
+        // given
+        var overflowingAmount = new BigDecimal("92233720368547758.08");
+
+        // when / then
+        assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, overflowingAmount))
+                .isInstanceOf(FundingFailedException.class)
+                .hasMessageContaining("SP-0021")
+                .hasMessageContaining("Amount precision")
+                .hasCauseInstanceOf(ArithmeticException.class);
     }
 
     @Test
@@ -297,6 +359,7 @@ class StripePaymentAdapterTest {
         assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC))
                 .isInstanceOf(FundingFailedException.class)
                 .hasMessageContaining("SP-0021")
+                .hasMessageContaining("[invalid_request_error]")
                 .hasCause(stripeException);
     }
 

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
@@ -207,6 +207,66 @@ class StripePaymentAdapterTest {
     }
 
     @Test
+    void shouldUseCurrencyFromRequestWhenProvided() throws StripeException {
+        // given
+        var request = paymentRequest().toBuilder().currency("eur").build();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        adapter.initiatePayment(request);
+
+        // then
+        var expected = PaymentIntentCreateParams.builder()
+                .setAmount(2500L)
+                .setCurrency("eur")
+                .putMetadata("funding_id", SOME_FUNDING_ID.toString())
+                .putMetadata("wallet_id", SOME_WALLET_ID.toString())
+                .setConfirm(true)
+                .setPaymentMethod(SOME_STRIPE_TEST_PAYMENT_METHOD)
+                .build();
+        assertThat(paymentIntentParamsCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldFallBackToConfigCurrencyWhenRequestCurrencyNull() throws StripeException {
+        // given
+        var request = PaymentRequest.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .build();
+        given(stripeClient.paymentIntents()).willReturn(paymentIntentService);
+        given(paymentIntentService.create(paymentIntentParamsCaptor.capture())).willReturn(paymentIntent);
+        stubPaymentIntentGetters();
+
+        // when
+        adapter.initiatePayment(request);
+
+        // then
+        assertThat(paymentIntentParamsCaptor.getValue().getCurrency()).isEqualTo(SOME_STRIPE_CURRENCY);
+    }
+
+    @Test
+    void shouldRejectNullAmountOnRefund() {
+        // when / then
+        assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("amount");
+    }
+
+    @Test
+    void shouldRejectNullPaymentIntentIdOnRefund() {
+        // when / then
+        assertThatThrownBy(() -> adapter.refund(null, SOME_AMOUNT_USDC))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("paymentIntentId");
+    }
+
+    @Test
     void shouldRefundViaStripe() throws StripeException {
         // given
         given(stripeClient.refunds()).willReturn(refundService);

--- a/backend/src/testFixtures/java/com/stablepay/testutil/StripeFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/StripeFixtures.java
@@ -1,0 +1,12 @@
+package com.stablepay.testutil;
+
+public final class StripeFixtures {
+
+    private StripeFixtures() {}
+
+    public static final String SOME_STRIPE_CLIENT_SECRET = "pi_3MnTest0123456789_secret_abcdef";
+    public static final String SOME_STRIPE_PAYMENT_INTENT_STATUS = "requires_payment_method";
+    public static final String SOME_STRIPE_API_KEY = "sk_test_stablepay";
+    public static final String SOME_STRIPE_TEST_PAYMENT_METHOD = "pm_card_visa";
+    public static final String SOME_STRIPE_CURRENCY = "usd";
+}


### PR DESCRIPTION
## STA Issue
Closes #152

## Changes
- Add `com.stripe:stripe-java:28.2.0` dependency to `backend/build.gradle.kts`.
- `infrastructure/stripe/StripeProperties` — `@ConfigurationProperties` record bound to `stablepay.stripe.*` (api-key, webhook-secret, test-mode, auto-confirm, test-payment-method, currency).
- `infrastructure/stripe/StripeConfig` — exposes a `StripeClient` `@Bean` built from the configured api-key.
- `infrastructure/stripe/StripePaymentAdapter` — implements the `PaymentGateway` domain port:
  - `initiatePayment` creates a `PaymentIntent` and stamps `funding_id` + `wallet_id` metadata (funding_id is the STA-77 webhook lookup key).
  - Auto-confirms with `pm_card_visa` only when `testMode && autoConfirm`.
  - Converts `BigDecimal` USDC to Stripe cents via `movePointRight(2).longValueExact()`.
  - Wraps `StripeException` and defensive `ArithmeticException` into `FundingFailedException.stripeError` (SP-0021).
  - `refund` creates a Stripe refund for a given `paymentIntentId`.
- `StripePaymentAdapterTest` — mocks `StripeClient`, verifies `PaymentIntentCreateParams` / `RefundCreateParams`, metadata, test-mode gating, and exception translation.
- `testutil/StripeFixtures` — shared constants for Stripe tests.
- `application.yml` — adds `stablepay.stripe` block wired to `STRIPE_*` env vars with safe defaults.

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (`StripePaymentAdapterTest`)
- [ ] Integration tests — N/A for this slice; full E2E lives in STA-82
- [x] ArchUnit rules pass (covered by `./gradlew build`)
- [x] Spotless formatting applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stripe payment gateway integration now available, enabling payment initiation and refund processing
  * Configurable test mode for development environments

* **Tests**
  * Added comprehensive test coverage for payment adapter functionality

* **Chores**
  * Integrated Stripe SDK dependency and configuration infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->