### PR TITLE
STA-78: add real treasury adapter for SPL + SOL on-chain transfers

### DIFF
--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
@@ -34,4 +34,9 @@ public class SolanaTransactionException extends RuntimeException {
         return new SolanaTransactionException(
                 "SP-0014: Claim authority private key is not configured");
     }
+
+    public static SolanaTransactionException treasuryNotConfigured() {
+        return new SolanaTransactionException(
+                "SP-0015: Treasury private key is not configured");
+    }
 }

--- a/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
@@ -3,7 +3,14 @@ package com.stablepay.domain.wallet.port;
 import java.math.BigDecimal;
 
 public interface TreasuryService {
-    void transferFromTreasury(String destinationAddress, BigDecimal amount);
 
-    BigDecimal getBalance();
+    void transferUsdc(String destinationAddress, BigDecimal amountUsdc);
+
+    void transferSol(String destinationAddress, long lamports);
+
+    BigDecimal getSolBalance(String address);
+
+    BigDecimal getUsdcBalance(String address);
+
+    void createAtaIfNeeded(String ownerAddress);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaConfig.java
@@ -26,4 +26,10 @@ public class SolanaConfig {
     public Connection solanaConnection(SolanaProperties solanaProperties) {
         return new Connection(solanaProperties.rpcUrl());
     }
+
+    @Bean
+    public TreasuryProperties treasuryProperties(
+            @Value("${stablepay.treasury.private-key:}") String privateKey) {
+        return new TreasuryProperties(privateKey);
+    }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryProperties.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryProperties.java
@@ -1,0 +1,12 @@
+package com.stablepay.infrastructure.solana;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record TreasuryProperties(String privateKey) {
+    public TreasuryProperties {
+        Objects.requireNonNull(privateKey, "privateKey must not be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -53,7 +53,8 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var transaction = new VersionedTransaction(message);
             transaction.sign(treasuryKeypair);
 
-            var signature = sendWithSkipPreflight(transaction.serialize());
+            var opContext = "treasury-sol:" + destinationAddress;
+            var signature = sendWithSkipPreflight(transaction.serialize(), opContext);
             log.info("Treasury SOL transfer submitted with signature {}", signature);
         } catch (SolanaTransactionException e) {
             throw e;
@@ -74,7 +75,9 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var usdcMint = solanaProperties.usdcMint();
             var treasuryAta = deriveAta(treasuryPubkey, usdcMint);
             var destinationAta = deriveAta(destinationOwner, usdcMint);
-            var amountBaseUnits = amountUsdc.multiply(USDC_SCALE).longValueExact();
+            var amountBaseUnits = amountUsdc.setScale(USDC_DECIMALS, RoundingMode.HALF_UP)
+                    .multiply(USDC_SCALE)
+                    .longValueExact();
 
             var instruction = new SplTransferInstruction(
                     treasuryAta, destinationAta, usdcMint, treasuryPubkey,
@@ -85,7 +88,8 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var transaction = new VersionedTransaction(message);
             transaction.sign(treasuryKeypair);
 
-            var signature = sendWithSkipPreflight(transaction.serialize());
+            var opContext = "treasury-usdc:" + destinationAddress;
+            var signature = sendWithSkipPreflight(transaction.serialize(), opContext);
             log.info("Treasury USDC transfer submitted with signature {}", signature);
         } catch (SolanaTransactionException e) {
             throw e;
@@ -123,7 +127,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
             return new BigDecimal(balance.getAmount())
                     .divide(USDC_SCALE, USDC_DECIMALS, RoundingMode.DOWN);
         } catch (Exception e) {
-            log.debug("USDC balance query failed for {} (ata {}): {} — treating as zero",
+            log.warn("USDC balance query for {} (ata {}) failed: {} — treating as zero (fail-closed)",
                     address, ata.toBase58(), e.getMessage());
             return BigDecimal.ZERO;
         }
@@ -152,7 +156,8 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var transaction = new VersionedTransaction(message);
             transaction.sign(treasuryKeypair);
 
-            var signature = sendWithSkipPreflight(transaction.serialize());
+            var opContext = "treasury-ata:" + ownerAddress;
+            var signature = sendWithSkipPreflight(transaction.serialize(), opContext);
             log.info("ATA creation for owner {} submitted with signature {}", ownerAddress, signature);
         } catch (SolanaTransactionException e) {
             throw e;
@@ -172,13 +177,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
     }
 
     private boolean accountExists(PublicKey address) {
-        try {
-            return solanaConnection.getAccountInfo(address) != null;
-        } catch (Exception e) {
-            log.debug("Account {} does not exist or query failed: {}",
-                    address.toBase58(), e.getMessage());
-            return false;
-        }
+        return solanaConnection.getAccountInfo(address) != null;
     }
 
     private Keypair resolveTreasuryKeypair() {
@@ -189,11 +188,12 @@ public class TreasuryServiceAdapter implements TreasuryService {
         return Keypair.fromSecretKey(Base58.decode(privateKeyStr));
     }
 
-    private String sendWithSkipPreflight(byte[] txBytes) {
+    private String sendWithSkipPreflight(byte[] txBytes, String opContext) {
         try {
             return solanaConnection.sendTransaction(txBytes);
         } catch (Exception preflightEx) {
-            log.warn("Preflight failed, retrying with skipPreflight: {}", preflightEx.getMessage());
+            log.warn("Preflight failed for {}, retrying with skipPreflight: {}",
+                    opContext, preflightEx.getMessage());
             var txBase64 = Base64.getEncoder().encodeToString(txBytes);
             HttpURLConnection conn = null;
             try {
@@ -227,7 +227,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
                 }
             } catch (Exception e) {
                 throw SolanaTransactionException.submissionFailed(
-                        "treasury-skipPreflight", readRpcErrorDetails(conn, e));
+                        opContext + " (skipPreflight)", readRpcErrorDetails(conn, e));
             } finally {
                 if (conn != null) {
                     conn.disconnect();

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -1,25 +1,254 @@
 package com.stablepay.infrastructure.solana;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
+import org.sol4k.Base58;
+import org.sol4k.Connection;
+import org.sol4k.Keypair;
+import org.sol4k.PublicKey;
+import org.sol4k.TransactionMessage;
+import org.sol4k.VersionedTransaction;
+import org.sol4k.instruction.CreateAssociatedTokenAccountInstruction;
+import org.sol4k.instruction.SplTransferInstruction;
+import org.sol4k.instruction.TransferInstruction;
 import org.springframework.stereotype.Component;
 
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.wallet.port.TreasuryService;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class TreasuryServiceAdapter implements TreasuryService {
 
+    private static final int USDC_DECIMALS = 6;
+    private static final BigDecimal USDC_SCALE = BigDecimal.TEN.pow(USDC_DECIMALS);
+    private static final BigDecimal LAMPORTS_PER_SOL = BigDecimal.valueOf(1_000_000_000L);
+
+    private final Connection solanaConnection;
+    private final SolanaProperties solanaProperties;
+    private final TreasuryProperties treasuryProperties;
+
     @Override
-    public void transferFromTreasury(String destinationAddress, BigDecimal amount) {
-        log.info("STUB: Transferring {} USDC from treasury to {}", amount, destinationAddress);
+    public void transferSol(String destinationAddress, long lamports) {
+        log.info("Treasury transferring {} lamports to {}", lamports, destinationAddress);
+
+        try {
+            var treasuryKeypair = resolveTreasuryKeypair();
+            var destination = new PublicKey(destinationAddress);
+            var instruction = new TransferInstruction(
+                    treasuryKeypair.getPublicKey(), destination, lamports);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(
+                    treasuryKeypair.getPublicKey(), blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+            transaction.sign(treasuryKeypair);
+
+            var signature = sendWithSkipPreflight(transaction.serialize());
+            log.info("Treasury SOL transfer submitted with signature {}", signature);
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "treasury-sol:" + destinationAddress, e);
+        }
     }
 
     @Override
-    public BigDecimal getBalance() {
-        log.debug("STUB: Returning treasury balance of 1,000,000 USDC");
-        return BigDecimal.valueOf(1_000_000);
+    public void transferUsdc(String destinationAddress, BigDecimal amountUsdc) {
+        log.info("Treasury transferring {} USDC to {}", amountUsdc, destinationAddress);
+
+        try {
+            var treasuryKeypair = resolveTreasuryKeypair();
+            var treasuryPubkey = treasuryKeypair.getPublicKey();
+            var destinationOwner = new PublicKey(destinationAddress);
+            var usdcMint = solanaProperties.usdcMint();
+            var treasuryAta = deriveAta(treasuryPubkey, usdcMint);
+            var destinationAta = deriveAta(destinationOwner, usdcMint);
+            var amountBaseUnits = amountUsdc.multiply(USDC_SCALE).longValueExact();
+
+            var instruction = new SplTransferInstruction(
+                    treasuryAta, destinationAta, usdcMint, treasuryPubkey,
+                    amountBaseUnits, USDC_DECIMALS);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(treasuryPubkey, blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+            transaction.sign(treasuryKeypair);
+
+            var signature = sendWithSkipPreflight(transaction.serialize());
+            log.info("Treasury USDC transfer submitted with signature {}", signature);
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "treasury-usdc:" + destinationAddress, e);
+        }
+    }
+
+    @Override
+    public BigDecimal getSolBalance(String address) {
+        try {
+            var lamports = solanaConnection.getBalance(new PublicKey(address));
+            return new BigDecimal(lamports).divide(LAMPORTS_PER_SOL, 9, RoundingMode.DOWN);
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "treasury-sol-balance:" + address, e);
+        }
+    }
+
+    @Override
+    public BigDecimal getUsdcBalance(String address) {
+        PublicKey ata;
+        try {
+            ata = deriveAta(new PublicKey(address), solanaProperties.usdcMint());
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.pdaDerivationFailed(
+                    "ata:" + address, e);
+        }
+
+        try {
+            var balance = solanaConnection.getTokenAccountBalance(ata);
+            return new BigDecimal(balance.getAmount())
+                    .divide(USDC_SCALE, USDC_DECIMALS, RoundingMode.DOWN);
+        } catch (Exception e) {
+            log.debug("USDC balance query failed for {} (ata {}): {} — treating as zero",
+                    address, ata.toBase58(), e.getMessage());
+            return BigDecimal.ZERO;
+        }
+    }
+
+    @Override
+    public void createAtaIfNeeded(String ownerAddress) {
+        try {
+            var treasuryKeypair = resolveTreasuryKeypair();
+            var owner = new PublicKey(ownerAddress);
+            var usdcMint = solanaProperties.usdcMint();
+            var ata = deriveAta(owner, usdcMint);
+
+            if (accountExists(ata)) {
+                log.debug("ATA {} for owner {} already exists — no-op", ata.toBase58(), ownerAddress);
+                return;
+            }
+
+            log.info("Creating ATA {} for owner {}", ata.toBase58(), ownerAddress);
+            var instruction = new CreateAssociatedTokenAccountInstruction(
+                    treasuryKeypair.getPublicKey(), ata, owner, usdcMint);
+
+            var blockhash = solanaConnection.getLatestBlockhash();
+            var message = TransactionMessage.newMessage(
+                    treasuryKeypair.getPublicKey(), blockhash, instruction);
+            var transaction = new VersionedTransaction(message);
+            transaction.sign(treasuryKeypair);
+
+            var signature = sendWithSkipPreflight(transaction.serialize());
+            log.info("ATA creation for owner {} submitted with signature {}", ownerAddress, signature);
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "treasury-ata:" + ownerAddress, e);
+        }
+    }
+
+    private PublicKey deriveAta(PublicKey owner, PublicKey mint) {
+        try {
+            return PublicKey.findProgramDerivedAddress(owner, mint).getPublicKey();
+        } catch (Exception e) {
+            throw SolanaTransactionException.pdaDerivationFailed(
+                    "ata:" + owner.toBase58() + ":" + mint.toBase58(), e);
+        }
+    }
+
+    private boolean accountExists(PublicKey address) {
+        try {
+            return solanaConnection.getAccountInfo(address) != null;
+        } catch (Exception e) {
+            log.debug("Account {} does not exist or query failed: {}",
+                    address.toBase58(), e.getMessage());
+            return false;
+        }
+    }
+
+    private Keypair resolveTreasuryKeypair() {
+        var privateKeyStr = treasuryProperties.privateKey();
+        if (privateKeyStr == null || privateKeyStr.isBlank()) {
+            throw SolanaTransactionException.treasuryNotConfigured();
+        }
+        return Keypair.fromSecretKey(Base58.decode(privateKeyStr));
+    }
+
+    private String sendWithSkipPreflight(byte[] txBytes) {
+        try {
+            return solanaConnection.sendTransaction(txBytes);
+        } catch (Exception preflightEx) {
+            log.warn("Preflight failed, retrying with skipPreflight: {}", preflightEx.getMessage());
+            var txBase64 = Base64.getEncoder().encodeToString(txBytes);
+            HttpURLConnection conn = null;
+            try {
+                var url = new URI(solanaProperties.rpcUrl()).toURL();
+                conn = (HttpURLConnection) url.openConnection();
+                conn.setConnectTimeout(10_000);
+                conn.setReadTimeout(30_000);
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/json");
+                conn.setDoOutput(true);
+
+                var body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"sendTransaction\",\"params\":[\""
+                        + txBase64 + "\",{\"skipPreflight\":true,\"encoding\":\"base64\"}]}";
+
+                try (var os = conn.getOutputStream()) {
+                    os.write(body.getBytes(StandardCharsets.UTF_8));
+                }
+
+                try (var is = conn.getInputStream()) {
+                    var response = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                    if (response.contains("\"error\"")) {
+                        throw new RuntimeException("RPC error: " + response);
+                    }
+                    var resultStart = response.indexOf("\"result\":\"");
+                    if (resultStart < 0) {
+                        throw new RuntimeException("Unexpected RPC response: " + response);
+                    }
+                    var sigStart = resultStart + "\"result\":\"".length();
+                    var sigEnd = response.indexOf("\"", sigStart);
+                    return response.substring(sigStart, sigEnd);
+                }
+            } catch (Exception e) {
+                throw SolanaTransactionException.submissionFailed(
+                        "treasury-skipPreflight", readRpcErrorDetails(conn, e));
+            } finally {
+                if (conn != null) {
+                    conn.disconnect();
+                }
+            }
+        }
+    }
+
+    private Exception readRpcErrorDetails(HttpURLConnection conn, Exception original) {
+        if (conn == null) {
+            return original;
+        }
+        try (var errorStream = conn.getErrorStream()) {
+            if (errorStream != null) {
+                var errorBody = new String(errorStream.readAllBytes(), StandardCharsets.UTF_8);
+                log.error("Solana RPC error response: {}", errorBody);
+                return new RuntimeException("RPC error: " + errorBody, original);
+            }
+        } catch (Exception ignored) {
+            log.warn("Failed to read RPC error stream: {}", ignored.getMessage());
+        }
+        return original;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -51,6 +51,8 @@ stablepay:
     escrow-program-id: ${STABLEPAY_ESCROW_PROGRAM_ID:7C2zsbhgDnxQuC1Nd2rzXQfsfnKazQWFpoUJNqS8zWij}
     usdc-mint: ${USDC_MINT:4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU}
     claim-authority-private-key: ${CLAIM_AUTHORITY_PRIVATE_KEY:}
+  treasury:
+    private-key: ${TREASURY_PRIVATE_KEY:}
   stripe:
     api-key: ${STRIPE_API_KEY:}
     webhook-secret: ${STRIPE_WEBHOOK_SECRET:}

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapterTest.java
@@ -1,31 +1,260 @@
 package com.stablepay.infrastructure.solana;
 
+import static com.stablepay.testutil.SolanaFixtures.SOME_BLOCKHASH;
+import static com.stablepay.testutil.SolanaFixtures.SOME_DESTINATION_WALLET;
+import static com.stablepay.testutil.SolanaFixtures.SOME_PROGRAM_ID;
+import static com.stablepay.testutil.SolanaFixtures.SOME_TRANSACTION_SIGNATURE;
+import static com.stablepay.testutil.SolanaFixtures.SOME_TREASURY_ADDRESS;
+import static com.stablepay.testutil.SolanaFixtures.SOME_TREASURY_PRIVATE_KEY;
+import static com.stablepay.testutil.SolanaFixtures.SOME_USDC_MINT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sol4k.Base58;
+import org.sol4k.Connection;
+import org.sol4k.Keypair;
+import org.sol4k.PublicKey;
+import org.sol4k.api.AccountInfo;
+import org.sol4k.api.TokenAccountBalance;
 
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+
+@ExtendWith(MockitoExtension.class)
 class TreasuryServiceAdapterTest {
 
-    private final TreasuryServiceAdapter adapter = new TreasuryServiceAdapter();
+    @Mock
+    private Connection solanaConnection;
 
-    @Test
-    void shouldReturnStubBalanceOfOneMillion() {
-        // when
-        var balance = adapter.getBalance();
+    @Captor
+    private ArgumentCaptor<byte[]> txBytesCaptor;
 
-        // then
-        assertThat(balance).isEqualByComparingTo(BigDecimal.valueOf(1_000_000));
+    private SolanaProperties solanaProperties;
+    private TreasuryProperties configuredTreasury;
+    private TreasuryProperties unconfiguredTreasury;
+    private PublicKey treasuryPubkey;
+    private PublicKey usdcMint;
+
+    @BeforeEach
+    void setUp() {
+        solanaProperties = new SolanaProperties(
+                new PublicKey(SOME_PROGRAM_ID),
+                new PublicKey(SOME_USDC_MINT),
+                "",
+                "http://localhost:8899");
+        configuredTreasury = new TreasuryProperties(SOME_TREASURY_PRIVATE_KEY);
+        unconfiguredTreasury = new TreasuryProperties("");
+        treasuryPubkey = Keypair.fromSecretKey(Base58.decode(SOME_TREASURY_PRIVATE_KEY)).getPublicKey();
+        usdcMint = new PublicKey(SOME_USDC_MINT);
     }
 
-    @Test
-    void shouldTransferFromTreasuryWithoutError() {
-        // given — stub implementation is a no-op
+    @Nested
+    class TransferSol {
 
-        // when / then
-        assertThatCode(() -> adapter.transferFromTreasury("SoLaNa1234567890AbCdEf", BigDecimal.valueOf(500)))
-                .doesNotThrowAnyException();
+        @Test
+        void shouldSignAndSubmitSolTransfer() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(solanaConnection.sendTransaction(txBytesCaptor.capture()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            adapter.transferSol(SOME_DESTINATION_WALLET, 500_000L);
+
+            // then
+            var txBytes = txBytesCaptor.getValue();
+            assertThat(txBytes[0]).isEqualTo((byte) 1);
+            assertThat(txBytes.length).isGreaterThan(65);
+        }
+
+        @Test
+        void shouldThrowWhenTreasuryNotConfigured() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, unconfiguredTreasury);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.transferSol(SOME_DESTINATION_WALLET, 500_000L))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0015");
+        }
+    }
+
+    @Nested
+    class TransferUsdc {
+
+        @Test
+        void shouldSignAndSubmitUsdcTransferUsingSplInstruction() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(solanaConnection.sendTransaction(txBytesCaptor.capture()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            adapter.transferUsdc(SOME_DESTINATION_WALLET, new BigDecimal("12.500000"));
+
+            // then
+            var txBytes = txBytesCaptor.getValue();
+            assertThat(txBytes[0]).isEqualTo((byte) 1);
+            assertThat(txBytes.length).isGreaterThan(65);
+        }
+
+        @Test
+        void shouldThrowWhenTreasuryNotConfigured() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, unconfiguredTreasury);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.transferUsdc(
+                    SOME_DESTINATION_WALLET, new BigDecimal("10")))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0015");
+        }
+    }
+
+    @Nested
+    class GetSolBalance {
+
+        @Test
+        void shouldReturnSolBalanceConvertedFromLamports() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            given(solanaConnection.getBalance(new PublicKey(SOME_TREASURY_ADDRESS)))
+                    .willReturn(BigInteger.valueOf(2_500_000_000L));
+
+            // when
+            var result = adapter.getSolBalance(SOME_TREASURY_ADDRESS);
+
+            // then
+            assertThat(result).isEqualByComparingTo(new BigDecimal("2.500000000"));
+        }
+
+        @Test
+        void shouldThrowWhenBalanceQueryFails() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            given(solanaConnection.getBalance(new PublicKey(SOME_TREASURY_ADDRESS)))
+                    .willThrow(new RuntimeException("rpc down"));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.getSolBalance(SOME_TREASURY_ADDRESS))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0010");
+        }
+    }
+
+    @Nested
+    class GetUsdcBalance {
+
+        @Test
+        void shouldReturnUsdcBalanceScaledFromBaseUnits() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            var ata = PublicKey.findProgramDerivedAddress(
+                    new PublicKey(SOME_TREASURY_ADDRESS), usdcMint).getPublicKey();
+            given(solanaConnection.getTokenAccountBalance(ata))
+                    .willReturn(new TokenAccountBalance(
+                            BigInteger.valueOf(123_456_789L), 6, "123.456789"));
+
+            // when
+            var result = adapter.getUsdcBalance(SOME_TREASURY_ADDRESS);
+
+            // then
+            assertThat(result).isEqualByComparingTo(new BigDecimal("123.456789"));
+        }
+
+        @Test
+        void shouldReturnZeroWhenAtaDoesNotExist() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            var ata = PublicKey.findProgramDerivedAddress(
+                    new PublicKey(SOME_DESTINATION_WALLET), usdcMint).getPublicKey();
+            given(solanaConnection.getTokenAccountBalance(ata))
+                    .willThrow(new RuntimeException("ata not found"));
+
+            // when
+            var result = adapter.getUsdcBalance(SOME_DESTINATION_WALLET);
+
+            // then
+            assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+    }
+
+    @Nested
+    class CreateAtaIfNeeded {
+
+        @Test
+        void shouldSubmitCreateAtaTransactionWhenAccountMissing() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            var ata = PublicKey.findProgramDerivedAddress(
+                    new PublicKey(SOME_DESTINATION_WALLET), usdcMint).getPublicKey();
+            given(solanaConnection.getAccountInfo(ata)).willReturn(null);
+            given(solanaConnection.getLatestBlockhash()).willReturn(SOME_BLOCKHASH);
+            given(solanaConnection.sendTransaction(txBytesCaptor.capture()))
+                    .willReturn(SOME_TRANSACTION_SIGNATURE);
+
+            // when
+            adapter.createAtaIfNeeded(SOME_DESTINATION_WALLET);
+
+            // then
+            var txBytes = txBytesCaptor.getValue();
+            assertThat(txBytes[0]).isEqualTo((byte) 1);
+            assertThat(txBytes.length).isGreaterThan(65);
+        }
+
+        @Test
+        void shouldBeNoOpWhenAtaAlreadyExists() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            var ata = PublicKey.findProgramDerivedAddress(
+                    new PublicKey(SOME_DESTINATION_WALLET), usdcMint).getPublicKey();
+            var existingAccount = new AccountInfo(
+                    new byte[0], false, BigInteger.valueOf(2_039_280L),
+                    treasuryPubkey, BigInteger.ZERO, 165);
+            given(solanaConnection.getAccountInfo(ata)).willReturn(existingAccount);
+
+            // when
+            adapter.createAtaIfNeeded(SOME_DESTINATION_WALLET);
+
+            // then
+            then(solanaConnection).should().getAccountInfo(ata);
+            then(solanaConnection).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        void shouldThrowWhenTreasuryNotConfigured() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, unconfiguredTreasury);
+
+            // when / then
+            assertThatThrownBy(() -> adapter.createAtaIfNeeded(SOME_DESTINATION_WALLET))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0015");
+        }
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapterTest.java
@@ -35,6 +35,13 @@ import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 @ExtendWith(MockitoExtension.class)
 class TreasuryServiceAdapterTest {
 
+    private static final byte[] SYSTEM_PROGRAM_ID =
+            new PublicKey("11111111111111111111111111111111").bytes();
+    private static final byte[] SPL_TOKEN_PROGRAM_ID =
+            new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").bytes();
+    private static final byte[] ASSOCIATED_TOKEN_PROGRAM_ID =
+            new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL").bytes();
+
     @Mock
     private Connection solanaConnection;
 
@@ -46,6 +53,22 @@ class TreasuryServiceAdapterTest {
     private TreasuryProperties unconfiguredTreasury;
     private PublicKey treasuryPubkey;
     private PublicKey usdcMint;
+
+    private static boolean containsBytes(byte[] haystack, byte[] needle) {
+        if (needle.length == 0 || needle.length > haystack.length) {
+            return false;
+        }
+        outer:
+        for (var i = 0; i <= haystack.length - needle.length; i++) {
+            for (var j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
 
     @BeforeEach
     void setUp() {
@@ -79,6 +102,9 @@ class TreasuryServiceAdapterTest {
             var txBytes = txBytesCaptor.getValue();
             assertThat(txBytes[0]).isEqualTo((byte) 1);
             assertThat(txBytes.length).isGreaterThan(65);
+            assertThat(containsBytes(txBytes, SYSTEM_PROGRAM_ID))
+                    .as("SOL transfer must reference the System Program")
+                    .isTrue();
         }
 
         @Test
@@ -113,6 +139,9 @@ class TreasuryServiceAdapterTest {
             var txBytes = txBytesCaptor.getValue();
             assertThat(txBytes[0]).isEqualTo((byte) 1);
             assertThat(txBytes.length).isGreaterThan(65);
+            assertThat(containsBytes(txBytes, SPL_TOKEN_PROGRAM_ID))
+                    .as("USDC transfer must reference the SPL Token Program")
+                    .isTrue();
         }
 
         @Test
@@ -223,6 +252,9 @@ class TreasuryServiceAdapterTest {
             var txBytes = txBytesCaptor.getValue();
             assertThat(txBytes[0]).isEqualTo((byte) 1);
             assertThat(txBytes.length).isGreaterThan(65);
+            assertThat(containsBytes(txBytes, ASSOCIATED_TOKEN_PROGRAM_ID))
+                    .as("ATA creation must reference the Associated Token Program")
+                    .isTrue();
         }
 
         @Test
@@ -255,6 +287,24 @@ class TreasuryServiceAdapterTest {
             assertThatThrownBy(() -> adapter.createAtaIfNeeded(SOME_DESTINATION_WALLET))
                     .isInstanceOf(SolanaTransactionException.class)
                     .hasMessageContaining("SP-0015");
+        }
+
+        @Test
+        void shouldPropagateAccountInfoFailureInsteadOfAttemptingDuplicateCreate() {
+            // given
+            var adapter = new TreasuryServiceAdapter(
+                    solanaConnection, solanaProperties, configuredTreasury);
+            var ata = PublicKey.findProgramDerivedAddress(
+                    new PublicKey(SOME_DESTINATION_WALLET), usdcMint).getPublicKey();
+            given(solanaConnection.getAccountInfo(ata))
+                    .willThrow(new RuntimeException("rpc rate limited"));
+
+            // when / then
+            assertThatThrownBy(() -> adapter.createAtaIfNeeded(SOME_DESTINATION_WALLET))
+                    .isInstanceOf(SolanaTransactionException.class)
+                    .hasMessageContaining("SP-0010");
+            then(solanaConnection).should().getAccountInfo(ata);
+            then(solanaConnection).shouldHaveNoMoreInteractions();
         }
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/SolanaFixtures.java
@@ -36,4 +36,13 @@ public final class SolanaFixtures {
 
     public static final String SOME_CLAIM_AUTHORITY_PUBLIC_KEY =
             "HKqwNCgGAtg4TXmQCeMURZNpMdbz6QbvJSBVQzwQ5TC";
+
+    public static final String SOME_TREASURY_PRIVATE_KEY =
+            "TuncLi5MKiNXH2BG3m2wnPsMLyXkx41zwouStjE8bRmJEZ6SxxsHN21sR8RFdTQXJMBif4pBkkfX17JSPtYVZmp";
+
+    public static final String SOME_TREASURY_ADDRESS =
+            "HKqwNCgGAtg4TXmQCeMURZNpMdbz6QbvJSBVQzwQ5TC";
+
+    public static final String SOME_DESTINATION_WALLET =
+            "DestWa11et111111111111111111111111111111111";
 }


### PR DESCRIPTION
## STA Issue
Closes #155

## Changes
- Expand `TreasuryService` port: rename `transferFromTreasury` → `transferUsdc`; add `transferSol`, `getSolBalance`, `getUsdcBalance`, `createAtaIfNeeded`; drop unused `getBalance`.
- Replace the stub `TreasuryServiceAdapter` with a sol4k-backed implementation: `TransferInstruction` for SOL, `SplTransferInstruction` for USDC, `CreateAssociatedTokenAccountInstruction` for ATA bootstrap, all signed with the treasury keypair.
- `getUsdcBalance` returns `BigDecimal.ZERO` when the ATA does not exist (required by STA-80 refund balance gate).
- Reuse the `sendWithSkipPreflight` pattern from `SolanaTransactionServiceAdapter` for transaction submission.
- New `TreasuryProperties` record + `SolanaConfig` bean loading the treasury keypair from `stablepay.treasury.private-key` (`TREASURY_PRIVATE_KEY` env var).
- Add `SP-0015: Treasury private key is not configured` via `SolanaTransactionException.treasuryNotConfigured()`.
- Rewrite `TreasuryServiceAdapterTest` with mocked `Connection` + sol4k calls, covering all four operations, the treasury-not-configured guard, the missing-ATA zero-balance path, and ATA idempotency.
- New test fixtures: `SOME_TREASURY_PRIVATE_KEY`, `SOME_TREASURY_ADDRESS`, `SOME_DESTINATION_WALLET`.

## Spec deviation
The issue spec lists `SplTransferInstruction(from, to, owner, mint, amount, decimals)`. sol4k 0.7.0's actual constructor order is `(from, to, mint, owner, amount, decimals)`. Implementation uses the real constructor order; behaviour matches the spec intent (treasury ATA → destination ATA, owner=treasury pubkey, mint=USDC, 6 decimals).

## Checklist
- [x] `./gradlew build` passes
- [x] `./gradlew integrationTest` passes
- [x] Unit tests added (11 cases in `TreasuryServiceAdapterTest`)
- [x] ArchUnit rules pass (included in build)
- [x] Spotless formatting applied