### PR TITLE
STA-79: add WalletFundingWorkflow with 5 activities on Temporal

### DIFF
--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
@@ -17,8 +17,11 @@ import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.WalletRepository;
 import com.stablepay.test.PgTest;
 
+// No class-level @Transactional: each handler invocation must commit in its own
+// transaction so the retry in shouldBeIdempotentWhenRetriedAfterSuccessfulCommit
+// actually exercises the post-commit idempotency guard (status = FUNDED) rather
+// than reading dirty in-session state from the same outer transaction.
 @PgTest
-@Transactional
 class FinalizeFundingHandlerIntegrationTest {
 
     private static final BigDecimal INITIAL_BALANCE = new BigDecimal("0.000000");
@@ -33,28 +36,33 @@ class FinalizeFundingHandlerIntegrationTest {
     @Autowired
     private FundingOrderRepository fundingOrderRepository;
 
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
     private Long walletId;
     private UUID fundingId;
 
     @BeforeEach
     void setUp() {
         var unique = String.valueOf(System.nanoTime());
-        var wallet = Wallet.builder()
-                .userId("finalize-user-" + unique)
-                .solanaAddress("finalize-addr-" + unique)
-                .availableBalance(INITIAL_BALANCE)
-                .totalBalance(INITIAL_BALANCE)
-                .build();
-        walletId = walletRepository.save(wallet).id();
+        transactionTemplate.executeWithoutResult(status -> {
+            var saved = walletRepository.save(Wallet.builder()
+                    .userId("finalize-user-" + unique)
+                    .solanaAddress("finalize-addr-" + unique)
+                    .availableBalance(INITIAL_BALANCE)
+                    .totalBalance(INITIAL_BALANCE)
+                    .build());
+            walletId = saved.id();
 
-        fundingId = UUID.randomUUID();
-        fundingOrderRepository.save(FundingOrder.builder()
-                .fundingId(fundingId)
-                .walletId(walletId)
-                .amountUsdc(FUNDING_AMOUNT)
-                .stripePaymentIntentId("pi_finalize_" + unique)
-                .status(FundingStatus.PAYMENT_CONFIRMED)
-                .build());
+            fundingId = UUID.randomUUID();
+            fundingOrderRepository.save(FundingOrder.builder()
+                    .fundingId(fundingId)
+                    .walletId(walletId)
+                    .amountUsdc(FUNDING_AMOUNT)
+                    .stripePaymentIntentId("pi_finalize_" + unique)
+                    .status(FundingStatus.PAYMENT_CONFIRMED)
+                    .build());
+        });
     }
 
     @Test
@@ -63,28 +71,34 @@ class FinalizeFundingHandlerIntegrationTest {
         handler.handle(fundingId, walletId, FUNDING_AMOUNT);
 
         // then
-        var reloadedWallet = walletRepository.findById(walletId).orElseThrow();
+        var reloadedWallet = reloadWallet();
         assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
         assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
-
-        var reloadedOrder = fundingOrderRepository.findByFundingId(fundingId).orElseThrow();
-        assertThat(reloadedOrder.status()).isEqualTo(FundingStatus.FUNDED);
+        assertThat(reloadOrder().status()).isEqualTo(FundingStatus.FUNDED);
     }
 
     @Test
     void shouldBeIdempotentWhenRetriedAfterSuccessfulCommit() {
-        // given — first successful invocation
+        // given — first call commits in its own transaction
         handler.handle(fundingId, walletId, FUNDING_AMOUNT);
 
-        // when — retry (e.g. Temporal ack lost after commit)
+        // when — second call (Temporal retry after ack lost) in a new transaction
         handler.handle(fundingId, walletId, FUNDING_AMOUNT);
 
-        // then — balance incremented exactly once, status remains FUNDED
-        var reloadedWallet = walletRepository.findById(walletId).orElseThrow();
+        // then — balance incremented exactly once, status stays FUNDED
+        var reloadedWallet = reloadWallet();
         assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
         assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
+        assertThat(reloadOrder().status()).isEqualTo(FundingStatus.FUNDED);
+    }
 
-        var reloadedOrder = fundingOrderRepository.findByFundingId(fundingId).orElseThrow();
-        assertThat(reloadedOrder.status()).isEqualTo(FundingStatus.FUNDED);
+    private Wallet reloadWallet() {
+        return transactionTemplate.execute(
+                status -> walletRepository.findById(walletId).orElseThrow());
+    }
+
+    private FundingOrder reloadOrder() {
+        return transactionTemplate.execute(
+                status -> fundingOrderRepository.findByFundingId(fundingId).orElseThrow());
     }
 }

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
@@ -17,10 +17,6 @@ import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.WalletRepository;
 import com.stablepay.test.PgTest;
 
-// No class-level @Transactional: each handler invocation must commit in its own
-// transaction so the retry in shouldBeIdempotentWhenRetriedAfterSuccessfulCommit
-// actually exercises the post-commit idempotency guard (status = FUNDED) rather
-// than reading dirty in-session state from the same outer transaction.
 @PgTest
 class FinalizeFundingHandlerIntegrationTest {
 

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.stablepay.domain.funding.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.test.PgTest;
+
+@PgTest
+@Transactional
+class FinalizeFundingHandlerIntegrationTest {
+
+    private static final BigDecimal INITIAL_BALANCE = new BigDecimal("0.000000");
+    private static final BigDecimal FUNDING_AMOUNT = new BigDecimal("25.000000");
+
+    @Autowired
+    private FinalizeFundingHandler handler;
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Autowired
+    private FundingOrderRepository fundingOrderRepository;
+
+    private Long walletId;
+    private UUID fundingId;
+
+    @BeforeEach
+    void setUp() {
+        var unique = String.valueOf(System.nanoTime());
+        var wallet = Wallet.builder()
+                .userId("finalize-user-" + unique)
+                .solanaAddress("finalize-addr-" + unique)
+                .availableBalance(INITIAL_BALANCE)
+                .totalBalance(INITIAL_BALANCE)
+                .build();
+        walletId = walletRepository.save(wallet).id();
+
+        fundingId = UUID.randomUUID();
+        fundingOrderRepository.save(FundingOrder.builder()
+                .fundingId(fundingId)
+                .walletId(walletId)
+                .amountUsdc(FUNDING_AMOUNT)
+                .stripePaymentIntentId("pi_finalize_" + unique)
+                .status(FundingStatus.PAYMENT_CONFIRMED)
+                .build());
+    }
+
+    @Test
+    void shouldIncrementBalanceAndFlipToFundedOnFirstInvocation() {
+        // when
+        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+
+        // then
+        var reloadedWallet = walletRepository.findById(walletId).orElseThrow();
+        assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
+        assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
+
+        var reloadedOrder = fundingOrderRepository.findByFundingId(fundingId).orElseThrow();
+        assertThat(reloadedOrder.status()).isEqualTo(FundingStatus.FUNDED);
+    }
+
+    @Test
+    void shouldBeIdempotentWhenRetriedAfterSuccessfulCommit() {
+        // given — first successful invocation
+        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+
+        // when — retry (e.g. Temporal ack lost after commit)
+        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+
+        // then — balance incremented exactly once, status remains FUNDED
+        var reloadedWallet = walletRepository.findById(walletId).orElseThrow();
+        assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
+        assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
+
+        var reloadedOrder = fundingOrderRepository.findByFundingId(fundingId).orElseThrow();
+        assertThat(reloadedOrder.status()).isEqualTo(FundingStatus.FUNDED);
+    }
+}

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
@@ -26,6 +26,10 @@ class FinalizeFundingHandlerIntegrationTest {
 
     private static final BigDecimal INITIAL_BALANCE = new BigDecimal("0.000000");
     private static final BigDecimal FUNDING_AMOUNT = new BigDecimal("25.000000");
+    private static final String[] WALLET_IGNORED_FIELDS =
+            {"id", "createdAt", "updatedAt"};
+    private static final String[] ORDER_IGNORED_FIELDS =
+            {"id", "createdAt", "updatedAt"};
 
     @Autowired
     private FinalizeFundingHandler handler;
@@ -39,25 +43,22 @@ class FinalizeFundingHandlerIntegrationTest {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
-    private Long walletId;
-    private UUID fundingId;
+    private Wallet initialWallet;
+    private FundingOrder initialOrder;
 
     @BeforeEach
     void setUp() {
         var unique = String.valueOf(System.nanoTime());
         transactionTemplate.executeWithoutResult(status -> {
-            var saved = walletRepository.save(Wallet.builder()
+            initialWallet = walletRepository.save(Wallet.builder()
                     .userId("finalize-user-" + unique)
                     .solanaAddress("finalize-addr-" + unique)
                     .availableBalance(INITIAL_BALANCE)
                     .totalBalance(INITIAL_BALANCE)
                     .build());
-            walletId = saved.id();
-
-            fundingId = UUID.randomUUID();
-            fundingOrderRepository.save(FundingOrder.builder()
-                    .fundingId(fundingId)
-                    .walletId(walletId)
+            initialOrder = fundingOrderRepository.save(FundingOrder.builder()
+                    .fundingId(UUID.randomUUID())
+                    .walletId(initialWallet.id())
                     .amountUsdc(FUNDING_AMOUNT)
                     .stripePaymentIntentId("pi_finalize_" + unique)
                     .status(FundingStatus.PAYMENT_CONFIRMED)
@@ -68,37 +69,58 @@ class FinalizeFundingHandlerIntegrationTest {
     @Test
     void shouldIncrementBalanceAndFlipToFundedOnFirstInvocation() {
         // when
-        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+        handler.handle(initialOrder.fundingId(), initialWallet.id(), FUNDING_AMOUNT);
 
         // then
-        var reloadedWallet = reloadWallet();
-        assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
-        assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
-        assertThat(reloadOrder().status()).isEqualTo(FundingStatus.FUNDED);
+        var expectedWallet = initialWallet.toBuilder()
+                .availableBalance(FUNDING_AMOUNT)
+                .totalBalance(FUNDING_AMOUNT)
+                .build();
+        assertThat(reloadWallet())
+                .usingRecursiveComparison()
+                .ignoringFields(WALLET_IGNORED_FIELDS)
+                .isEqualTo(expectedWallet);
+
+        var expectedOrder = initialOrder.toBuilder().status(FundingStatus.FUNDED).build();
+        assertThat(reloadOrder())
+                .usingRecursiveComparison()
+                .ignoringFields(ORDER_IGNORED_FIELDS)
+                .isEqualTo(expectedOrder);
     }
 
     @Test
     void shouldBeIdempotentWhenRetriedAfterSuccessfulCommit() {
         // given — first call commits in its own transaction
-        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+        handler.handle(initialOrder.fundingId(), initialWallet.id(), FUNDING_AMOUNT);
 
         // when — second call (Temporal retry after ack lost) in a new transaction
-        handler.handle(fundingId, walletId, FUNDING_AMOUNT);
+        handler.handle(initialOrder.fundingId(), initialWallet.id(), FUNDING_AMOUNT);
 
         // then — balance incremented exactly once, status stays FUNDED
-        var reloadedWallet = reloadWallet();
-        assertThat(reloadedWallet.availableBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
-        assertThat(reloadedWallet.totalBalance()).isEqualByComparingTo(FUNDING_AMOUNT);
-        assertThat(reloadOrder().status()).isEqualTo(FundingStatus.FUNDED);
+        var expectedWallet = initialWallet.toBuilder()
+                .availableBalance(FUNDING_AMOUNT)
+                .totalBalance(FUNDING_AMOUNT)
+                .build();
+        assertThat(reloadWallet())
+                .usingRecursiveComparison()
+                .ignoringFields(WALLET_IGNORED_FIELDS)
+                .isEqualTo(expectedWallet);
+
+        var expectedOrder = initialOrder.toBuilder().status(FundingStatus.FUNDED).build();
+        assertThat(reloadOrder())
+                .usingRecursiveComparison()
+                .ignoringFields(ORDER_IGNORED_FIELDS)
+                .isEqualTo(expectedOrder);
     }
 
     private Wallet reloadWallet() {
         return transactionTemplate.execute(
-                status -> walletRepository.findById(walletId).orElseThrow());
+                status -> walletRepository.findById(initialWallet.id()).orElseThrow());
     }
 
     private FundingOrder reloadOrder() {
         return transactionTemplate.execute(
-                status -> fundingOrderRepository.findByFundingId(fundingId).orElseThrow());
+                status -> fundingOrderRepository.findByFundingId(initialOrder.fundingId())
+                        .orElseThrow());
     }
 }

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowIntegrationTest.java
@@ -1,18 +1,17 @@
 package com.stablepay.infrastructure.temporal;
 
 import static com.stablepay.infrastructure.temporal.TaskQueue.Constants.TASK_QUEUE_WALLET_FUNDING;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.inOrder;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -74,12 +73,12 @@ class WalletFundingWorkflowIntegrationTest {
         newWorkflow().execute(newRequest());
 
         // then
-        var inOrder = inOrder(activities);
-        inOrder.verify(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
-        inOrder.verify(activities).ensureSolBalance(SOME_SENDER_ADDRESS);
-        inOrder.verify(activities).createAtaIfNeeded(SOME_SENDER_ADDRESS);
-        inOrder.verify(activities).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
-        inOrder.verify(activities).finalizeFunding(fundingId, walletId, SOME_AMOUNT_USDC);
+        var inOrder = BDDMockito.inOrder(activities);
+        then(activities).should(inOrder).checkTreasuryBalance(SOME_AMOUNT_USDC);
+        then(activities).should(inOrder).ensureSolBalance(SOME_SENDER_ADDRESS);
+        then(activities).should(inOrder).createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        then(activities).should(inOrder).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        then(activities).should(inOrder).finalizeFunding(fundingId, walletId, SOME_AMOUNT_USDC);
     }
 
     @Test
@@ -94,18 +93,5 @@ class WalletFundingWorkflowIntegrationTest {
 
         then(activities).should().checkTreasuryBalance(SOME_AMOUNT_USDC);
         then(activities).shouldHaveNoMoreInteractions();
-    }
-
-    @Test
-    void shouldUseCorrectTaskQueueForWalletFundingWorkflow() {
-        // given
-        given(activities.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC))
-                .willReturn(SOME_TX_SIGNATURE);
-
-        // when
-        newWorkflow().execute(newRequest());
-
-        // then
-        assertThat(TASK_QUEUE_WALLET_FUNDING).isEqualTo("stablepay-wallet-funding");
     }
 }

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.stablepay.infrastructure.temporal;
+
+import static com.stablepay.infrastructure.temporal.TaskQueue.Constants.TASK_QUEUE_WALLET_FUNDING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.test.TemporalTest;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowOptions;
+
+@TemporalTest
+class WalletFundingWorkflowIntegrationTest {
+
+    private static final String SOME_SENDER_ADDRESS = "WfItSend3r1234567890AbCdEfGhIjKlMnOp";
+    private static final BigDecimal SOME_AMOUNT_USDC = new BigDecimal("25.00");
+    private static final String SOME_TX_SIGNATURE = "WfItSig1234567890AbCdEfGhIjKlMnOpQrStUv";
+
+    @Autowired
+    private WorkflowClient workflowClient;
+
+    @Autowired
+    private WalletFundingActivities activities;
+
+    private UUID fundingId;
+    private Long walletId;
+
+    @BeforeEach
+    void setUp() {
+        fundingId = UUID.randomUUID();
+        walletId = 42L;
+        Mockito.reset(activities);
+    }
+
+    private WalletFundingWorkflow newWorkflow() {
+        return workflowClient.newWorkflowStub(
+                WalletFundingWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE_WALLET_FUNDING)
+                        .setWorkflowId(WalletFundingWorkflow.workflowId(fundingId))
+                        .build());
+    }
+
+    private WalletFundingWorkflowRequest newRequest() {
+        return WalletFundingWorkflowRequest.builder()
+                .fundingId(fundingId)
+                .walletId(walletId)
+                .senderSolanaAddress(SOME_SENDER_ADDRESS)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .build();
+    }
+
+    @Test
+    void shouldExecuteFiveActivitiesInOrderOnWalletFundingQueue() {
+        // given
+        given(activities.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC))
+                .willReturn(SOME_TX_SIGNATURE);
+
+        // when
+        newWorkflow().execute(newRequest());
+
+        // then
+        var inOrder = inOrder(activities);
+        inOrder.verify(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
+        inOrder.verify(activities).ensureSolBalance(SOME_SENDER_ADDRESS);
+        inOrder.verify(activities).createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        inOrder.verify(activities).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        inOrder.verify(activities).finalizeFunding(fundingId, walletId, SOME_AMOUNT_USDC);
+    }
+
+    @Test
+    void shouldFailWorkflowAndSkipDownstreamActivitiesWhenTreasuryIsEmpty() {
+        // given
+        willThrow(TreasuryDepletedException.insufficientTreasury(SOME_AMOUNT_USDC, BigDecimal.ZERO))
+                .given(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
+
+        // when / then
+        assertThatThrownBy(() -> newWorkflow().execute(newRequest()))
+                .isInstanceOf(WorkflowFailedException.class);
+
+        then(activities).should().checkTreasuryBalance(SOME_AMOUNT_USDC);
+        then(activities).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldUseCorrectTaskQueueForWalletFundingWorkflow() {
+        // given
+        given(activities.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC))
+                .willReturn(SOME_TX_SIGNATURE);
+
+        // when
+        newWorkflow().execute(newRequest());
+
+        // then
+        assertThat(TASK_QUEUE_WALLET_FUNDING).isEqualTo("stablepay-wallet-funding");
+    }
+}

--- a/backend/src/integration-test/java/com/stablepay/test/TemporalTestConfig.java
+++ b/backend/src/integration-test/java/com/stablepay/test/TemporalTestConfig.java
@@ -1,5 +1,7 @@
 package com.stablepay.test;
 
+import java.util.List;
+
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +10,8 @@ import org.springframework.context.annotation.Primary;
 import com.stablepay.infrastructure.temporal.RemittanceLifecycleActivities;
 import com.stablepay.infrastructure.temporal.RemittanceLifecycleWorkflowImpl;
 import com.stablepay.infrastructure.temporal.TaskQueue;
+import com.stablepay.infrastructure.temporal.WalletFundingActivities;
+import com.stablepay.infrastructure.temporal.WalletFundingWorkflowImpl;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -33,13 +37,38 @@ public class TemporalTestConfig {
     }
 
     @Bean
-    Worker worker(
+    @Primary
+    WalletFundingActivities walletFundingActivities() {
+        return Mockito.mock(WalletFundingActivities.class);
+    }
+
+    @Bean
+    Worker remittanceLifecycleWorker(
             TestWorkflowEnvironment testEnv,
             RemittanceLifecycleActivities activities) {
         var worker = testEnv.newWorker(TaskQueue.REMITTANCE_LIFECYCLE.getName());
         worker.registerWorkflowImplementationTypes(RemittanceLifecycleWorkflowImpl.class);
         worker.registerActivitiesImplementations(activities);
-        testEnv.start();
         return worker;
     }
+
+    @Bean
+    Worker walletFundingWorker(
+            TestWorkflowEnvironment testEnv,
+            WalletFundingActivities activities) {
+        var worker = testEnv.newWorker(TaskQueue.WALLET_FUNDING.getName());
+        worker.registerWorkflowImplementationTypes(WalletFundingWorkflowImpl.class);
+        worker.registerActivitiesImplementations(activities);
+        return worker;
+    }
+
+    // Starts the TestWorkflowEnvironment exactly once after ALL workers are registered.
+    @Bean
+    TemporalEnvironmentStarter temporalEnvironmentStarter(
+            TestWorkflowEnvironment testEnv, List<Worker> workers) {
+        testEnv.start();
+        return new TemporalEnvironmentStarter(workers.size());
+    }
+
+    public record TemporalEnvironmentStarter(int workerCount) {}
 }

--- a/backend/src/integration-test/java/com/stablepay/test/TemporalTestConfig.java
+++ b/backend/src/integration-test/java/com/stablepay/test/TemporalTestConfig.java
@@ -62,7 +62,6 @@ public class TemporalTestConfig {
         return worker;
     }
 
-    // Starts the TestWorkflowEnvironment exactly once after ALL workers are registered.
     @Bean
     TemporalEnvironmentStarter temporalEnvironmentStarter(
             TestWorkflowEnvironment testEnv, List<Worker> workers) {

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
 import com.stablepay.domain.funding.port.FundingWorkflowStarter;
@@ -63,19 +62,18 @@ public class CompleteFundingHandler {
         }
         var wallet = walletOpt.get();
 
-        var funded = order.toBuilder().status(FundingStatus.FUNDED).build();
-        FundingOrder persisted = fundingOrderRepository.save(funded);
-        log.info("Funding order confirmed fundingId={} walletId={} status={}",
-                persisted.fundingId(), persisted.walletId(), persisted.status());
+        log.info(
+                "Starting wallet funding workflow fundingId={} walletId={}",
+                fundingId, order.walletId());
 
         fundingWorkflowStarter.ifPresentOrElse(
                 starter -> starter.startFundingWorkflow(
-                        persisted.fundingId(),
-                        persisted.walletId(),
+                        order.fundingId(),
+                        order.walletId(),
                         wallet.solanaAddress(),
-                        persisted.amountUsdc()),
+                        order.amountUsdc()),
                 () -> log.warn(
                         "FundingWorkflowStarter not configured; skipping workflow start for fundingId={}",
-                        persisted.fundingId()));
+                        order.fundingId()));
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/CompleteFundingHandler.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class CompleteFundingHandler {
 
     private static final Set<FundingStatus> TERMINAL_STATUSES = Set.of(

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/FinalizeFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/FinalizeFundingHandler.java
@@ -1,0 +1,57 @@
+package com.stablepay.domain.funding.handler;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinalizeFundingHandler {
+
+    private final WalletRepository walletRepository;
+    private final FundingOrderRepository fundingOrderRepository;
+
+    @Transactional
+    public void handle(UUID fundingId, Long walletId, BigDecimal amountUsdc) {
+        requireNonNull(fundingId, "fundingId cannot be null");
+        requireNonNull(walletId, "walletId cannot be null");
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+
+        var wallet = walletRepository.findById(walletId)
+                .orElseThrow(() -> WalletNotFoundException.byId(walletId));
+        var order = fundingOrderRepository.findByFundingId(fundingId)
+                .orElseThrow(() -> FundingOrderNotFoundException.byFundingId(fundingId));
+
+        if (order.status() == FundingStatus.FUNDED) {
+            log.info("finalizeFunding no-op: fundingId={} already FUNDED", fundingId);
+            return;
+        }
+
+        var creditedWallet = wallet.toBuilder()
+                .availableBalance(wallet.availableBalance().add(amountUsdc))
+                .totalBalance(wallet.totalBalance().add(amountUsdc))
+                .build();
+        walletRepository.save(creditedWallet);
+
+        var fundedOrder = order.toBuilder().status(FundingStatus.FUNDED).build();
+        fundingOrderRepository.save(fundedOrder);
+
+        log.info(
+                "finalizeFunding committed fundingId={} walletId={} amount={} newAvailable={}",
+                fundingId, walletId, amountUsdc, creditedWallet.availableBalance());
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/port/TreasuryService.java
@@ -4,13 +4,15 @@ import java.math.BigDecimal;
 
 public interface TreasuryService {
 
-    void transferUsdc(String destinationAddress, BigDecimal amountUsdc);
+    String transferUsdc(String destinationAddress, BigDecimal amountUsdc);
 
-    void transferSol(String destinationAddress, long lamports);
+    String transferSol(String destinationAddress, long lamports);
 
     BigDecimal getSolBalance(String address);
 
     BigDecimal getUsdcBalance(String address);
+
+    BigDecimal getTreasuryUsdcBalance();
 
     void createAtaIfNeeded(String ownerAddress);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -38,7 +38,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
     private final TreasuryProperties treasuryProperties;
 
     @Override
-    public void transferSol(String destinationAddress, long lamports) {
+    public String transferSol(String destinationAddress, long lamports) {
         log.info("Treasury transferring {} lamports to {}", lamports, destinationAddress);
 
         try {
@@ -56,6 +56,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var opContext = "treasury-sol:" + destinationAddress;
             var signature = sendWithSkipPreflight(transaction.serialize(), opContext);
             log.info("Treasury SOL transfer submitted with signature {}", signature);
+            return signature;
         } catch (SolanaTransactionException e) {
             throw e;
         } catch (Exception e) {
@@ -65,7 +66,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
     }
 
     @Override
-    public void transferUsdc(String destinationAddress, BigDecimal amountUsdc) {
+    public String transferUsdc(String destinationAddress, BigDecimal amountUsdc) {
         log.info("Treasury transferring {} USDC to {}", amountUsdc, destinationAddress);
 
         try {
@@ -91,6 +92,7 @@ public class TreasuryServiceAdapter implements TreasuryService {
             var opContext = "treasury-usdc:" + destinationAddress;
             var signature = sendWithSkipPreflight(transaction.serialize(), opContext);
             log.info("Treasury USDC transfer submitted with signature {}", signature);
+            return signature;
         } catch (SolanaTransactionException e) {
             throw e;
         } catch (Exception e) {
@@ -108,6 +110,12 @@ public class TreasuryServiceAdapter implements TreasuryService {
             throw SolanaTransactionException.submissionFailed(
                     "treasury-sol-balance:" + address, e);
         }
+    }
+
+    @Override
+    public BigDecimal getTreasuryUsdcBalance() {
+        var treasuryKeypair = resolveTreasuryKeypair();
+        return getUsdcBalance(treasuryKeypair.getPublicKey().toBase58());
     }
 
     @Override

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -112,10 +112,6 @@ public class TreasuryServiceAdapter implements TreasuryService {
         }
     }
 
-    // Strict balance query for authorization checks: propagates RPC failures as
-    // SolanaTransactionException so callers can distinguish "treasury depleted"
-    // from "RPC transiently unreachable". Does NOT use the fail-closed ZERO
-    // sentinel that getUsdcBalance uses for arbitrary addresses.
     @Override
     public BigDecimal getTreasuryUsdcBalance() {
         var treasuryKeypair = resolveTreasuryKeypair();

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/TreasuryServiceAdapter.java
@@ -112,10 +112,23 @@ public class TreasuryServiceAdapter implements TreasuryService {
         }
     }
 
+    // Strict balance query for authorization checks: propagates RPC failures as
+    // SolanaTransactionException so callers can distinguish "treasury depleted"
+    // from "RPC transiently unreachable". Does NOT use the fail-closed ZERO
+    // sentinel that getUsdcBalance uses for arbitrary addresses.
     @Override
     public BigDecimal getTreasuryUsdcBalance() {
         var treasuryKeypair = resolveTreasuryKeypair();
-        return getUsdcBalance(treasuryKeypair.getPublicKey().toBase58());
+        var treasuryPubkey = treasuryKeypair.getPublicKey();
+        var ata = deriveAta(treasuryPubkey, solanaProperties.usdcMint());
+        try {
+            var balance = solanaConnection.getTokenAccountBalance(ata);
+            return new BigDecimal(balance.getAmount())
+                    .divide(USDC_SCALE, USDC_DECIMALS, RoundingMode.DOWN);
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "treasury-usdc-balance:" + treasuryPubkey.toBase58(), e);
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
@@ -94,7 +94,6 @@ public class TemporalConfig {
         return worker;
     }
 
-    // Must be called exactly ONCE after ALL workers are registered.
     @Bean
     @Profile("!test")
     CommandLineRunner workerFactoryStarter(WorkerFactory workerFactory, List<Worker> workers) {

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
@@ -2,7 +2,6 @@ package com.stablepay.infrastructure.temporal;
 
 import java.util.List;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -74,26 +73,24 @@ public class TemporalConfig {
     @Bean
     @Profile("!test")
     Worker remittanceLifecycleWorker(
-            WorkerFactory workerFactory,
-            ObjectProvider<RemittanceLifecycleActivities> activitiesProvider) {
+            WorkerFactory workerFactory, RemittanceLifecycleActivities activities) {
         var taskQueue = TaskQueue.REMITTANCE_LIFECYCLE.getName();
         log.info("Registering Temporal worker for task queue {}", taskQueue);
         var worker = workerFactory.newWorker(taskQueue);
         worker.registerWorkflowImplementationTypes(RemittanceLifecycleWorkflowImpl.class);
-        activitiesProvider.ifAvailable(worker::registerActivitiesImplementations);
+        worker.registerActivitiesImplementations(activities);
         return worker;
     }
 
     @Bean
     @Profile("!test")
     Worker walletFundingWorker(
-            WorkerFactory workerFactory,
-            ObjectProvider<WalletFundingActivities> activitiesProvider) {
+            WorkerFactory workerFactory, WalletFundingActivities activities) {
         var taskQueue = TaskQueue.WALLET_FUNDING.getName();
         log.info("Registering Temporal worker for task queue {}", taskQueue);
         var worker = workerFactory.newWorker(taskQueue);
         worker.registerWorkflowImplementationTypes(WalletFundingWorkflowImpl.class);
-        activitiesProvider.ifAvailable(worker::registerActivitiesImplementations);
+        worker.registerActivitiesImplementations(activities);
         return worker;
     }
 

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalConfig.java
@@ -1,6 +1,9 @@
 package com.stablepay.infrastructure.temporal;
 
+import java.util.List;
+
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -70,16 +73,37 @@ public class TemporalConfig {
 
     @Bean
     @Profile("!test")
-    Worker worker(
+    Worker remittanceLifecycleWorker(
             WorkerFactory workerFactory,
             ObjectProvider<RemittanceLifecycleActivities> activitiesProvider) {
         var taskQueue = TaskQueue.REMITTANCE_LIFECYCLE.getName();
-        log.info("Creating Temporal worker for task queue {}", taskQueue);
+        log.info("Registering Temporal worker for task queue {}", taskQueue);
         var worker = workerFactory.newWorker(taskQueue);
         worker.registerWorkflowImplementationTypes(RemittanceLifecycleWorkflowImpl.class);
         activitiesProvider.ifAvailable(worker::registerActivitiesImplementations);
-        workerFactory.start();
-        log.info("Temporal WorkerFactory started, polling task queue {}", taskQueue);
         return worker;
+    }
+
+    @Bean
+    @Profile("!test")
+    Worker walletFundingWorker(
+            WorkerFactory workerFactory,
+            ObjectProvider<WalletFundingActivities> activitiesProvider) {
+        var taskQueue = TaskQueue.WALLET_FUNDING.getName();
+        log.info("Registering Temporal worker for task queue {}", taskQueue);
+        var worker = workerFactory.newWorker(taskQueue);
+        worker.registerWorkflowImplementationTypes(WalletFundingWorkflowImpl.class);
+        activitiesProvider.ifAvailable(worker::registerActivitiesImplementations);
+        return worker;
+    }
+
+    // Must be called exactly ONCE after ALL workers are registered.
+    @Bean
+    @Profile("!test")
+    CommandLineRunner workerFactoryStarter(WorkerFactory workerFactory, List<Worker> workers) {
+        return args -> {
+            workerFactory.start();
+            log.info("Temporal WorkerFactory started with {} worker(s)", workers.size());
+        };
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
@@ -73,13 +73,14 @@ public class TemporalFundingWorkflowStarter implements FundingWorkflowStarter {
                     fundingId,
                     e);
         } catch (RuntimeException e) {
-            // FundingOrder is already FUNDED in the DB (this runs afterCommit). A Stripe
-            // retry will no-op on the terminal status, so this workflow will NOT be started
-            // by any future webhook. Log loudly so operators can manually reconcile.
+            // FundingOrder stays in PAYMENT_CONFIRMED (the FUNDED flip now happens inside
+            // the workflow's finalizeFunding activity, per spec appendix #25). A Stripe
+            // retry will re-enter CompleteFundingHandler and retry the start. Log loudly
+            // so operators can investigate if retries don't arrive.
             // Follow-up: STA-84 adds an outbox + reconciler to recover automatically.
             log.error(
-                    "CRITICAL: wallet funding workflow start FAILED after FUNDED committed "
-                            + "fundingId={} walletId={} — manual reconciliation required",
+                    "wallet funding workflow start FAILED fundingId={} walletId={} — "
+                            + "relying on Stripe webhook retry",
                     fundingId, walletId, e);
         }
     }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalFundingWorkflowStarter.java
@@ -73,11 +73,6 @@ public class TemporalFundingWorkflowStarter implements FundingWorkflowStarter {
                     fundingId,
                     e);
         } catch (RuntimeException e) {
-            // FundingOrder stays in PAYMENT_CONFIRMED (the FUNDED flip now happens inside
-            // the workflow's finalizeFunding activity, per spec appendix #25). A Stripe
-            // retry will re-enter CompleteFundingHandler and retry the start. Log loudly
-            // so operators can investigate if retries don't arrive.
-            // Follow-up: STA-84 adds an outbox + reconciler to recover automatically.
             log.error(
                     "wallet funding workflow start FAILED fundingId={} walletId={} — "
                             + "relying on Stripe webhook retry",

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivities.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivities.java
@@ -1,0 +1,20 @@
+package com.stablepay.infrastructure.temporal;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface WalletFundingActivities {
+
+    void checkTreasuryBalance(BigDecimal amountUsdc);
+
+    void ensureSolBalance(String senderSolanaAddress);
+
+    void createAtaIfNeeded(String senderSolanaAddress);
+
+    String transferUsdc(String senderSolanaAddress, BigDecimal amountUsdc);
+
+    void finalizeFunding(UUID fundingId, Long walletId, BigDecimal amountUsdc);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImpl.java
@@ -1,0 +1,73 @@
+package com.stablepay.infrastructure.temporal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.funding.handler.FinalizeFundingHandler;
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.port.TreasuryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WalletFundingActivitiesImpl implements WalletFundingActivities {
+
+    private static final BigDecimal MIN_SENDER_SOL = new BigDecimal("0.005");
+    private static final long SOL_TOP_UP_LAMPORTS = 10_000_000L;
+
+    private final TreasuryService treasuryService;
+    private final FinalizeFundingHandler finalizeFundingHandler;
+
+    @Override
+    public void checkTreasuryBalance(BigDecimal amountUsdc) {
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        var available = treasuryService.getTreasuryUsdcBalance();
+        if (available.compareTo(amountUsdc) < 0) {
+            log.error("Treasury USDC insufficient requested={} available={}", amountUsdc, available);
+            throw TreasuryDepletedException.insufficientTreasury(amountUsdc, available);
+        }
+        log.info("Treasury USDC sufficient requested={} available={}", amountUsdc, available);
+    }
+
+    @Override
+    public void ensureSolBalance(String senderSolanaAddress) {
+        requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
+        var senderSol = treasuryService.getSolBalance(senderSolanaAddress);
+        if (senderSol.compareTo(MIN_SENDER_SOL) >= 0) {
+            log.debug("Sender {} SOL {} >= {} — no top-up",
+                    senderSolanaAddress, senderSol, MIN_SENDER_SOL);
+            return;
+        }
+        log.info("Topping up sender {} with {} lamports (current {} SOL)",
+                senderSolanaAddress, SOL_TOP_UP_LAMPORTS, senderSol);
+        treasuryService.transferSol(senderSolanaAddress, SOL_TOP_UP_LAMPORTS);
+    }
+
+    @Override
+    public void createAtaIfNeeded(String senderSolanaAddress) {
+        requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
+        treasuryService.createAtaIfNeeded(senderSolanaAddress);
+    }
+
+    @Override
+    public String transferUsdc(String senderSolanaAddress, BigDecimal amountUsdc) {
+        requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        return treasuryService.transferUsdc(senderSolanaAddress, amountUsdc);
+    }
+
+    @Override
+    public void finalizeFunding(UUID fundingId, Long walletId, BigDecimal amountUsdc) {
+        requireNonNull(fundingId, "fundingId cannot be null");
+        requireNonNull(walletId, "walletId cannot be null");
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        finalizeFundingHandler.handle(fundingId, walletId, amountUsdc);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImpl.java
@@ -27,7 +27,7 @@ public class WalletFundingActivitiesImpl implements WalletFundingActivities {
 
     @Override
     public void checkTreasuryBalance(BigDecimal amountUsdc) {
-        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        requirePositiveAmount(amountUsdc);
         var available = treasuryService.getTreasuryUsdcBalance();
         if (available.compareTo(amountUsdc) < 0) {
             log.error("Treasury USDC insufficient requested={} available={}", amountUsdc, available);
@@ -59,7 +59,7 @@ public class WalletFundingActivitiesImpl implements WalletFundingActivities {
     @Override
     public String transferUsdc(String senderSolanaAddress, BigDecimal amountUsdc) {
         requireNonNull(senderSolanaAddress, "senderSolanaAddress cannot be null");
-        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        requirePositiveAmount(amountUsdc);
         return treasuryService.transferUsdc(senderSolanaAddress, amountUsdc);
     }
 
@@ -67,7 +67,15 @@ public class WalletFundingActivitiesImpl implements WalletFundingActivities {
     public void finalizeFunding(UUID fundingId, Long walletId, BigDecimal amountUsdc) {
         requireNonNull(fundingId, "fundingId cannot be null");
         requireNonNull(walletId, "walletId cannot be null");
-        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        requirePositiveAmount(amountUsdc);
         finalizeFundingHandler.handle(fundingId, walletId, amountUsdc);
+    }
+
+    private static void requirePositiveAmount(BigDecimal amountUsdc) {
+        requireNonNull(amountUsdc, "amountUsdc cannot be null");
+        if (amountUsdc.signum() <= 0) {
+            throw new IllegalArgumentException(
+                    "amountUsdc must be positive, got: " + amountUsdc);
+        }
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
@@ -1,0 +1,92 @@
+package com.stablepay.infrastructure.temporal;
+
+import java.time.Duration;
+
+import org.slf4j.Logger;
+
+import com.stablepay.infrastructure.temporal.TaskQueue.Constants;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.common.RetryOptions;
+import io.temporal.spring.boot.WorkflowImpl;
+import io.temporal.workflow.Workflow;
+
+@WorkflowImpl(taskQueues = Constants.TASK_QUEUE_WALLET_FUNDING)
+public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
+
+    private static final Logger log = Workflow.getLogger(WalletFundingWorkflowImpl.class);
+
+    private final WalletFundingActivities treasuryCheckActivity =
+            Workflow.newActivityStub(WalletFundingActivities.class, treasuryCheckOptions());
+    private final WalletFundingActivities solTopUpActivity =
+            Workflow.newActivityStub(WalletFundingActivities.class, solTopUpOptions());
+    private final WalletFundingActivities ataActivity =
+            Workflow.newActivityStub(WalletFundingActivities.class, ataOptions());
+    private final WalletFundingActivities transferActivity =
+            Workflow.newActivityStub(WalletFundingActivities.class, transferOptions());
+    private final WalletFundingActivities finalizeActivity =
+            Workflow.newActivityStub(WalletFundingActivities.class, finalizeOptions());
+
+    @Override
+    public void execute(WalletFundingWorkflowRequest request) {
+        log.info("Starting wallet funding workflow fundingId={} walletId={}",
+                request.fundingId(), request.walletId());
+
+        treasuryCheckActivity.checkTreasuryBalance(request.amountUsdc());
+        solTopUpActivity.ensureSolBalance(request.senderSolanaAddress());
+        ataActivity.createAtaIfNeeded(request.senderSolanaAddress());
+        var signature = transferActivity.transferUsdc(
+                request.senderSolanaAddress(), request.amountUsdc());
+        log.info("USDC transfer submitted fundingId={} signature={}",
+                request.fundingId(), signature);
+        finalizeActivity.finalizeFunding(
+                request.fundingId(), request.walletId(), request.amountUsdc());
+
+        log.info("Wallet funding workflow completed fundingId={}", request.fundingId());
+    }
+
+    private static ActivityOptions treasuryCheckOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(10))
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(1)
+                        .build())
+                .build();
+    }
+
+    private static ActivityOptions solTopUpOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(30))
+                .setRetryOptions(standardRetry())
+                .build();
+    }
+
+    private static ActivityOptions ataOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(30))
+                .setRetryOptions(standardRetry())
+                .build();
+    }
+
+    private static ActivityOptions transferOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(60))
+                .setRetryOptions(standardRetry())
+                .build();
+    }
+
+    private static ActivityOptions finalizeOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(Duration.ofSeconds(15))
+                .setRetryOptions(standardRetry())
+                .build();
+    }
+
+    private static RetryOptions standardRetry() {
+        return RetryOptions.newBuilder()
+                .setMaximumAttempts(3)
+                .setInitialInterval(Duration.ofSeconds(2))
+                .setBackoffCoefficient(2.0)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
@@ -16,6 +16,11 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
 
     private static final Logger log = Workflow.getLogger(WalletFundingWorkflowImpl.class);
 
+    private static final String TREASURY_DEPLETED_EXCEPTION =
+            "com.stablepay.domain.wallet.exception.TreasuryDepletedException";
+    private static final String ILLEGAL_ARGUMENT_EXCEPTION =
+            "java.lang.IllegalArgumentException";
+
     private final WalletFundingActivities treasuryCheckActivity =
             Workflow.newActivityStub(WalletFundingActivities.class, treasuryCheckOptions());
     private final WalletFundingActivities solTopUpActivity =
@@ -45,9 +50,9 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
         log.info("Wallet funding workflow completed fundingId={}", request.fundingId());
     }
 
-    // Treasury depletion is a permanent business failure — don't retry. Any
-    // other exception (RPC transient) must retry up to 3 times so a flaky
-    // Solana RPC call doesn't permanently fail an otherwise-fundable workflow.
+    // Treasury depletion is a permanent business failure — don't retry.
+    // IllegalArgumentException signals a programming error upstream (non-positive
+    // amount) that will not change across retries.
     private static ActivityOptions treasuryCheckOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(10))
@@ -55,16 +60,25 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
                         .setMaximumAttempts(3)
                         .setInitialInterval(Duration.ofSeconds(1))
                         .setBackoffCoefficient(2.0)
-                        .setDoNotRetry(
-                                "com.stablepay.domain.wallet.exception.TreasuryDepletedException")
+                        .setDoNotRetry(TREASURY_DEPLETED_EXCEPTION, ILLEGAL_ARGUMENT_EXCEPTION)
                         .build())
                 .build();
     }
 
+    // 10s initial interval gives Solana confirmation time to propagate so the
+    // pre-check on a retry reads the post-transfer balance rather than stale
+    // pre-transfer state. Combined with the pre-check short-circuit this
+    // narrows (but does not eliminate) the double-send window. Revisit after
+    // STA-84 adds signature-persisted idempotency.
     private static ActivityOptions solTopUpOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(30))
-                .setRetryOptions(standardRetry())
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(3)
+                        .setInitialInterval(Duration.ofSeconds(10))
+                        .setBackoffCoefficient(2.0)
+                        .setDoNotRetry(ILLEGAL_ARGUMENT_EXCEPTION)
+                        .build())
                 .build();
     }
 
@@ -79,15 +93,13 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
     // activity that actually succeeded on-chain could be retried and produce a
     // second USDC transfer. Until STA-84 adds signature persistence keyed by
     // fundingId, cap this activity at a single attempt and let the workflow
-    // fail (operators re-drive). ensureSolBalance stays retryable because its
-    // pre-check naturally short-circuits if the sender already holds SOL, and
-    // createAtaIfNeeded stays retryable because its pre-check detects an
-    // existing ATA.
+    // fail (operators re-drive).
     private static ActivityOptions transferOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(60))
                 .setRetryOptions(RetryOptions.newBuilder()
                         .setMaximumAttempts(1)
+                        .setDoNotRetry(ILLEGAL_ARGUMENT_EXCEPTION)
                         .build())
                 .build();
     }
@@ -104,6 +116,7 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
                 .setMaximumAttempts(3)
                 .setInitialInterval(Duration.ofSeconds(2))
                 .setBackoffCoefficient(2.0)
+                .setDoNotRetry(ILLEGAL_ARGUMENT_EXCEPTION)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
@@ -50,9 +50,6 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
         log.info("Wallet funding workflow completed fundingId={}", request.fundingId());
     }
 
-    // Treasury depletion is a permanent business failure — don't retry.
-    // IllegalArgumentException signals a programming error upstream (non-positive
-    // amount) that will not change across retries.
     private static ActivityOptions treasuryCheckOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(10))
@@ -65,11 +62,6 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
                 .build();
     }
 
-    // 10s initial interval gives Solana confirmation time to propagate so the
-    // pre-check on a retry reads the post-transfer balance rather than stale
-    // pre-transfer state. Combined with the pre-check short-circuit this
-    // narrows (but does not eliminate) the double-send window. Revisit after
-    // STA-84 adds signature-persisted idempotency.
     private static ActivityOptions solTopUpOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(30))
@@ -89,11 +81,6 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
                 .build();
     }
 
-    // transferUsdc has no signature-persistence idempotency, so a timed-out
-    // activity that actually succeeded on-chain could be retried and produce a
-    // second USDC transfer. Until STA-84 adds signature persistence keyed by
-    // fundingId, cap this activity at a single attempt and let the workflow
-    // fail (operators re-drive).
     private static ActivityOptions transferOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(60))

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
@@ -45,11 +45,18 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
         log.info("Wallet funding workflow completed fundingId={}", request.fundingId());
     }
 
+    // Treasury depletion is a permanent business failure — don't retry. Any
+    // other exception (RPC transient) must retry up to 3 times so a flaky
+    // Solana RPC call doesn't permanently fail an otherwise-fundable workflow.
     private static ActivityOptions treasuryCheckOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(10))
                 .setRetryOptions(RetryOptions.newBuilder()
-                        .setMaximumAttempts(1)
+                        .setMaximumAttempts(3)
+                        .setInitialInterval(Duration.ofSeconds(1))
+                        .setBackoffCoefficient(2.0)
+                        .setDoNotRetry(
+                                "com.stablepay.domain.wallet.exception.TreasuryDepletedException")
                         .build())
                 .build();
     }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImpl.java
@@ -75,10 +75,20 @@ public class WalletFundingWorkflowImpl implements WalletFundingWorkflow {
                 .build();
     }
 
+    // transferUsdc has no signature-persistence idempotency, so a timed-out
+    // activity that actually succeeded on-chain could be retried and produce a
+    // second USDC transfer. Until STA-84 adds signature persistence keyed by
+    // fundingId, cap this activity at a single attempt and let the workflow
+    // fail (operators re-drive). ensureSolBalance stays retryable because its
+    // pre-check naturally short-circuits if the sender already holds SOL, and
+    // createAtaIfNeeded stays retryable because its pre-check detects an
+    // existing ATA.
     private static ActivityOptions transferOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(Duration.ofSeconds(60))
-                .setRetryOptions(standardRetry())
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(1)
+                        .build())
                 .build();
     }
 

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerTest.java
@@ -6,7 +6,6 @@ import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
 import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -15,12 +14,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
 import com.stablepay.domain.funding.port.FundingWorkflowStarter;
