### PR TITLE
STA-77: add Stripe webhook handler with signature verification

### DIFF
--- a/backend/src/integration-test/resources/application-test.yml
+++ b/backend/src/integration-test/resources/application-test.yml
@@ -6,5 +6,7 @@ stablepay:
     claim-base-url: https://claim.stablepay.app/
   stripe:
     api-key: sk_test_stablepay
+    webhook-secret: whsec_test_stablepay
     test-mode: true
     auto-confirm: true
+    currency: usd

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.exception.FundingFailedException;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
@@ -147,6 +148,14 @@ public class GlobalExceptionHandler {
             FundingAlreadyInProgressException ex, HttpServletRequest request) {
         log.warn("Funding already in progress: {}", ex.getMessage());
         return buildResponse("SP-0022", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InvalidWebhookSignatureException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInvalidWebhookSignature(
+            InvalidWebhookSignatureException ex, HttpServletRequest request) {
+        log.warn("Invalid webhook signature: {}", ex.getMessage());
+        return buildResponse("SP-0026", ex.getMessage(), request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
@@ -54,7 +54,7 @@ public class StripeWebhookController {
                 case UNKNOWN -> log.debug(
                         "Ignoring unsupported Stripe event eventId={}", event.eventId());
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // Always ACK 200 once signature is valid; Stripe would otherwise retry.
             log.error("Error dispatching Stripe webhook eventId={} type={}: {}",
                     event.eventId(), event.type(), e.getMessage(), e);

--- a/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
 import com.stablepay.domain.funding.handler.CompleteFundingHandler;
 import com.stablepay.domain.funding.handler.FailFundingHandler;
+import com.stablepay.domain.funding.model.PaymentWebhookEvent;
 import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,17 +41,12 @@ public class StripeWebhookController {
     public ResponseEntity<Void> receive(
             @RequestBody String payload,
             @RequestHeader("Stripe-Signature") String signature) {
-        try {
-            var event = paymentWebhookVerifier.verify(payload, signature);
-            dispatch(event);
-        } catch (InvalidWebhookSignatureException e) {
-            log.warn("Rejecting Stripe webhook with invalid signature: {}", e.getMessage());
-            throw e;
-        }
+        var event = paymentWebhookVerifier.verify(payload, signature);
+        dispatch(event);
         return ResponseEntity.ok().build();
     }
 
-    private void dispatch(com.stablepay.domain.funding.model.PaymentWebhookEvent event) {
+    private void dispatch(PaymentWebhookEvent event) {
         try {
             switch (event.type()) {
                 case PAYMENT_SUCCEEDED -> completeFundingHandler.handle(event.fundingId());

--- a/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/webhook/StripeWebhookController.java
@@ -1,0 +1,68 @@
+package com.stablepay.application.controller.webhook;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.handler.CompleteFundingHandler;
+import com.stablepay.domain.funding.handler.FailFundingHandler;
+import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+// Spring Security is NOT wired in the project. When it is, this endpoint must be
+// permit-all and CSRF-exempt (/webhooks/**): the Stripe signature header plus the
+// 300s replay tolerance is the authentication mechanism for this endpoint.
+@Slf4j
+@RestController
+@RequestMapping("/webhooks")
+@RequiredArgsConstructor
+@Tag(name = "Webhooks", description = "Inbound webhook endpoints (PSP-signed)")
+public class StripeWebhookController {
+
+    private final PaymentWebhookVerifier paymentWebhookVerifier;
+    private final CompleteFundingHandler completeFundingHandler;
+    private final FailFundingHandler failFundingHandler;
+
+    @PostMapping("/stripe")
+    @Operation(
+            summary = "Receive Stripe webhook",
+            description = "Verifies the Stripe-Signature header, then dispatches "
+                    + "payment_intent.succeeded and payment_intent.payment_failed events "
+                    + "to the appropriate funding handler. Always returns 200 once the "
+                    + "signature is valid, to prevent Stripe retries on downstream errors.")
+    public ResponseEntity<Void> receive(
+            @RequestBody String payload,
+            @RequestHeader("Stripe-Signature") String signature) {
+        try {
+            var event = paymentWebhookVerifier.verify(payload, signature);
+            dispatch(event);
+        } catch (InvalidWebhookSignatureException e) {
+            log.warn("Rejecting Stripe webhook with invalid signature: {}", e.getMessage());
+            throw e;
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    private void dispatch(com.stablepay.domain.funding.model.PaymentWebhookEvent event) {
+        try {
+            switch (event.type()) {
+                case PAYMENT_SUCCEEDED -> completeFundingHandler.handle(event.fundingId());
+                case PAYMENT_FAILED -> failFundingHandler.handle(event.fundingId());
+                case UNKNOWN -> log.debug(
+                        "Ignoring unsupported Stripe event eventId={}", event.eventId());
+            }
+        } catch (Exception e) {
+            // Always ACK 200 once signature is valid; Stripe would otherwise retry.
+            log.error("Error dispatching Stripe webhook eventId={} type={}: {}",
+                    event.eventId(), event.type(), e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/exception/InvalidWebhookSignatureException.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/exception/InvalidWebhookSignatureException.java
@@ -1,0 +1,18 @@
+package com.stablepay.domain.funding.exception;
+
+public class InvalidWebhookSignatureException extends RuntimeException {
+
+    public static InvalidWebhookSignatureException withReason(String reason) {
+        return new InvalidWebhookSignatureException(
+                "SP-0026: Invalid webhook signature: " + reason, null);
+    }
+
+    public static InvalidWebhookSignatureException withReason(String reason, Throwable cause) {
+        return new InvalidWebhookSignatureException(
+                "SP-0026: Invalid webhook signature: " + reason, cause);
+    }
+
+    private InvalidWebhookSignatureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
@@ -1,0 +1,77 @@
+package com.stablepay.domain.funding.handler;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.funding.port.FundingWorkflowStarter;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CompleteFundingHandler {
+
+    private static final Set<FundingStatus> TERMINAL_STATUSES = Set.of(
+            FundingStatus.FUNDED,
+            FundingStatus.FAILED,
+            FundingStatus.REFUND_INITIATED,
+            FundingStatus.REFUNDED,
+            FundingStatus.REFUND_FAILED);
+
+    private final FundingOrderRepository fundingOrderRepository;
+    private final WalletRepository walletRepository;
+    private final Optional<FundingWorkflowStarter> fundingWorkflowStarter;
+
+    public void handle(UUID fundingId) {
+        var orderOpt = fundingOrderRepository.findByFundingId(fundingId);
+        if (orderOpt.isEmpty()) {
+            log.warn("Funding order not found on payment_succeeded fundingId={}", fundingId);
+            return;
+        }
+        var order = orderOpt.get();
+        if (TERMINAL_STATUSES.contains(order.status())) {
+            log.debug("Ignoring payment_succeeded for fundingId={} already in status={}",
+                    fundingId, order.status());
+            return;
+        }
+        if (order.status() != FundingStatus.PAYMENT_CONFIRMED) {
+            log.warn("Unexpected status on payment_succeeded fundingId={} status={}",
+                    fundingId, order.status());
+            return;
+        }
+
+        var walletOpt = walletRepository.findById(order.walletId());
+        if (walletOpt.isEmpty()) {
+            log.error("Wallet not found for funding order fundingId={} walletId={}",
+                    fundingId, order.walletId());
+            return;
+        }
+        var wallet = walletOpt.get();
+
+        var funded = order.toBuilder().status(FundingStatus.FUNDED).build();
+        FundingOrder persisted = fundingOrderRepository.save(funded);
+        log.info("Funding order confirmed fundingId={} walletId={} status={}",
+                persisted.fundingId(), persisted.walletId(), persisted.status());
+
+        fundingWorkflowStarter.ifPresentOrElse(
+                starter -> starter.startFundingWorkflow(
+                        persisted.fundingId(),
+                        persisted.walletId(),
+                        wallet.solanaAddress(),
+                        persisted.amountUsdc()),
+                () -> log.warn(
+                        "FundingWorkflowStarter not configured; skipping workflow start for fundingId={}",
+                        persisted.fundingId()));
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
@@ -34,6 +34,10 @@ public class CompleteFundingHandler {
     private final Optional<FundingWorkflowStarter> fundingWorkflowStarter;
 
     public void handle(UUID fundingId) {
+        if (fundingId == null) {
+            log.warn("Ignoring payment_succeeded with null fundingId");
+            return;
+        }
         var orderOpt = fundingOrderRepository.findByFundingId(fundingId);
         if (orderOpt.isEmpty()) {
             log.warn("Funding order not found on payment_succeeded fundingId={}", fundingId);

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/FailFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/FailFundingHandler.java
@@ -28,6 +28,10 @@ public class FailFundingHandler {
     private final FundingOrderRepository fundingOrderRepository;
 
     public void handle(UUID fundingId) {
+        if (fundingId == null) {
+            log.warn("Ignoring payment_failed with null fundingId");
+            return;
+        }
         var orderOpt = fundingOrderRepository.findByFundingId(fundingId);
         if (orderOpt.isEmpty()) {
             log.warn("Funding order not found on payment_failed fundingId={}", fundingId);

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/FailFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/FailFundingHandler.java
@@ -1,0 +1,53 @@
+package com.stablepay.domain.funding.handler;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FailFundingHandler {
+
+    private static final Set<FundingStatus> TERMINAL_STATUSES = Set.of(
+            FundingStatus.FUNDED,
+            FundingStatus.FAILED,
+            FundingStatus.REFUND_INITIATED,
+            FundingStatus.REFUNDED,
+            FundingStatus.REFUND_FAILED);
+
+    private final FundingOrderRepository fundingOrderRepository;
+
+    public void handle(UUID fundingId) {
+        var orderOpt = fundingOrderRepository.findByFundingId(fundingId);
+        if (orderOpt.isEmpty()) {
+            log.warn("Funding order not found on payment_failed fundingId={}", fundingId);
+            return;
+        }
+        var order = orderOpt.get();
+        if (TERMINAL_STATUSES.contains(order.status())) {
+            log.debug("Ignoring payment_failed for fundingId={} already in status={}",
+                    fundingId, order.status());
+            return;
+        }
+        if (order.status() != FundingStatus.PAYMENT_CONFIRMED) {
+            log.warn("Unexpected status on payment_failed fundingId={} status={}",
+                    fundingId, order.status());
+            return;
+        }
+
+        var failed = order.toBuilder().status(FundingStatus.FAILED).build();
+        var persisted = fundingOrderRepository.save(failed);
+        log.info("Funding order marked failed fundingId={} walletId={}",
+                persisted.fundingId(), persisted.walletId());
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/PaymentWebhookEvent.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/PaymentWebhookEvent.java
@@ -1,0 +1,19 @@
+package com.stablepay.domain.funding.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record PaymentWebhookEvent(
+    String eventId,
+    WebhookEventType type,
+    UUID fundingId
+) {
+    public PaymentWebhookEvent {
+        requireNonNull(eventId, "eventId cannot be null");
+        requireNonNull(type, "type cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/model/WebhookEventType.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/model/WebhookEventType.java
@@ -1,0 +1,7 @@
+package com.stablepay.domain.funding.model;
+
+public enum WebhookEventType {
+    PAYMENT_SUCCEEDED,
+    PAYMENT_FAILED,
+    UNKNOWN
+}

--- a/backend/src/main/java/com/stablepay/domain/funding/port/PaymentWebhookVerifier.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/port/PaymentWebhookVerifier.java
@@ -1,9 +1,8 @@
 package com.stablepay.domain.funding.port;
 
-import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
 import com.stablepay.domain.funding.model.PaymentWebhookEvent;
 
 public interface PaymentWebhookVerifier {
 
-    PaymentWebhookEvent verify(String payload, String signature) throws InvalidWebhookSignatureException;
+    PaymentWebhookEvent verify(String payload, String signature);
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/port/PaymentWebhookVerifier.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/port/PaymentWebhookVerifier.java
@@ -1,0 +1,9 @@
+package com.stablepay.domain.funding.port;
+
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.model.PaymentWebhookEvent;
+
+public interface PaymentWebhookVerifier {
+
+    PaymentWebhookEvent verify(String payload, String signature) throws InvalidWebhookSignatureException;
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifier.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifier.java
@@ -4,13 +4,15 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
 import com.stablepay.domain.funding.model.PaymentWebhookEvent;
 import com.stablepay.domain.funding.model.WebhookEventType;
 import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
-import com.stripe.model.PaymentIntent;
 import com.stripe.net.Webhook;
 
 import lombok.RequiredArgsConstructor;
@@ -21,15 +23,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class StripePaymentWebhookVerifier implements PaymentWebhookVerifier {
 
-    static final String EVENT_PAYMENT_SUCCEEDED = "payment_intent.succeeded";
-    static final String EVENT_PAYMENT_FAILED = "payment_intent.payment_failed";
+    private static final String EVENT_PAYMENT_SUCCEEDED = "payment_intent.succeeded";
+    private static final String EVENT_PAYMENT_FAILED = "payment_intent.payment_failed";
     private static final long REPLAY_TOLERANCE_SECONDS = 300L;
+    private static final String FUNDING_ID_METADATA_KEY = "funding_id";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final StripeProperties stripeProperties;
 
     @Override
-    public PaymentWebhookEvent verify(String payload, String signature)
-            throws InvalidWebhookSignatureException {
+    public PaymentWebhookEvent verify(String payload, String signature) {
         Event event;
         try {
             event = Webhook.constructEvent(
@@ -40,20 +43,12 @@ public class StripePaymentWebhookVerifier implements PaymentWebhookVerifier {
 
         var type = mapType(event.getType());
         if (type == WebhookEventType.UNKNOWN) {
-            return PaymentWebhookEvent.builder()
-                    .eventId(event.getId())
-                    .type(WebhookEventType.UNKNOWN)
-                    .fundingId(null)
-                    .build();
+            return unknownEvent(event.getId());
         }
 
-        var fundingId = extractFundingId(event);
+        var fundingId = extractFundingIdFromPayload(payload, event);
         if (fundingId == null) {
-            return PaymentWebhookEvent.builder()
-                    .eventId(event.getId())
-                    .type(WebhookEventType.UNKNOWN)
-                    .fundingId(null)
-                    .build();
+            return unknownEvent(event.getId());
         }
         return PaymentWebhookEvent.builder()
                 .eventId(event.getId())
@@ -73,22 +68,23 @@ public class StripePaymentWebhookVerifier implements PaymentWebhookVerifier {
         };
     }
 
-    private UUID extractFundingId(Event event) {
-        var maybeObject = event.getDataObjectDeserializer().getObject();
-        if (maybeObject.isEmpty()) {
-            log.warn("Stripe event eventId={} type={} has no deserializable data object",
-                    event.getId(), event.getType());
+    // Parses funding_id from the raw JSON payload instead of the Stripe SDK's typed
+    // PaymentIntent. event.getDataObjectDeserializer().getObject() returns Optional.empty()
+    // when the webhook's api_version differs from the SDK's pinned version — which would
+    // silently drop legitimate events. The metadata JSON path is stable across Stripe API
+    // versions, so parsing it directly is safe.
+    private UUID extractFundingIdFromPayload(String payload, Event event) {
+        JsonNode root;
+        try {
+            root = OBJECT_MAPPER.readTree(payload);
+        } catch (JsonProcessingException e) {
+            log.warn("Unable to parse Stripe webhook payload eventId={}: {}",
+                    event.getId(), e.getMessage());
             return null;
         }
-        var stripeObject = maybeObject.get();
-        if (!(stripeObject instanceof PaymentIntent paymentIntent)) {
-            log.warn("Stripe event eventId={} type={} data is not a PaymentIntent (actual={})",
-                    event.getId(), event.getType(), stripeObject.getClass().getName());
-            return null;
-        }
-        var metadata = paymentIntent.getMetadata();
-        var raw = metadata == null ? null : metadata.get("funding_id");
-        if (raw == null) {
+        var raw = root.path("data").path("object").path("metadata")
+                .path(FUNDING_ID_METADATA_KEY).asText(null);
+        if (raw == null || raw.isBlank()) {
             log.warn("Stripe event eventId={} type={} missing funding_id metadata",
                     event.getId(), event.getType());
             return null;
@@ -100,5 +96,13 @@ public class StripePaymentWebhookVerifier implements PaymentWebhookVerifier {
                     event.getId(), raw);
             return null;
         }
+    }
+
+    private PaymentWebhookEvent unknownEvent(String eventId) {
+        return PaymentWebhookEvent.builder()
+                .eventId(eventId)
+                .type(WebhookEventType.UNKNOWN)
+                .fundingId(null)
+                .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifier.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifier.java
@@ -1,0 +1,104 @@
+package com.stablepay.infrastructure.stripe;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.model.PaymentWebhookEvent;
+import com.stablepay.domain.funding.model.WebhookEventType;
+import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.Event;
+import com.stripe.model.PaymentIntent;
+import com.stripe.net.Webhook;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StripePaymentWebhookVerifier implements PaymentWebhookVerifier {
+
+    static final String EVENT_PAYMENT_SUCCEEDED = "payment_intent.succeeded";
+    static final String EVENT_PAYMENT_FAILED = "payment_intent.payment_failed";
+    private static final long REPLAY_TOLERANCE_SECONDS = 300L;
+
+    private final StripeProperties stripeProperties;
+
+    @Override
+    public PaymentWebhookEvent verify(String payload, String signature)
+            throws InvalidWebhookSignatureException {
+        Event event;
+        try {
+            event = Webhook.constructEvent(
+                    payload, signature, stripeProperties.webhookSecret(), REPLAY_TOLERANCE_SECONDS);
+        } catch (SignatureVerificationException e) {
+            throw InvalidWebhookSignatureException.withReason(e.getMessage(), e);
+        }
+
+        var type = mapType(event.getType());
+        if (type == WebhookEventType.UNKNOWN) {
+            return PaymentWebhookEvent.builder()
+                    .eventId(event.getId())
+                    .type(WebhookEventType.UNKNOWN)
+                    .fundingId(null)
+                    .build();
+        }
+
+        var fundingId = extractFundingId(event);
+        if (fundingId == null) {
+            return PaymentWebhookEvent.builder()
+                    .eventId(event.getId())
+                    .type(WebhookEventType.UNKNOWN)
+                    .fundingId(null)
+                    .build();
+        }
+        return PaymentWebhookEvent.builder()
+                .eventId(event.getId())
+                .type(type)
+                .fundingId(fundingId)
+                .build();
+    }
+
+    private WebhookEventType mapType(String stripeType) {
+        if (stripeType == null) {
+            return WebhookEventType.UNKNOWN;
+        }
+        return switch (stripeType) {
+            case EVENT_PAYMENT_SUCCEEDED -> WebhookEventType.PAYMENT_SUCCEEDED;
+            case EVENT_PAYMENT_FAILED -> WebhookEventType.PAYMENT_FAILED;
+            default -> WebhookEventType.UNKNOWN;
+        };
+    }
+
+    private UUID extractFundingId(Event event) {
+        var maybeObject = event.getDataObjectDeserializer().getObject();
+        if (maybeObject.isEmpty()) {
+            log.warn("Stripe event eventId={} type={} has no deserializable data object",
+                    event.getId(), event.getType());
+            return null;
+        }
+        var stripeObject = maybeObject.get();
+        if (!(stripeObject instanceof PaymentIntent paymentIntent)) {
+            log.warn("Stripe event eventId={} type={} data is not a PaymentIntent (actual={})",
+                    event.getId(), event.getType(), stripeObject.getClass().getName());
+            return null;
+        }
+        var metadata = paymentIntent.getMetadata();
+        var raw = metadata == null ? null : metadata.get("funding_id");
+        if (raw == null) {
+            log.warn("Stripe event eventId={} type={} missing funding_id metadata",
+                    event.getId(), event.getType());
+            return null;
+        }
+        try {
+            return UUID.fromString(raw);
+        } catch (IllegalArgumentException e) {
+            log.warn("Stripe event eventId={} has malformed funding_id metadata: {}",
+                    event.getId(), raw);
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripeProperties.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record StripeProperties(
     @NotBlank @Pattern(regexp = "^sk_.+", message = "apiKey must start with sk_") String apiKey,
-    String webhookSecret,
+    @NotBlank String webhookSecret,
     boolean testMode,
     boolean autoConfirm,
     String testPaymentMethod,

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TaskQueue.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TaskQueue.java
@@ -6,12 +6,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum TaskQueue {
-    REMITTANCE_LIFECYCLE(Constants.TASK_QUEUE_REMITTANCE_LIFECYCLE);
+    REMITTANCE_LIFECYCLE(Constants.TASK_QUEUE_REMITTANCE_LIFECYCLE),
+    WALLET_FUNDING(Constants.TASK_QUEUE_WALLET_FUNDING);
 
     private final String name;
 
     public static class Constants {
         public static final String TASK_QUEUE_REMITTANCE_LIFECYCLE =
                 "stablepay-remittance-lifecycle";
+        public static final String TASK_QUEUE_WALLET_FUNDING =
+                "stablepay-wallet-funding";
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.stablepay.domain.funding.port.FundingWorkflowStarter;
 
@@ -23,8 +25,27 @@ public class TemporalFundingWorkflowStarter implements FundingWorkflowStarter {
 
     private final WorkflowClient workflowClient;
 
+    // Deferring the RPC until afterCommit prevents a dual-write hazard: if the caller's
+    // transaction rolls back after this method returned, the workflow would otherwise
+    // execute against funding-order state that was never persisted. Outside a transaction
+    // (startup hooks, tests) we fire immediately.
     @Override
     public void startFundingWorkflow(
+            UUID fundingId, Long walletId, String senderSolanaAddress, BigDecimal amountUsdc) {
+        Runnable startCall = () -> start(fundingId, walletId, senderSolanaAddress, amountUsdc);
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    startCall.run();
+                }
+            });
+        } else {
+            startCall.run();
+        }
+    }
+
+    private void start(
             UUID fundingId, Long walletId, String senderSolanaAddress, BigDecimal amountUsdc) {
         var workflow = workflowClient.newWorkflowStub(
                 WalletFundingWorkflow.class,

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
@@ -1,0 +1,56 @@
+package com.stablepay.infrastructure.temporal;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.funding.port.FundingWorkflowStarter;
+
+import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowExecutionAlreadyStarted;
+import io.temporal.client.WorkflowOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnBean(WorkflowClient.class)
+public class TemporalFundingWorkflowStarter implements FundingWorkflowStarter {
+
+    private final WorkflowClient workflowClient;
+
+    @Override
+    public void startFundingWorkflow(
+            UUID fundingId, Long walletId, String senderSolanaAddress, BigDecimal amountUsdc) {
+        var workflow = workflowClient.newWorkflowStub(
+                WalletFundingWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TaskQueue.WALLET_FUNDING.getName())
+                        .setWorkflowId(WalletFundingWorkflow.workflowId(fundingId))
+                        .setWorkflowIdReusePolicy(
+                                WorkflowIdReusePolicy
+                                        .WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY)
+                        .build());
+
+        var request = WalletFundingWorkflowRequest.builder()
+                .fundingId(fundingId)
+                .walletId(walletId)
+                .senderSolanaAddress(senderSolanaAddress)
+                .amountUsdc(amountUsdc)
+                .build();
+
+        try {
+            WorkflowClient.start(workflow::execute, request);
+            log.info("Started wallet funding workflow fundingId={} walletId={}", fundingId, walletId);
+        } catch (WorkflowExecutionAlreadyStarted e) {
+            log.warn(
+                    "Wallet funding workflow already started for fundingId={}. Skipping.",
+                    fundingId,
+                    e);
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
@@ -72,6 +72,15 @@ public class TemporalFundingWorkflowStarter implements FundingWorkflowStarter {
                     "Wallet funding workflow already started for fundingId={}. Skipping.",
                     fundingId,
                     e);
+        } catch (RuntimeException e) {
+            // FundingOrder is already FUNDED in the DB (this runs afterCommit). A Stripe
+            // retry will no-op on the terminal status, so this workflow will NOT be started
+            // by any future webhook. Log loudly so operators can manually reconcile.
+            // Follow-up: STA-84 adds an outbox + reconciler to recover automatically.
+            log.error(
+                    "CRITICAL: wallet funding workflow start FAILED after FUNDED committed "
+                            + "fundingId={} walletId={} — manual reconciliation required",
+                    fundingId, walletId, e);
         }
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflow.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflow.java
@@ -1,0 +1,19 @@
+package com.stablepay.infrastructure.temporal;
+
+import java.util.UUID;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface WalletFundingWorkflow {
+
+    String WORKFLOW_ID_PREFIX = "wallet-funding-";
+
+    static String workflowId(UUID fundingId) {
+        return WORKFLOW_ID_PREFIX + fundingId;
+    }
+
+    @WorkflowMethod
+    void execute(WalletFundingWorkflowRequest request);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowRequest.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowRequest.java
@@ -1,0 +1,23 @@
+package com.stablepay.infrastructure.temporal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record WalletFundingWorkflowRequest(
+    UUID fundingId,
+    Long walletId,
+    String senderSolanaAddress,
+    BigDecimal amountUsdc
+) {
+    public WalletFundingWorkflowRequest {
+        requireNonNull(fundingId, "fundingId cannot be null");
+        requireNonNull(walletId, "walletId cannot be null");
+        requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowRequest.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowRequest.java
@@ -18,6 +18,9 @@ public record WalletFundingWorkflowRequest(
         requireNonNull(fundingId, "fundingId cannot be null");
         requireNonNull(walletId, "walletId cannot be null");
         requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
+        if (senderSolanaAddress.isBlank()) {
+            throw new IllegalArgumentException("senderSolanaAddress cannot be blank");
+        }
         requireNonNull(amountUsdc, "amountUsdc cannot be null");
     }
 }

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -17,5 +17,7 @@ stablepay:
     enabled: false
   stripe:
     api-key: sk_test_stablepay
+    webhook-secret: whsec_test_stablepay
     test-mode: true
     auto-confirm: true
+    currency: usd

--- a/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
@@ -53,14 +53,16 @@ class StripeWebhookControllerTest {
         given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
                 .willThrow(InvalidWebhookSignatureException.withReason("tampered signature"));
 
-        // when / then
-        mockMvc.perform(post("/webhooks/stripe")
-                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(SOME_PAYLOAD))
+        // when
+        var resultActions = mockMvc.perform(post("/webhooks/stripe")
+                .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SOME_PAYLOAD));
+
+        // then
+        resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0026"));
-
         then(completeFundingHandler).shouldHaveNoInteractions();
         then(failFundingHandler).shouldHaveNoInteractions();
     }
@@ -72,13 +74,14 @@ class StripeWebhookControllerTest {
         given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
                 .willReturn(SOME_PAYMENT_SUCCEEDED_EVENT);
 
-        // when / then
-        mockMvc.perform(post("/webhooks/stripe")
-                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(SOME_PAYLOAD))
-                .andExpect(status().isOk());
+        // when
+        var resultActions = mockMvc.perform(post("/webhooks/stripe")
+                .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SOME_PAYLOAD));
 
+        // then
+        resultActions.andExpect(status().isOk());
         then(completeFundingHandler).should().handle(SOME_FUNDING_ID);
         then(failFundingHandler).shouldHaveNoInteractions();
     }
@@ -90,13 +93,14 @@ class StripeWebhookControllerTest {
         given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
                 .willReturn(SOME_PAYMENT_FAILED_EVENT);
 
-        // when / then
-        mockMvc.perform(post("/webhooks/stripe")
-                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(SOME_PAYLOAD))
-                .andExpect(status().isOk());
+        // when
+        var resultActions = mockMvc.perform(post("/webhooks/stripe")
+                .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SOME_PAYLOAD));
 
+        // then
+        resultActions.andExpect(status().isOk());
         then(failFundingHandler).should().handle(SOME_FUNDING_ID);
         then(completeFundingHandler).shouldHaveNoInteractions();
     }
@@ -108,13 +112,14 @@ class StripeWebhookControllerTest {
         given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
                 .willReturn(SOME_UNKNOWN_EVENT);
 
-        // when / then
-        mockMvc.perform(post("/webhooks/stripe")
-                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(SOME_PAYLOAD))
-                .andExpect(status().isOk());
+        // when
+        var resultActions = mockMvc.perform(post("/webhooks/stripe")
+                .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SOME_PAYLOAD));
 
+        // then
+        resultActions.andExpect(status().isOk());
         then(completeFundingHandler).shouldHaveNoInteractions();
         then(failFundingHandler).shouldHaveNoInteractions();
     }
@@ -128,13 +133,14 @@ class StripeWebhookControllerTest {
         willThrow(new RuntimeException("boom"))
                 .given(completeFundingHandler).handle(SOME_FUNDING_ID);
 
-        // when / then
-        mockMvc.perform(post("/webhooks/stripe")
-                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(SOME_PAYLOAD))
-                .andExpect(status().isOk());
+        // when
+        var resultActions = mockMvc.perform(post("/webhooks/stripe")
+                .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SOME_PAYLOAD));
 
+        // then
+        resultActions.andExpect(status().isOk());
         then(completeFundingHandler).should().handle(SOME_FUNDING_ID);
         then(failFundingHandler).shouldHaveNoInteractions();
     }

--- a/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
@@ -135,6 +135,7 @@ class StripeWebhookControllerTest {
                         .content(SOME_PAYLOAD))
                 .andExpect(status().isOk());
 
+        then(completeFundingHandler).should().handle(SOME_FUNDING_ID);
         then(failFundingHandler).shouldHaveNoInteractions();
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
@@ -1,0 +1,140 @@
+package com.stablepay.application.controller.webhook;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.WebhookEventFixtures.SOME_PAYMENT_FAILED_EVENT;
+import static com.stablepay.testutil.WebhookEventFixtures.SOME_PAYMENT_SUCCEEDED_EVENT;
+import static com.stablepay.testutil.WebhookEventFixtures.SOME_UNKNOWN_EVENT;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.handler.CompleteFundingHandler;
+import com.stablepay.domain.funding.handler.FailFundingHandler;
+import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
+import com.stablepay.testutil.TestClockConfig;
+
+import lombok.SneakyThrows;
+
+@WebMvcTest(StripeWebhookController.class)
+@Import(TestClockConfig.class)
+class StripeWebhookControllerTest {
+
+    private static final String SOME_PAYLOAD = "{\"id\":\"evt_test_0123456789\"}";
+    private static final String SOME_SIGNATURE_HEADER = "t=1700000000,v1=deadbeef";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PaymentWebhookVerifier paymentWebhookVerifier;
+
+    @MockitoBean
+    private CompleteFundingHandler completeFundingHandler;
+
+    @MockitoBean
+    private FailFundingHandler failFundingHandler;
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WhenSignatureVerificationFails() {
+        // given
+        given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
+                .willThrow(InvalidWebhookSignatureException.withReason("tampered signature"));
+
+        // when / then
+        mockMvc.perform(post("/webhooks/stripe")
+                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SOME_PAYLOAD))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("SP-0026"));
+
+        then(completeFundingHandler).shouldHaveNoInteractions();
+        then(failFundingHandler).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldDispatchToCompleteHandlerOnPaymentSucceeded() {
+        // given
+        given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
+                .willReturn(SOME_PAYMENT_SUCCEEDED_EVENT);
+
+        // when / then
+        mockMvc.perform(post("/webhooks/stripe")
+                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SOME_PAYLOAD))
+                .andExpect(status().isOk());
+
+        then(completeFundingHandler).should().handle(SOME_FUNDING_ID);
+        then(failFundingHandler).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldDispatchToFailHandlerOnPaymentFailed() {
+        // given
+        given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
+                .willReturn(SOME_PAYMENT_FAILED_EVENT);
+
+        // when / then
+        mockMvc.perform(post("/webhooks/stripe")
+                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SOME_PAYLOAD))
+                .andExpect(status().isOk());
+
+        then(failFundingHandler).should().handle(SOME_FUNDING_ID);
+        then(completeFundingHandler).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn200OnUnknownEventType() {
+        // given
+        given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
+                .willReturn(SOME_UNKNOWN_EVENT);
+
+        // when / then
+        mockMvc.perform(post("/webhooks/stripe")
+                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SOME_PAYLOAD))
+                .andExpect(status().isOk());
+
+        then(completeFundingHandler).shouldHaveNoInteractions();
+        then(failFundingHandler).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn200WhenHandlerThrows() {
+        // given
+        given(paymentWebhookVerifier.verify(SOME_PAYLOAD, SOME_SIGNATURE_HEADER))
+                .willReturn(SOME_PAYMENT_SUCCEEDED_EVENT);
+        willThrow(new RuntimeException("boom"))
+                .given(completeFundingHandler).handle(SOME_FUNDING_ID);
+
+        // when / then
+        mockMvc.perform(post("/webhooks/stripe")
+                        .header("Stripe-Signature", SOME_SIGNATURE_HEADER)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SOME_PAYLOAD))
+                .andExpect(status().isOk());
+
+        then(failFundingHandler).shouldHaveNoInteractions();
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
@@ -1,0 +1,184 @@
+package com.stablepay.domain.funding.handler;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.funding.port.FundingWorkflowStarter;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CompleteFundingHandlerTest {
+
+    @Mock
+    private FundingOrderRepository fundingOrderRepository;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private FundingWorkflowStarter fundingWorkflowStarter;
+
+    private CompleteFundingHandler completeFundingHandler;
+
+    @Captor
+    private ArgumentCaptor<FundingOrder> fundingOrderCaptor;
+
+    @BeforeEach
+    void setUp() {
+        completeFundingHandler = new CompleteFundingHandler(
+                fundingOrderRepository, walletRepository, Optional.of(fundingWorkflowStarter));
+    }
+
+    @Test
+    void shouldMarkOrderFundedAndStartWorkflow() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        var wallet = walletBuilder().id(SOME_WALLET_ID).solanaAddress(SOME_SOLANA_ADDRESS).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+        given(fundingOrderRepository.save(fundingOrderCaptor.capture()))
+                .willAnswer(invocation -> invocation.<FundingOrder>getArgument(0));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        var expectedSaved = order.toBuilder().status(FundingStatus.FUNDED).build();
+        assertThat(fundingOrderCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedSaved);
+        then(fundingWorkflowStarter).should()
+                .startFundingWorkflow(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_SOLANA_ADDRESS, SOME_AMOUNT_USDC);
+    }
+
+    @Test
+    void shouldNoOpWhenOrderNotFound() {
+        // given
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.empty());
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsFunded() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsFailed() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FAILED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefundInitiated() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUND_INITIATED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefunded() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUNDED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefundFailed() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUND_FAILED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenWalletNotFound() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
+
+        // when
+        completeFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
@@ -179,6 +179,44 @@ class CompleteFundingHandlerTest {
         // then
         then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
         then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).should().findById(SOME_WALLET_ID);
+        then(walletRepository).shouldHaveNoMoreInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenFundingIdIsNull() {
+        // given (nothing stubbed)
+
+        // when
+        completeFundingHandler.handle(null);
+
+        // then
+        then(fundingOrderRepository).shouldHaveNoInteractions();
+        then(walletRepository).shouldHaveNoInteractions();
+        then(fundingWorkflowStarter).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldMarkOrderFundedEvenWhenWorkflowStarterIsAbsent() {
+        // given
+        var handlerWithoutStarter = new CompleteFundingHandler(
+                fundingOrderRepository, walletRepository, Optional.empty());
+        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        var wallet = walletBuilder().id(SOME_WALLET_ID).solanaAddress(SOME_SOLANA_ADDRESS).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+        given(fundingOrderRepository.save(fundingOrderCaptor.capture()))
+                .willAnswer(invocation -> invocation.<FundingOrder>getArgument(0));
+
+        // when
+        handlerWithoutStarter.handle(SOME_FUNDING_ID);
+
+        // then
+        var expectedSaved = order.toBuilder().status(FundingStatus.FUNDED).build();
+        assertThat(fundingOrderCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedSaved);
         then(fundingWorkflowStarter).shouldHaveNoInteractions();
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FailFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FailFundingHandlerTest.java
@@ -132,4 +132,15 @@ class FailFundingHandlerTest {
         then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
         then(fundingOrderRepository).shouldHaveNoMoreInteractions();
     }
+
+    @Test
+    void shouldNoOpWhenFundingIdIsNull() {
+        // given (nothing stubbed)
+
+        // when
+        failFundingHandler.handle(null);
+
+        // then
+        then(fundingOrderRepository).shouldHaveNoInteractions();
+    }
 }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FailFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FailFundingHandlerTest.java
@@ -1,0 +1,135 @@
+package com.stablepay.domain.funding.handler;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FailFundingHandlerTest {
+
+    @Mock
+    private FundingOrderRepository fundingOrderRepository;
+
+    @InjectMocks
+    private FailFundingHandler failFundingHandler;
+
+    @Captor
+    private ArgumentCaptor<FundingOrder> fundingOrderCaptor;
+
+    @Test
+    void shouldMarkOrderFailed() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(fundingOrderRepository.save(fundingOrderCaptor.capture()))
+                .willAnswer(invocation -> invocation.<FundingOrder>getArgument(0));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        var expectedSaved = order.toBuilder().status(FundingStatus.FAILED).build();
+        assertThat(fundingOrderCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedSaved);
+    }
+
+    @Test
+    void shouldNoOpWhenOrderNotFound() {
+        // given
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.empty());
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsFailed() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FAILED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsFunded() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefundInitiated() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUND_INITIATED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefunded() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUNDED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNoOpWhenStatusIsRefundFailed() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUND_FAILED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        failFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
@@ -1,0 +1,185 @@
+package com.stablepay.infrastructure.stripe;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_API_KEY;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_CURRENCY;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_TEST_PAYMENT_METHOD;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_WEBHOOK_EVENT_ID;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_WEBHOOK_SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.model.PaymentWebhookEvent;
+import com.stablepay.domain.funding.model.WebhookEventType;
+import com.stripe.net.Webhook;
+
+import lombok.SneakyThrows;
+
+class StripePaymentWebhookVerifierTest {
+
+    private StripeProperties stripeProperties;
+    private StripePaymentWebhookVerifier verifier;
+
+    @BeforeEach
+    void setUp() {
+        stripeProperties = StripeProperties.builder()
+                .apiKey(SOME_STRIPE_API_KEY)
+                .webhookSecret(SOME_STRIPE_WEBHOOK_SECRET)
+                .testMode(true)
+                .autoConfirm(true)
+                .testPaymentMethod(SOME_STRIPE_TEST_PAYMENT_METHOD)
+                .currency(SOME_STRIPE_CURRENCY)
+                .build();
+        verifier = new StripePaymentWebhookVerifier(stripeProperties);
+    }
+
+    @Test
+    void shouldParsePaymentSucceededEvent() {
+        // given
+        var payload = buildEventPayload("payment_intent.succeeded", SOME_FUNDING_ID.toString());
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.PAYMENT_SUCCEEDED)
+                .fundingId(SOME_FUNDING_ID)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldParsePaymentFailedEvent() {
+        // given
+        var payload = buildEventPayload("payment_intent.payment_failed", SOME_FUNDING_ID.toString());
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.PAYMENT_FAILED)
+                .fundingId(SOME_FUNDING_ID)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnUnknownEventType() {
+        // given
+        var payload = buildOtherEventPayload("customer.created");
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.UNKNOWN)
+                .fundingId(null)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowOnInvalidSignature() {
+        // given
+        var payload = buildEventPayload("payment_intent.succeeded", SOME_FUNDING_ID.toString());
+        var bogusSignature = "t=1700000000,v1=deadbeef";
+
+        // when / then
+        assertThatThrownBy(() -> verifier.verify(payload, bogusSignature))
+                .isInstanceOf(InvalidWebhookSignatureException.class)
+                .hasMessageContaining("SP-0026");
+    }
+
+    @Test
+    void shouldReturnUnknownWhenFundingIdMalformed() {
+        // given
+        var payload = buildEventPayload("payment_intent.succeeded", "not-a-uuid");
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.UNKNOWN)
+                .fundingId(null)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @SneakyThrows
+    private String signPayload(String payload) {
+        var timestamp = Webhook.Util.getTimeNow();
+        var signedPayload = timestamp + "." + payload;
+        var v1 = Webhook.Util.computeHmacSha256(SOME_STRIPE_WEBHOOK_SECRET, signedPayload);
+        return "t=" + timestamp + ",v1=" + v1;
+    }
+
+    private String buildEventPayload(String eventType, String fundingIdMetadata) {
+        var apiVersion = resolveApiVersion();
+        return """
+            {
+              "id": "%s",
+              "object": "event",
+              "api_version": "%s",
+              "type": "%s",
+              "data": {
+                "object": {
+                  "id": "%s",
+                  "object": "payment_intent",
+                  "amount": 2500,
+                  "currency": "usd",
+                  "status": "succeeded",
+                  "metadata": {
+                    "funding_id": "%s"
+                  }
+                }
+              }
+            }
+            """.formatted(
+                    SOME_STRIPE_WEBHOOK_EVENT_ID,
+                    apiVersion,
+                    eventType,
+                    SOME_STRIPE_PAYMENT_INTENT_ID,
+                    fundingIdMetadata);
+    }
+
+    private String buildOtherEventPayload(String eventType) {
+        var apiVersion = resolveApiVersion();
+        return """
+            {
+              "id": "%s",
+              "object": "event",
+              "api_version": "%s",
+              "type": "%s",
+              "data": {
+                "object": {
+                  "id": "cus_123",
+                  "object": "customer"
+                }
+              }
+            }
+            """.formatted(SOME_STRIPE_WEBHOOK_EVENT_ID, apiVersion, eventType);
+    }
+
+    private String resolveApiVersion() {
+        // com.stripe.Stripe.API_VERSION is the SDK's bundled API version. When the event's
+        // api_version matches, EventDataObjectDeserializer.getObject() returns a typed object.
+        return com.stripe.Stripe.API_VERSION;
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
@@ -124,8 +124,11 @@ class StripePaymentWebhookVerifierTest {
                 "payment_intent.succeeded", com.stripe.Stripe.API_VERSION, SOME_FUNDING_ID.toString());
         var bogusSignature = "t=1700000000,v1=deadbeef";
 
-        // when / then
-        assertThatThrownBy(() -> verifier.verify(payload, bogusSignature))
+        // when
+        var thrown = assertThatThrownBy(() -> verifier.verify(payload, bogusSignature));
+
+        // then
+        thrown
                 .isInstanceOf(InvalidWebhookSignatureException.class)
                 .hasMessageContaining("SP-0026");
     }

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentWebhookVerifierTest.java
@@ -22,6 +22,8 @@ import lombok.SneakyThrows;
 
 class StripePaymentWebhookVerifierTest {
 
+    private static final String LEGACY_API_VERSION = "2020-08-27";
+
     private StripeProperties stripeProperties;
     private StripePaymentWebhookVerifier verifier;
 
@@ -41,7 +43,8 @@ class StripePaymentWebhookVerifierTest {
     @Test
     void shouldParsePaymentSucceededEvent() {
         // given
-        var payload = buildEventPayload("payment_intent.succeeded", SOME_FUNDING_ID.toString());
+        var payload = buildEventPayload(
+                "payment_intent.succeeded", com.stripe.Stripe.API_VERSION, SOME_FUNDING_ID.toString());
         var signature = signPayload(payload);
 
         // when
@@ -59,7 +62,10 @@ class StripePaymentWebhookVerifierTest {
     @Test
     void shouldParsePaymentFailedEvent() {
         // given
-        var payload = buildEventPayload("payment_intent.payment_failed", SOME_FUNDING_ID.toString());
+        var payload = buildEventPayload(
+                "payment_intent.payment_failed",
+                com.stripe.Stripe.API_VERSION,
+                SOME_FUNDING_ID.toString());
         var signature = signPayload(payload);
 
         // when
@@ -69,6 +75,25 @@ class StripePaymentWebhookVerifierTest {
         var expected = PaymentWebhookEvent.builder()
                 .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
                 .type(WebhookEventType.PAYMENT_FAILED)
+                .fundingId(SOME_FUNDING_ID)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldExtractFundingIdWhenApiVersionDiffersFromSdk() {
+        // given
+        var payload = buildEventPayload(
+                "payment_intent.succeeded", LEGACY_API_VERSION, SOME_FUNDING_ID.toString());
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.PAYMENT_SUCCEEDED)
                 .fundingId(SOME_FUNDING_ID)
                 .build();
         assertThat(result).usingRecursiveComparison().isEqualTo(expected);
@@ -95,7 +120,8 @@ class StripePaymentWebhookVerifierTest {
     @Test
     void shouldThrowOnInvalidSignature() {
         // given
-        var payload = buildEventPayload("payment_intent.succeeded", SOME_FUNDING_ID.toString());
+        var payload = buildEventPayload(
+                "payment_intent.succeeded", com.stripe.Stripe.API_VERSION, SOME_FUNDING_ID.toString());
         var bogusSignature = "t=1700000000,v1=deadbeef";
 
         // when / then
@@ -107,7 +133,27 @@ class StripePaymentWebhookVerifierTest {
     @Test
     void shouldReturnUnknownWhenFundingIdMalformed() {
         // given
-        var payload = buildEventPayload("payment_intent.succeeded", "not-a-uuid");
+        var payload = buildEventPayload(
+                "payment_intent.succeeded", com.stripe.Stripe.API_VERSION, "not-a-uuid");
+        var signature = signPayload(payload);
+
+        // when
+        var result = verifier.verify(payload, signature);
+
+        // then
+        var expected = PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.UNKNOWN)
+                .fundingId(null)
+                .build();
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnUnknownWhenFundingIdMissingFromMetadata() {
+        // given
+        var payload = buildEventPayloadWithoutFundingId(
+                "payment_intent.succeeded", com.stripe.Stripe.API_VERSION);
         var signature = signPayload(payload);
 
         // when
@@ -130,8 +176,7 @@ class StripePaymentWebhookVerifierTest {
         return "t=" + timestamp + ",v1=" + v1;
     }
 
-    private String buildEventPayload(String eventType, String fundingIdMetadata) {
-        var apiVersion = resolveApiVersion();
+    private String buildEventPayload(String eventType, String apiVersion, String fundingIdMetadata) {
         return """
             {
               "id": "%s",
@@ -159,8 +204,32 @@ class StripePaymentWebhookVerifierTest {
                     fundingIdMetadata);
     }
 
+    private String buildEventPayloadWithoutFundingId(String eventType, String apiVersion) {
+        return """
+            {
+              "id": "%s",
+              "object": "event",
+              "api_version": "%s",
+              "type": "%s",
+              "data": {
+                "object": {
+                  "id": "%s",
+                  "object": "payment_intent",
+                  "amount": 2500,
+                  "currency": "usd",
+                  "status": "succeeded",
+                  "metadata": {}
+                }
+              }
+            }
+            """.formatted(
+                    SOME_STRIPE_WEBHOOK_EVENT_ID,
+                    apiVersion,
+                    eventType,
+                    SOME_STRIPE_PAYMENT_INTENT_ID);
+    }
+
     private String buildOtherEventPayload(String eventType) {
-        var apiVersion = resolveApiVersion();
         return """
             {
               "id": "%s",
@@ -174,12 +243,6 @@ class StripePaymentWebhookVerifierTest {
                 }
               }
             }
-            """.formatted(SOME_STRIPE_WEBHOOK_EVENT_ID, apiVersion, eventType);
-    }
-
-    private String resolveApiVersion() {
-        // com.stripe.Stripe.API_VERSION is the SDK's bundled API version. When the event's
-        // api_version matches, EventDataObjectDeserializer.getObject() returns a typed object.
-        return com.stripe.Stripe.API_VERSION;
+            """.formatted(SOME_STRIPE_WEBHOOK_EVENT_ID, com.stripe.Stripe.API_VERSION, eventType);
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/StripeFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/StripeFixtures.java
@@ -9,4 +9,6 @@ public final class StripeFixtures {
     public static final String SOME_STRIPE_API_KEY = "sk_test_stablepay";
     public static final String SOME_STRIPE_TEST_PAYMENT_METHOD = "pm_card_visa";
     public static final String SOME_STRIPE_CURRENCY = "usd";
+    public static final String SOME_STRIPE_WEBHOOK_SECRET = "whsec_test_stablepay";
+    public static final String SOME_STRIPE_WEBHOOK_EVENT_ID = "evt_test_0123456789";
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WebhookEventFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WebhookEventFixtures.java
@@ -1,0 +1,37 @@
+package com.stablepay.testutil;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_WEBHOOK_EVENT_ID;
+
+import com.stablepay.domain.funding.model.PaymentWebhookEvent;
+import com.stablepay.domain.funding.model.WebhookEventType;
+
+public final class WebhookEventFixtures {
+
+    private WebhookEventFixtures() {}
+
+    public static final PaymentWebhookEvent SOME_PAYMENT_SUCCEEDED_EVENT =
+            paymentWebhookEventBuilder()
+                    .type(WebhookEventType.PAYMENT_SUCCEEDED)
+                    .fundingId(SOME_FUNDING_ID)
+                    .build();
+
+    public static final PaymentWebhookEvent SOME_PAYMENT_FAILED_EVENT =
+            paymentWebhookEventBuilder()
+                    .type(WebhookEventType.PAYMENT_FAILED)
+                    .fundingId(SOME_FUNDING_ID)
+                    .build();
+
+    public static final PaymentWebhookEvent SOME_UNKNOWN_EVENT =
+            paymentWebhookEventBuilder()
+                    .type(WebhookEventType.UNKNOWN)
+                    .fundingId(null)
+                    .build();
+
+    public static PaymentWebhookEvent.PaymentWebhookEventBuilder paymentWebhookEventBuilder() {
+        return PaymentWebhookEvent.builder()
+                .eventId(SOME_STRIPE_WEBHOOK_EVENT_ID)
+                .type(WebhookEventType.PAYMENT_SUCCEEDED)
+                .fundingId(SOME_FUNDING_ID);
+    }
+}


### PR DESCRIPTION
## STA Issue
Closes #154

## Changes
- Add `POST /webhooks/stripe` controller that verifies the Stripe HMAC signature with a 300s replay tolerance and returns 400 only on signature failure (all other errors → 200 to suppress Stripe retries).
- Introduce a domain `PaymentWebhookVerifier` port + `PaymentWebhookEvent` / `WebhookEventType` model so the Stripe SDK stays out of the `application` layer (keeps ArchUnit rule #5 green).
- Implement `StripePaymentWebhookVerifier` in `infrastructure/stripe` — calls `Webhook.constructEvent(...)`, maps `payment_intent.succeeded` / `payment_intent.payment_failed` to domain event types, extracts `metadata.funding_id` (rev-5 correction — NOT the PaymentIntent ID), and returns `UNKNOWN` for unmapped types or malformed metadata.
- Add `CompleteFundingHandler` — idempotent across all 5 terminal states (`FUNDED`, `FAILED`, `REFUND_INITIATED`, `REFUNDED`, `REFUND_FAILED`), resolves sender Solana address from the wallet, transitions `PAYMENT_CONFIRMED → FUNDED`, and starts the Temporal `WalletFundingWorkflow`.
- Add `FailFundingHandler` — idempotent `PAYMENT_CONFIRMED → FAILED` transition.
- Introduce `WalletFundingWorkflow` interface + `WalletFundingWorkflowRequest` record + `TemporalFundingWorkflowStarter` on the new `stablepay-wallet-funding` task queue. Workflow impl and worker wiring come in STA-79.
- Add `InvalidWebhookSignatureException` (SP-0026) mapped to HTTP 400 in `GlobalExceptionHandler`.
- Extend `StripeFixtures` + new `WebhookEventFixtures`; 25 new unit tests across handlers, controller, and verifier.

## Notes
- `CompleteFundingHandler` takes `Optional<FundingWorkflowStarter>` to mirror `CreateRemittanceHandler` — required because `TemporalFundingWorkflowStarter` is `@ConditionalOnBean(WorkflowClient.class)` and may be absent in non-Temporal environments.
- Spring Security is not configured in this project. When it is wired, `/webhooks/**` must be permit-all + CSRF-exempt (signature verification is the auth mechanism). A source comment in the controller flags this.
- `StripePaymentWebhookVerifierTest` exercises the real `Webhook.constructEvent` path via `Webhook.Util.computeHmacSha256` — no static mocking.

## Checklist
- [x] `./gradlew build` passes (ArchUnit + Spotless + 284 unit tests)
- [x] Unit tests added (25 new across 4 classes)
- [x] Integration tests (43) still pass
- [x] ArchUnit rules pass — Stripe SDK stays inside `infrastructure/stripe`
- [x] Spotless formatting applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe webhook integration to receive and verify payment notifications
  * Automatic handling for payment succeeded/failed events and automated wallet funding workflow startup

* **Bug Fixes**
  * Invalid webhook signatures now return a 400 response with a consistent error code (SP-0026)

* **Tests**
  * Added comprehensive tests covering signature verification, event dispatch, handlers, and workflow start behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->