### PR TITLE
STA-80: Refund funding endpoint (Stripe-only, on-chain balance gate)

### DIFF
--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -18,7 +18,10 @@ import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.exception.FundingFailedException;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.exception.InsufficientBalanceForRefundException;
 import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
+import com.stablepay.domain.funding.exception.RefundFailedException;
+import com.stablepay.domain.funding.exception.RefundNotAllowedException;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
@@ -156,6 +159,30 @@ public class GlobalExceptionHandler {
             InvalidWebhookSignatureException ex, HttpServletRequest request) {
         log.warn("Invalid webhook signature: {}", ex.getMessage());
         return buildResponse("SP-0026", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RefundNotAllowedException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleRefundNotAllowed(
+            RefundNotAllowedException ex, HttpServletRequest request) {
+        log.warn("Refund not allowed: {}", ex.getMessage());
+        return buildResponse("SP-0023", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RefundFailedException.class)
+    @ResponseStatus(HttpStatus.BAD_GATEWAY)
+    public ErrorResponse handleRefundFailed(
+            RefundFailedException ex, HttpServletRequest request) {
+        log.error("Refund failed: {}", ex.getMessage());
+        return buildResponse("SP-0024", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InsufficientBalanceForRefundException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleInsufficientBalanceForRefund(
+            InsufficientBalanceForRefundException ex, HttpServletRequest request) {
+        log.warn("Insufficient balance for refund: {}", ex.getMessage());
+        return buildResponse("SP-0025", ex.getMessage(), request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/stablepay/application/controller/funding/FundingController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/funding/FundingController.java
@@ -19,6 +19,7 @@ import com.stablepay.application.dto.FundWalletRequest;
 import com.stablepay.application.dto.FundingOrderResponse;
 import com.stablepay.domain.funding.handler.GetFundingOrderHandler;
 import com.stablepay.domain.funding.handler.InitiateFundingHandler;
+import com.stablepay.domain.funding.handler.RefundFundingHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,6 +37,7 @@ public class FundingController {
 
     private final InitiateFundingHandler initiateFundingHandler;
     private final GetFundingOrderHandler getFundingOrderHandler;
+    private final RefundFundingHandler refundFundingHandler;
     private final FundingApiMapper fundingApiMapper;
 
     @PostMapping("/wallets/{id}/fund")
@@ -72,6 +74,26 @@ public class FundingController {
     })
     public FundingOrderResponse getFundingOrder(@PathVariable UUID fundingId) {
         var order = getFundingOrderHandler.handle(fundingId);
+        return fundingApiMapper.toResponse(order);
+    }
+
+    @PostMapping("/funding-orders/{fundingId}/refund")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Refund a funded wallet",
+            description = "Refunds a FUNDED order via Stripe. Rejects if the sender's on-chain USDC "
+                    + "balance or wallet available balance is less than the funding amount. "
+                    + "No on-chain USDC is returned — the sender's test tokens stay in their ATA.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Refund completed"),
+        @ApiResponse(responseCode = "404", description = "Funding order not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "Refund not allowed or balance insufficient",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Stripe refund failed",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public FundingOrderResponse refundFunding(@PathVariable UUID fundingId) {
+        var order = refundFundingHandler.handle(fundingId);
         return fundingApiMapper.toResponse(order);
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
@@ -6,8 +6,10 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.funding.exception.FundingFailedException;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
 import com.stablepay.domain.funding.exception.InsufficientBalanceForRefundException;
 import com.stablepay.domain.funding.exception.RefundFailedException;
@@ -27,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(noRollbackFor = RefundFailedException.class)
+@Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = RefundFailedException.class)
 public class RefundFundingHandler {
 
     private final FundingOrderRepository fundingOrderRepository;
@@ -56,7 +58,7 @@ public class RefundFundingHandler {
 
         try {
             paymentGateway.refund(order.stripePaymentIntentId(), amount);
-        } catch (RuntimeException e) {
+        } catch (FundingFailedException e) {
             var refundFailed = refundInitiated.toBuilder().status(FundingStatus.REFUND_FAILED).build();
             fundingOrderRepository.save(refundFailed);
             log.error(

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
@@ -1,0 +1,93 @@
+package com.stablepay.domain.funding.handler;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.exception.InsufficientBalanceForRefundException;
+import com.stablepay.domain.funding.exception.RefundFailedException;
+import com.stablepay.domain.funding.exception.RefundNotAllowedException;
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.funding.port.PaymentGateway;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.TreasuryService;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(noRollbackFor = RefundFailedException.class)
+public class RefundFundingHandler {
+
+    private final FundingOrderRepository fundingOrderRepository;
+    private final WalletRepository walletRepository;
+    private final TreasuryService treasuryService;
+    private final PaymentGateway paymentGateway;
+
+    public FundingOrder handle(UUID fundingId) {
+        requireNonNull(fundingId, "fundingId cannot be null");
+
+        var order = fundingOrderRepository.findByFundingId(fundingId)
+                .orElseThrow(() -> FundingOrderNotFoundException.byFundingId(fundingId));
+
+        if (order.status() != FundingStatus.FUNDED) {
+            throw RefundNotAllowedException.forStatus(order.status());
+        }
+
+        var wallet = walletRepository.findById(order.walletId())
+                .orElseThrow(() -> WalletNotFoundException.byId(order.walletId()));
+
+        var amount = order.amountUsdc();
+        assertSufficientBalance(wallet, amount);
+
+        var refundInitiated = order.toBuilder().status(FundingStatus.REFUND_INITIATED).build();
+        fundingOrderRepository.save(refundInitiated);
+
+        try {
+            paymentGateway.refund(order.stripePaymentIntentId(), amount);
+        } catch (RuntimeException e) {
+            var refundFailed = refundInitiated.toBuilder().status(FundingStatus.REFUND_FAILED).build();
+            fundingOrderRepository.save(refundFailed);
+            log.error(
+                    "Stripe refund failed fundingId={} paymentIntentId={}",
+                    fundingId, order.stripePaymentIntentId(), e);
+            throw RefundFailedException.stripeRefundFailed(order.stripePaymentIntentId(), e);
+        }
+
+        var decrementedWallet = wallet.toBuilder()
+                .availableBalance(wallet.availableBalance().subtract(amount))
+                .totalBalance(wallet.totalBalance().subtract(amount))
+                .build();
+        walletRepository.save(decrementedWallet);
+
+        var refunded = refundInitiated.toBuilder().status(FundingStatus.REFUNDED).build();
+        var saved = fundingOrderRepository.save(refunded);
+
+        log.info(
+                "Refund completed fundingId={} walletId={} amount={} newAvailable={}",
+                fundingId, order.walletId(), amount, decrementedWallet.availableBalance());
+
+        return saved;
+    }
+
+    private void assertSufficientBalance(Wallet wallet, BigDecimal amount) {
+        var onChainBalance = treasuryService.getUsdcBalance(wallet.solanaAddress());
+        if (onChainBalance.compareTo(amount) < 0) {
+            throw InsufficientBalanceForRefundException.forAmount(amount, onChainBalance);
+        }
+        if (wallet.availableBalance().compareTo(amount) < 0) {
+            throw InsufficientBalanceForRefundException.forAmount(amount, wallet.availableBalance());
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/stripe/StripePaymentAdapter.java
@@ -10,6 +10,7 @@ import com.stablepay.domain.funding.model.PaymentResult;
 import com.stablepay.domain.funding.port.PaymentGateway;
 import com.stripe.StripeClient;
 import com.stripe.exception.StripeException;
+import com.stripe.net.RequestOptions;
 import com.stripe.param.PaymentIntentCreateParams;
 import com.stripe.param.RefundCreateParams;
 
@@ -56,7 +57,10 @@ public class StripePaymentAdapter implements PaymentGateway {
         log.info("Initiating Stripe refund paymentIntentId={}", paymentIntentId);
         try {
             var params = buildRefundParams(paymentIntentId, amount);
-            stripeClient.refunds().create(params);
+            var requestOptions = RequestOptions.builder()
+                    .setIdempotencyKey("refund-" + paymentIntentId)
+                    .build();
+            stripeClient.refunds().create(params, requestOptions);
         } catch (StripeException e) {
             log.warn("Stripe refund failed paymentIntentId={} code={} status={} requestId={}",
                     paymentIntentId, e.getCode(), e.getStatusCode(), e.getRequestId(), e);

--- a/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
@@ -30,8 +30,12 @@ import com.stablepay.application.dto.FundingOrderResponse;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.exception.FundingFailedException;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.exception.InsufficientBalanceForRefundException;
+import com.stablepay.domain.funding.exception.RefundFailedException;
+import com.stablepay.domain.funding.exception.RefundNotAllowedException;
 import com.stablepay.domain.funding.handler.GetFundingOrderHandler;
 import com.stablepay.domain.funding.handler.InitiateFundingHandler;
+import com.stablepay.domain.funding.handler.RefundFundingHandler;
 import com.stablepay.domain.funding.model.FundingInitiationResult;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
@@ -55,6 +59,9 @@ class FundingControllerTest {
 
     @MockitoBean
     private GetFundingOrderHandler getFundingOrderHandler;
+
+    @MockitoBean
+    private RefundFundingHandler refundFundingHandler;
 
     @MockitoBean
     private FundingApiMapper fundingApiMapper;
@@ -229,5 +236,84 @@ class FundingControllerTest {
         mockMvc.perform(get("/api/funding-orders/{fundingId}", missingId))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0020"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldRefundFundedOrderAndReturnUpdatedStatus() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.REFUNDED).build();
+        var response = FundingOrderResponse.builder()
+                .fundingId(SOME_FUNDING_ID)
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .status(FundingStatus.REFUNDED)
+                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .createdAt(SOME_CREATED_AT)
+                .build();
+
+        given(refundFundingHandler.handle(SOME_FUNDING_ID)).willReturn(order);
+        given(fundingApiMapper.toResponse(order)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fundingId").value(SOME_FUNDING_ID.toString()))
+                .andExpect(jsonPath("$.status").value("REFUNDED"))
+                .andExpect(jsonPath("$.stripeClientSecret").doesNotExist());
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenRefundingMissingOrder() {
+        // given
+        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+                .willThrow(FundingOrderNotFoundException.byFundingId(SOME_FUNDING_ID));
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0020"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WhenRefundNotAllowed() {
+        // given
+        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+                .willThrow(RefundNotAllowedException.forStatus(FundingStatus.PAYMENT_CONFIRMED));
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0023"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WhenRefundBalanceInsufficient() {
+        // given
+        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+                .willThrow(InsufficientBalanceForRefundException.forAmount(
+                        SOME_AMOUNT_USDC, new BigDecimal("0.00")));
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0025"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn502WhenStripeRefundFails() {
+        // given
+        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+                .willThrow(RefundFailedException.stripeRefundFailed(
+                        SOME_STRIPE_PAYMENT_INTENT_ID, new RuntimeException("boom")));
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.errorCode").value("SP-0024"));
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
@@ -18,6 +18,9 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -116,17 +119,18 @@ class RefundFundingHandlerTest {
         then(paymentGateway).shouldHaveNoInteractions();
     }
 
-    @Test
-    void shouldThrowWhenOrderStatusIsNotFunded() {
+    @ParameterizedTest
+    @EnumSource(value = FundingStatus.class, names = "FUNDED", mode = Mode.EXCLUDE)
+    void shouldThrowWhenOrderStatusIsNotFunded(FundingStatus nonFundedStatus) {
         // given
-        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        var order = fundingOrderBuilder().status(nonFundedStatus).build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
 
         // when / then
         assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
                 .isInstanceOf(RefundNotAllowedException.class)
                 .hasMessageContaining("SP-0023")
-                .hasMessageContaining("PAYMENT_CONFIRMED");
+                .hasMessageContaining(nonFundedStatus.name());
 
         then(walletRepository).shouldHaveNoInteractions();
         then(treasuryService).shouldHaveNoInteractions();

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
@@ -1,0 +1,229 @@
+package com.stablepay.domain.funding.handler;
+
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.funding.exception.FundingFailedException;
+import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
+import com.stablepay.domain.funding.exception.InsufficientBalanceForRefundException;
+import com.stablepay.domain.funding.exception.RefundFailedException;
+import com.stablepay.domain.funding.exception.RefundNotAllowedException;
+import com.stablepay.domain.funding.model.FundingOrder;
+import com.stablepay.domain.funding.model.FundingStatus;
+import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.funding.port.PaymentGateway;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.TreasuryService;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RefundFundingHandlerTest {
+
+    @Mock
+    private FundingOrderRepository fundingOrderRepository;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private TreasuryService treasuryService;
+
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @InjectMocks
+    private RefundFundingHandler refundFundingHandler;
+
+    @Captor
+    private ArgumentCaptor<FundingOrder> fundingOrderCaptor;
+
+    @Captor
+    private ArgumentCaptor<Wallet> walletCaptor;
+
+    @Test
+    void shouldRefundFundedOrderAndDecrementWalletBalance() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        var wallet = walletBuilder()
+                .id(order.walletId())
+                .availableBalance(new BigDecimal("100.00"))
+                .totalBalance(new BigDecimal("100.00"))
+                .build();
+
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+        given(treasuryService.getUsdcBalance(wallet.solanaAddress())).willReturn(new BigDecimal("100.00"));
+
+        var refundInitiated = order.toBuilder().status(FundingStatus.REFUND_INITIATED).build();
+        var refunded = order.toBuilder().status(FundingStatus.REFUNDED).build();
+        given(fundingOrderRepository.save(refundInitiated)).willReturn(refundInitiated);
+        given(fundingOrderRepository.save(refunded)).willReturn(refunded);
+
+        var decrementedWallet = wallet.toBuilder()
+                .availableBalance(new BigDecimal("75.00"))
+                .totalBalance(new BigDecimal("75.00"))
+                .build();
+        given(walletRepository.save(decrementedWallet)).willReturn(decrementedWallet);
+
+        // when
+        var result = refundFundingHandler.handle(SOME_FUNDING_ID);
+
+        // then
+        then(fundingOrderRepository).should(times(2)).save(fundingOrderCaptor.capture());
+        then(walletRepository).should().save(walletCaptor.capture());
+        then(paymentGateway).should().refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC);
+
+        var saves = fundingOrderCaptor.getAllValues();
+        assertThat(saves.get(0)).usingRecursiveComparison().isEqualTo(refundInitiated);
+        assertThat(saves.get(1)).usingRecursiveComparison().isEqualTo(refunded);
+        assertThat(walletCaptor.getValue()).usingRecursiveComparison().isEqualTo(decrementedWallet);
+        assertThat(result).usingRecursiveComparison().isEqualTo(refunded);
+    }
+
+    @Test
+    void shouldThrowWhenFundingOrderNotFound() {
+        // given
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+                .isInstanceOf(FundingOrderNotFoundException.class)
+                .hasMessageContaining("SP-0020");
+
+        then(walletRepository).shouldHaveNoInteractions();
+        then(treasuryService).shouldHaveNoInteractions();
+        then(paymentGateway).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenOrderStatusIsNotFunded() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.PAYMENT_CONFIRMED).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+                .isInstanceOf(RefundNotAllowedException.class)
+                .hasMessageContaining("SP-0023")
+                .hasMessageContaining("PAYMENT_CONFIRMED");
+
+        then(walletRepository).shouldHaveNoInteractions();
+        then(treasuryService).shouldHaveNoInteractions();
+        then(paymentGateway).shouldHaveNoInteractions();
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenOnChainBalanceIsInsufficient() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        var wallet = walletBuilder()
+                .id(order.walletId())
+                .availableBalance(new BigDecimal("100.00"))
+                .totalBalance(new BigDecimal("100.00"))
+                .build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+        given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("10.00"));
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+                .isInstanceOf(InsufficientBalanceForRefundException.class)
+                .hasMessageContaining("SP-0025")
+                .hasMessageContaining("25.00")
+                .hasMessageContaining("10.00");
+
+        then(paymentGateway).shouldHaveNoInteractions();
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).should().findById(order.walletId());
+        then(walletRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenWalletAvailableBalanceIsInsufficient() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        var wallet = walletBuilder()
+                .id(order.walletId())
+                .availableBalance(new BigDecimal("5.00"))
+                .totalBalance(new BigDecimal("100.00"))
+                .build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+        given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("100.00"));
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+                .isInstanceOf(InsufficientBalanceForRefundException.class)
+                .hasMessageContaining("SP-0025")
+                .hasMessageContaining("25.00")
+                .hasMessageContaining("5.00");
+
+        then(paymentGateway).shouldHaveNoInteractions();
+        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
+        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+        then(walletRepository).should().findById(order.walletId());
+        then(walletRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldMarkRefundFailedAndKeepWalletBalanceWhenStripeFails() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        var wallet = walletBuilder()
+                .id(order.walletId())
+                .availableBalance(new BigDecimal("100.00"))
+                .totalBalance(new BigDecimal("100.00"))
+                .build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+        given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("100.00"));
+
+        var refundInitiated = order.toBuilder().status(FundingStatus.REFUND_INITIATED).build();
+        given(fundingOrderRepository.save(refundInitiated)).willReturn(refundInitiated);
+
+        var stripeFailure = FundingFailedException.stripeError("card_declined", new RuntimeException("boom"));
+        willThrow(stripeFailure).given(paymentGateway).refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC);
+
+        var refundFailed = order.toBuilder().status(FundingStatus.REFUND_FAILED).build();
+        given(fundingOrderRepository.save(refundFailed)).willReturn(refundFailed);
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+                .isInstanceOf(RefundFailedException.class)
+                .hasMessageContaining("SP-0024")
+                .hasMessageContaining(SOME_STRIPE_PAYMENT_INTENT_ID)
+                .hasCause(stripeFailure);
+
+        then(fundingOrderRepository).should(times(2)).save(fundingOrderCaptor.capture());
+        then(walletRepository).should().findById(order.walletId());
+        then(walletRepository).shouldHaveNoMoreInteractions();
+
+        var saves = fundingOrderCaptor.getAllValues();
+        assertThat(saves.get(0)).usingRecursiveComparison().isEqualTo(refundInitiated);
+        assertThat(saves.get(1)).usingRecursiveComparison().isEqualTo(refundFailed);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/stripe/StripePaymentAdapterTest.java
@@ -33,6 +33,7 @@ import com.stripe.exception.ApiException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.Refund;
+import com.stripe.net.RequestOptions;
 import com.stripe.param.PaymentIntentCreateParams;
 import com.stripe.param.RefundCreateParams;
 import com.stripe.service.PaymentIntentService;
@@ -61,6 +62,9 @@ class StripePaymentAdapterTest {
 
     @Captor
     private ArgumentCaptor<RefundCreateParams> refundParamsCaptor;
+
+    @Captor
+    private ArgumentCaptor<RequestOptions> requestOptionsCaptor;
 
     private StripeProperties testModeProperties;
     private StripeProperties autoConfirmDisabledProperties;
@@ -329,10 +333,11 @@ class StripePaymentAdapterTest {
     }
 
     @Test
-    void shouldRefundViaStripe() throws StripeException {
+    void shouldRefundViaStripeWithIdempotencyKey() throws StripeException {
         // given
         given(stripeClient.refunds()).willReturn(refundService);
-        given(refundService.create(refundParamsCaptor.capture())).willReturn(refund);
+        given(refundService.create(refundParamsCaptor.capture(), requestOptionsCaptor.capture()))
+                .willReturn(refund);
 
         // when
         adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC);
@@ -345,6 +350,8 @@ class StripePaymentAdapterTest {
         assertThat(refundParamsCaptor.getValue())
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+        assertThat(requestOptionsCaptor.getValue().getIdempotencyKey())
+                .isEqualTo("refund-" + SOME_STRIPE_PAYMENT_INTENT_ID);
     }
 
     @Test
@@ -353,7 +360,8 @@ class StripePaymentAdapterTest {
         given(stripeClient.refunds()).willReturn(refundService);
         var stripeException = new ApiException(
                 "charge_already_refunded", "req_xyz", "invalid_request_error", 400, null);
-        willThrow(stripeException).given(refundService).create(refundParamsCaptor.capture());
+        willThrow(stripeException).given(refundService)
+                .create(refundParamsCaptor.capture(), requestOptionsCaptor.capture());
 
         // when / then
         assertThatThrownBy(() -> adapter.refund(SOME_STRIPE_PAYMENT_INTENT_ID, SOME_AMOUNT_USDC))


### PR DESCRIPTION
## STA Issue
Closes #157

## Summary
Implements the Stripe-only refund flow for FUNDED orders (spec §2 US-2, §9.3 rev 5). Senders get their fiat back only if they still hold the USDC on-chain — we do NOT return on-chain USDC, preventing platform loss when tokens have already moved.

## Changes
- Add `RefundFundingHandler` — loads order, enforces `status == FUNDED` (SP-0023), checks on-chain USDC balance via `TreasuryService.getUsdcBalance` AND `wallet.availableBalance` (SP-0025), transitions FUNDED → REFUND_INITIATED → REFUNDED with wallet decrement on Stripe success.
- On Stripe failure: mark REFUND_FAILED and throw `RefundFailedException` (SP-0024). Uses `@Transactional(noRollbackFor = RefundFailedException.class)` so the REFUND_FAILED save commits.
- Add `POST /api/funding-orders/{fundingId}/refund` to `FundingController` with OpenAPI annotations.
- Wire `RefundNotAllowedException` → 409, `RefundFailedException` → 502, `InsufficientBalanceForRefundException` → 409 into `GlobalExceptionHandler`.
- Unit tests (`RefundFundingHandlerTest`): happy path, not found, not FUNDED, on-chain balance gate, DB balance gate, Stripe failure.
- Controller tests: happy path, 404, 409 state, 409 balance, 502.

## Design notes
- No MPC wiring / no on-chain USDC return — out of scope for the hackathon (sender's ATA is MPC-owned). The on-chain balance check is the gate that prevents refunding fiat for USDC already in circulation.
- Sender's ATA is unchanged by the refund — devnet test tokens stay put.

## Checklist
- [x] `./gradlew build` passes
- [x] `./gradlew integrationTest` passes
- [x] Unit tests added for handler and controller
- [x] ArchUnit rules pass (domain/infra/application boundaries respected)
- [x] Spotless formatting applied