@@ -40,9 +36,6 @@ class CompleteFundingHandlerTest {
 
     private CompleteFundingHandler completeFundingHandler;
 
-    @Captor
-    private ArgumentCaptor<FundingOrder> fundingOrderCaptor;
-
     @BeforeEach
     void setUp() {
         completeFundingHandler = new CompleteFundingHandler(
@@ -50,23 +43,19 @@ class CompleteFundingHandlerTest {
     }
 
     @Test
-    void shouldMarkOrderFundedAndStartWorkflow() {
+    void shouldStartWorkflowWithoutFlippingStatus() {
         // given
         var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
         var wallet = walletBuilder().id(SOME_WALLET_ID).solanaAddress(SOME_SOLANA_ADDRESS).build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
         given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
-        given(fundingOrderRepository.save(fundingOrderCaptor.capture()))
-                .willAnswer(invocation -> invocation.<FundingOrder>getArgument(0));
 
         // when
         completeFundingHandler.handle(SOME_FUNDING_ID);
 
         // then
-        var expectedSaved = order.toBuilder().status(FundingStatus.FUNDED).build();
-        assertThat(fundingOrderCaptor.getValue())
-                .usingRecursiveComparison()
-                .isEqualTo(expectedSaved);
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
         then(fundingWorkflowStarter).should()
                 .startFundingWorkflow(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_SOLANA_ADDRESS, SOME_AMOUNT_USDC);
     }
@@ -198,7 +187,7 @@ class CompleteFundingHandlerTest {
     }
 
     @Test
-    void shouldMarkOrderFundedEvenWhenWorkflowStarterIsAbsent() {
+    void shouldStillValidateWhenWorkflowStarterIsAbsent() {
         // given
         var handlerWithoutStarter = new CompleteFundingHandler(
                 fundingOrderRepository, walletRepository, Optional.empty());
@@ -206,17 +195,13 @@ class CompleteFundingHandlerTest {
         var wallet = walletBuilder().id(SOME_WALLET_ID).solanaAddress(SOME_SOLANA_ADDRESS).build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
         given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
-        given(fundingOrderRepository.save(fundingOrderCaptor.capture()))
-                .willAnswer(invocation -> invocation.<FundingOrder>getArgument(0));
 
         // when
         handlerWithoutStarter.handle(SOME_FUNDING_ID);
 
         // then
-        var expectedSaved = order.toBuilder().status(FundingStatus.FUNDED).build();
-        assertThat(fundingOrderCaptor.getValue())
-                .usingRecursiveComparison()
-                .isEqualTo(expectedSaved);
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
         then(fundingWorkflowStarter).shouldHaveNoInteractions();
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
@@ -4,6 +4,7 @@ import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static com.stablepay.testutil.WalletFundingFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.WalletFundingFixtures.SOME_WALLET_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -71,13 +72,13 @@ class FinalizeFundingHandlerTest {
                 .availableBalance(new BigDecimal("35.000000"))
                 .totalBalance(new BigDecimal("35.000000"))
                 .build();
-        org.assertj.core.api.Assertions.assertThat(walletCaptor.getValue())
+        assertThat(walletCaptor.getValue())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedWallet);
 
         then(fundingOrderRepository).should().save(orderCaptor.capture());
         var expectedOrder = order.toBuilder().status(FundingStatus.FUNDED).build();
-        org.assertj.core.api.Assertions.assertThat(orderCaptor.getValue())
+        assertThat(orderCaptor.getValue())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedOrder);
     }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
@@ -1,0 +1,135 @@
+package com.stablepay.domain.funding.handler;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_WALLET_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.WalletRepository;
+import com.stablepay.testutil.FundingOrderFixtures;
+
+@ExtendWith(MockitoExtension.class)
+class FinalizeFundingHandlerTest {
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private FundingOrderRepository fundingOrderRepository;
+
+    @InjectMocks
+    private FinalizeFundingHandler handler;
+
+    @Captor
+    private ArgumentCaptor<Wallet> walletCaptor;
+
+    @Captor
+    private ArgumentCaptor<FundingOrder> orderCaptor;
+
+    @Test
+    void shouldIncrementBalancesAndFlipToFundedAtomically() {
+        // given
+        var wallet = walletBuilder()
+                .id(SOME_WALLET_ID)
+                .availableBalance(new BigDecimal("10.000000"))
+                .totalBalance(new BigDecimal("10.000000"))
+                .build();
+        var order = FundingOrderFixtures.fundingOrderBuilder()
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .status(FundingStatus.PAYMENT_CONFIRMED)
+                .build();
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+
+        // then
+        then(walletRepository).should().save(walletCaptor.capture());
+        var expectedWallet = wallet.toBuilder()
+                .availableBalance(new BigDecimal("35.000000"))
+                .totalBalance(new BigDecimal("35.000000"))
+                .build();
+        org.assertj.core.api.Assertions.assertThat(walletCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedWallet);
+
+        then(fundingOrderRepository).should().save(orderCaptor.capture());
+        var expectedOrder = order.toBuilder().status(FundingStatus.FUNDED).build();
+        org.assertj.core.api.Assertions.assertThat(orderCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedOrder);
+    }
+
+    @Test
+    void shouldShortCircuitWhenStatusAlreadyFunded() {
+        // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
+        var order = FundingOrderFixtures.fundingOrderBuilder()
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .status(FundingStatus.FUNDED)
+                .build();
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when
+        handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+
+        // then
+        then(walletRepository).should().findById(SOME_WALLET_ID);
+        then(walletRepository).shouldHaveNoMoreInteractions();
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenWalletNotFound() {
+        // given
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006");
+
+        then(fundingOrderRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenFundingOrderNotFound() {
+        // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC))
+                .isInstanceOf(FundingOrderNotFoundException.class)
+                .hasMessageContaining("SP-0020");
+
+        then(walletRepository).should().findById(SOME_WALLET_ID);
+        then(walletRepository).shouldHaveNoMoreInteractions();
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
@@ -67,6 +67,39 @@ class WalletFundingActivitiesImplTest {
     }
 
     @Test
+    void shouldRejectNonPositiveAmountOnCheckTreasuryBalance() {
+        // given
+        var zero = BigDecimal.ZERO;
+
+        // when / then
+        assertThatThrownBy(() -> activities.checkTreasuryBalance(zero))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amountUsdc must be positive");
+    }
+
+    @Test
+    void shouldRejectNegativeAmountOnTransferUsdc() {
+        // given
+        var negative = new BigDecimal("-1.00");
+
+        // when / then
+        assertThatThrownBy(() -> activities.transferUsdc(SOME_SENDER_ADDRESS, negative))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amountUsdc must be positive");
+    }
+
+    @Test
+    void shouldRejectZeroAmountOnFinalizeFunding() {
+        // given
+        var zero = BigDecimal.ZERO;
+
+        // when / then
+        assertThatThrownBy(() -> activities.finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, zero))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amountUsdc must be positive");
+    }
+
+    @Test
     void shouldPropagateSolanaExceptionWhenBalanceQueryFails() {
         // given
         var rpcFailure = SolanaTransactionException.submissionFailed(

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
@@ -17,11 +17,13 @@ import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.stablepay.domain.funding.handler.FinalizeFundingHandler;
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 import com.stablepay.domain.wallet.port.TreasuryService;
 
@@ -62,6 +64,20 @@ class WalletFundingActivitiesImplTest {
         assertThatThrownBy(() -> activities.checkTreasuryBalance(SOME_AMOUNT_USDC))
                 .isInstanceOf(TreasuryDepletedException.class)
                 .hasMessageContaining("SP-0007");
+    }
+
+    @Test
+    void shouldPropagateSolanaExceptionWhenBalanceQueryFails() {
+        // given
+        var rpcFailure = SolanaTransactionException.submissionFailed(
+                "treasury-usdc-balance", new RuntimeException("RPC 503"));
+        BDDMockito.willThrow(rpcFailure)
+                .given(treasuryService).getTreasuryUsdcBalance();
+
+        // when / then
+        assertThatThrownBy(() -> activities.checkTreasuryBalance(SOME_AMOUNT_USDC))
+                .isInstanceOf(SolanaTransactionException.class)
+                .hasMessageContaining("SP-0010");
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingActivitiesImplTest.java
@@ -1,0 +1,130 @@
+package com.stablepay.infrastructure.temporal;
+
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_LOW_SOL;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_SENDER_ADDRESS;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_SUFFICIENT_SOL;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_TREASURY_BALANCE;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_TX_SIGNATURE;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_WALLET_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.handler.FinalizeFundingHandler;
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+import com.stablepay.domain.wallet.port.TreasuryService;
+
+@ExtendWith(MockitoExtension.class)
+class WalletFundingActivitiesImplTest {
+
+    private static final long SOL_TOP_UP_LAMPORTS = 10_000_000L;
+
+    @Mock
+    private TreasuryService treasuryService;
+
+    @Mock
+    private FinalizeFundingHandler finalizeFundingHandler;
+
+    @InjectMocks
+    private WalletFundingActivitiesImpl activities;
+
+    @Test
+    void shouldPassTreasuryCheckWhenBalanceIsSufficient() {
+        // given
+        given(treasuryService.getTreasuryUsdcBalance()).willReturn(SOME_TREASURY_BALANCE);
+
+        // when
+        activities.checkTreasuryBalance(SOME_AMOUNT_USDC);
+
+        // then
+        then(treasuryService).should().getTreasuryUsdcBalance();
+        then(treasuryService).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldThrowTreasuryDepletedWhenBalanceIsInsufficient() {
+        // given
+        var available = new BigDecimal("1.00");
+        given(treasuryService.getTreasuryUsdcBalance()).willReturn(available);
+
+        // when / then
+        assertThatThrownBy(() -> activities.checkTreasuryBalance(SOME_AMOUNT_USDC))
+                .isInstanceOf(TreasuryDepletedException.class)
+                .hasMessageContaining("SP-0007");
+    }
+
+    @Test
+    void shouldSkipSolTopUpWhenSenderBalanceIsSufficient() {
+        // given
+        given(treasuryService.getSolBalance(SOME_SENDER_ADDRESS)).willReturn(SOME_SUFFICIENT_SOL);
+
+        // when
+        activities.ensureSolBalance(SOME_SENDER_ADDRESS);
+
+        // then
+        then(treasuryService).should().getSolBalance(SOME_SENDER_ADDRESS);
+        then(treasuryService).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldTopUpSolWhenSenderBalanceIsBelowThreshold() {
+        // given
+        given(treasuryService.getSolBalance(SOME_SENDER_ADDRESS)).willReturn(SOME_LOW_SOL);
+        given(treasuryService.transferSol(SOME_SENDER_ADDRESS, SOL_TOP_UP_LAMPORTS))
+                .willReturn(SOME_TX_SIGNATURE);
+
+        // when
+        activities.ensureSolBalance(SOME_SENDER_ADDRESS);
+
+        // then
+        then(treasuryService).should().getSolBalance(SOME_SENDER_ADDRESS);
+        then(treasuryService).should().transferSol(SOME_SENDER_ADDRESS, SOL_TOP_UP_LAMPORTS);
+    }
+
+    @Test
+    void shouldDelegateCreateAtaToTreasury() {
+        // given
+
+        // when
+        activities.createAtaIfNeeded(SOME_SENDER_ADDRESS);
+
+        // then
+        then(treasuryService).should().createAtaIfNeeded(SOME_SENDER_ADDRESS);
+    }
+
+    @Test
+    void shouldReturnSignatureFromUsdcTransfer() {
+        // given
+        given(treasuryService.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC))
+                .willReturn(SOME_TX_SIGNATURE);
+
+        // when
+        var signature = activities.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+
+        // then
+        assertThat(signature).isEqualTo(SOME_TX_SIGNATURE);
+    }
+
+    @Test
+    void shouldDelegateFinalizeToDomainHandler() {
+        // given
+
+        // when
+        activities.finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+
+        // then
+        then(finalizeFundingHandler).should()
+                .handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
@@ -13,6 +13,8 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,7 @@ import org.mockito.BDDMockito;
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 
 import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.failure.ActivityFailure;
 import io.temporal.testing.TestWorkflowEnvironment;
@@ -83,13 +86,13 @@ class WalletFundingWorkflowImplTest {
     @Test
     void shouldFailWorkflowWhenTreasuryInsufficient() {
         // given
-        willThrow(TreasuryDepletedException.insufficientTreasury(SOME_AMOUNT_USDC, java.math.BigDecimal.ZERO))
+        willThrow(TreasuryDepletedException.insufficientTreasury(SOME_AMOUNT_USDC, BigDecimal.ZERO))
                 .given(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
         testEnv.start();
 
         // when / then
         assertThatThrownBy(() -> newWorkflow().execute(requestBuilder().build()))
-                .isInstanceOf(io.temporal.client.WorkflowFailedException.class)
+                .isInstanceOf(WorkflowFailedException.class)
                 .hasCauseInstanceOf(ActivityFailure.class);
 
         then(activities).should(never()).ensureSolBalance(SOME_SENDER_ADDRESS);

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
@@ -1,0 +1,99 @@
+package com.stablepay.infrastructure.temporal;
+
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_SENDER_ADDRESS;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_TX_SIGNATURE;
+import static com.stablepay.testutil.WalletFundingFixtures.SOME_WALLET_ID;
+import static com.stablepay.testutil.WalletFundingFixtures.requestBuilder;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+
+class WalletFundingWorkflowImplTest {
+
+    private static final String TASK_QUEUE = "test-wallet-funding";
+
+    private TestWorkflowEnvironment testEnv;
+    private Worker worker;
+    private WorkflowClient client;
+    private WalletFundingActivities activities;
+
+    @BeforeEach
+    void setUp() {
+        testEnv = TestWorkflowEnvironment.newInstance();
+        worker = testEnv.newWorker(TASK_QUEUE);
+        worker.registerWorkflowImplementationTypes(WalletFundingWorkflowImpl.class);
+
+        activities = mock(WalletFundingActivities.class);
+        worker.registerActivitiesImplementations(activities);
+
+        client = testEnv.getWorkflowClient();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testEnv.close();
+    }
+
+    private WalletFundingWorkflow newWorkflow() {
+        return client.newWorkflowStub(
+                WalletFundingWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(WalletFundingWorkflow.workflowId(SOME_FUNDING_ID))
+                        .build());
+    }
+
+    @Test
+    void shouldExecuteFiveActivitiesInOrder() {
+        // given
+        given(activities.transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC))
+                .willReturn(SOME_TX_SIGNATURE);
+        testEnv.start();
+
+        // when
+        newWorkflow().execute(requestBuilder().build());
+
+        // then
+        var inOrder = org.mockito.BDDMockito.inOrder(activities);
+        inOrder.verify(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
+        inOrder.verify(activities).ensureSolBalance(SOME_SENDER_ADDRESS);
+        inOrder.verify(activities).createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        inOrder.verify(activities).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        inOrder.verify(activities).finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+    }
+
+    @Test
+    void shouldFailWorkflowWhenTreasuryInsufficient() {
+        // given
+        willThrow(TreasuryDepletedException.insufficientTreasury(SOME_AMOUNT_USDC, java.math.BigDecimal.ZERO))
+                .given(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
+        testEnv.start();
+
+        // when / then
+        assertThatThrownBy(() -> newWorkflow().execute(requestBuilder().build()))
+                .isInstanceOf(io.temporal.client.WorkflowFailedException.class)
+                .hasCauseInstanceOf(ActivityFailure.class);
+
+        then(activities).should(never()).ensureSolBalance(SOME_SENDER_ADDRESS);
+        then(activities).should(never()).createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        then(activities).should(never()).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        then(activities).should(never()).finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import java.math.BigDecimal;
 
@@ -81,6 +82,26 @@ class WalletFundingWorkflowImplTest {
         then(activities).should(inOrder).createAtaIfNeeded(SOME_SENDER_ADDRESS);
         then(activities).should(inOrder).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
         then(activities).should(inOrder).finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+    }
+
+    @Test
+    void shouldFailWorkflowImmediatelyWhenUsdcTransferFails() {
+        // given
+        willThrow(new RuntimeException("Solana RPC down"))
+                .given(activities).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        testEnv.start();
+
+        // when / then
+        assertThatThrownBy(() -> newWorkflow().execute(requestBuilder().build()))
+                .isInstanceOf(WorkflowFailedException.class)
+                .hasCauseInstanceOf(ActivityFailure.class);
+
+        then(activities).should().checkTreasuryBalance(SOME_AMOUNT_USDC);
+        then(activities).should().ensureSolBalance(SOME_SENDER_ADDRESS);
+        then(activities).should().createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        then(activities).should(times(1)).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        then(activities).should(never())
+                .finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/WalletFundingWorkflowImplTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 
 import com.stablepay.domain.wallet.exception.TreasuryDepletedException;
 
@@ -71,12 +72,12 @@ class WalletFundingWorkflowImplTest {
         newWorkflow().execute(requestBuilder().build());
 
         // then
-        var inOrder = org.mockito.BDDMockito.inOrder(activities);
-        inOrder.verify(activities).checkTreasuryBalance(SOME_AMOUNT_USDC);
-        inOrder.verify(activities).ensureSolBalance(SOME_SENDER_ADDRESS);
-        inOrder.verify(activities).createAtaIfNeeded(SOME_SENDER_ADDRESS);
-        inOrder.verify(activities).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
-        inOrder.verify(activities).finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+        var inOrder = BDDMockito.inOrder(activities);
+        then(activities).should(inOrder).checkTreasuryBalance(SOME_AMOUNT_USDC);
+        then(activities).should(inOrder).ensureSolBalance(SOME_SENDER_ADDRESS);
+        then(activities).should(inOrder).createAtaIfNeeded(SOME_SENDER_ADDRESS);
+        then(activities).should(inOrder).transferUsdc(SOME_SENDER_ADDRESS, SOME_AMOUNT_USDC);
+        then(activities).should(inOrder).finalizeFunding(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
     }
 
     @Test

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WalletFundingFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WalletFundingFixtures.java
@@ -1,0 +1,30 @@
+package com.stablepay.testutil;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.stablepay.infrastructure.temporal.WalletFundingWorkflowRequest;
+
+public final class WalletFundingFixtures {
+
+    private WalletFundingFixtures() {}
+
+    public static final UUID SOME_FUNDING_ID =
+            UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    public static final Long SOME_WALLET_ID = 7L;
+    public static final String SOME_SENDER_ADDRESS =
+            "SeNdEr1234567890AbCdEfGhIjKlMnOpQrStUvWx";
+    public static final BigDecimal SOME_AMOUNT_USDC = new BigDecimal("25.00");
+    public static final BigDecimal SOME_TREASURY_BALANCE = new BigDecimal("1000.00");
+    public static final BigDecimal SOME_SUFFICIENT_SOL = new BigDecimal("0.05");
+    public static final BigDecimal SOME_LOW_SOL = new BigDecimal("0.001");
+    public static final String SOME_TX_SIGNATURE = "FundingTxSig1234567890AbCdEfGhIjKlMnOpQr";
+
+    public static WalletFundingWorkflowRequest.WalletFundingWorkflowRequestBuilder requestBuilder() {
+        return WalletFundingWorkflowRequest.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .senderSolanaAddress(SOME_SENDER_ADDRESS)
+                .amountUsdc(SOME_AMOUNT_USDC);
+    }
+}


### PR DESCRIPTION
## STA Issue
Closes #156

> Re-target of PR #171, which was merged into `feature/STA-78-real-treasury-adapter` but missed `main` because STA-78 had already been squash-merged (PR #170) 33 min earlier. STA-79 commits were orphaned on the stacked branch. This PR cherry-picks them onto `main`.

## Changes
- **`WalletFundingWorkflowImpl`** — sequences 5 activities on `stablepay-wallet-funding` with per-activity timeouts and retry policies (10s/3·doNotRetry(TreasuryDepleted,IllegalArg), 30s/3 with 10s initial backoff, 30s/3, 60s/1·doNotRetry(IllegalArg), 15s/3·doNotRetry(IllegalArg)).
- **`WalletFundingActivities` + `Impl`** — `checkTreasuryBalance`, `ensureSolBalance` (tops up 0.01 SOL when sender < 0.005), `createAtaIfNeeded`, `transferUsdc`, `finalizeFunding`. Shared `requirePositiveAmount` guard.
- **`FinalizeFundingHandler`** (new domain handler) — `@Transactional`, pessimistic lock on wallet, status-gated idempotency (`FUNDED → no-op`), atomic FUNDED flip + balance increment in a single commit.
- **`TemporalConfig` refactor** — split into `remittanceLifecycleWorker` + `walletFundingWorker` beans plus `CommandLineRunner` starter so `workerFactory.start()` fires exactly once after all workers register (appendix #14). Direct bean injection — fails fast if an activities bean is missing.
- **`CompleteFundingHandler` correction** — no longer pre-flips `PAYMENT_CONFIRMED → FUNDED`; the workflow activity owns the flip atomically with the balance increment (appendix #25). `@Transactional(readOnly = true)`.
- **`TreasuryService` port additions** — `getTreasuryUsdcBalance()` (strict — propagates RPC errors); `transferSol`/`transferUsdc` now return the tx signature.

## Tests
- **Unit:** `FinalizeFundingHandlerTest`, `WalletFundingActivitiesImplTest` (incl. positive-amount guards and RPC-error propagation), `WalletFundingWorkflowImplTest` (incl. 5-activity ordering, treasury depletion, `shouldFailWorkflowImmediatelyWhenUsdcTransferFails` locking MaximumAttempts=1), updated `CompleteFundingHandlerTest`.
- **Integration:** `FinalizeFundingHandlerIntegrationTest` — real Postgres, `TransactionTemplate` for commit boundaries, `usingRecursiveComparison` per-object. `WalletFundingWorkflowIntegrationTest` — 5 activities run in order on the wallet-funding task queue; treasury-empty path fails and skips downstream activities.
- **Fixtures:** `WalletFundingFixtures` in `testFixtures`.

## Checklist
- [x] `./gradlew build` passes (unit tests + spotless + ArchUnit)
- [x] `./gradlew integrationTest` passes
- [x] Unit tests added
- [x] Integration tests added (idempotency + workflow orchestration)
- [x] ArchUnit rules pass (no domain → infrastructure imports)
- [x] Spotless formatting applied

## Commits
Cherry-picked in order from `feature/STA-79-wallet-funding-workflow`:
1. `STA-79: add WalletFundingWorkflow with 5 activities on Temporal`
2. `STA-79: address review findings on wallet funding workflow`
3. `STA-79: address CodeRabbit review feedback`
4. `STA-79: apply review follow-ups on wallet funding workflow`
5. `STA-79: drop non-marker comments per CLAUDE.md self-documenting rule`

## Follow-ups
- STA-84: outbox + reconciler for signature persistence, which will let us restore retryability on `transferUsdc` (currently capped at 1 attempt to avoid double-send).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented wallet funding workflow with multi-step validation including treasury USDC balance checks, sender SOL balance verification, and automated token account creation.
  * Added transaction signature tracking for funding operations to improve audit visibility.

* **Bug Fixes**
  * Enhanced error handling for insufficient treasury balances with proper failure recovery.
  * Improved funding finalization to prevent duplicate balance updates through idempotent operation design.

* **Tests**
  * Added comprehensive integration tests for wallet funding workflows and finalization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->