### PR TITLE
STA-81: Config, exception handler, and Postman updates for funding endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,14 @@ CLAIM_AUTHORITY_PRIVATE_KEY=
 
 # USDC mint address (defaults to devnet USDC if unset)
 # USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU
+
+# Stripe test-mode API key (sk_test_...). Required for PaymentIntent + refund calls.
+STRIPE_API_KEY=sk_test_...
+
+# Stripe webhook signing secret (whsec_...). Shown by `stripe listen` locally,
+# or taken from the endpoint in the Stripe dashboard.
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Treasury wallet secret key (base58-encoded). Funds SPL USDC + SOL rent transfers
+# to user wallets after a confirmed Stripe PaymentIntent. Devnet only.
+TREASURY_PRIVATE_KEY=

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs ps infra urls clean build-backend help
+.PHONY: up down restart logs ps infra urls clean build-backend help stripe-listen
 
 COMPOSE := docker compose
 
@@ -81,3 +81,6 @@ e2e-full: up ## Start stack + wait + run E2E tests
 clean: ## Stop all services and remove volumes
 	@$(COMPOSE) down -v
 	@echo "StablePay stack stopped and volumes removed."
+
+stripe-listen: ## Forward Stripe webhook events to the local backend (requires `stripe` CLI)
+	stripe listen --forward-to localhost:8080/webhooks/stripe

--- a/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/stablepay/application/config/GlobalExceptionHandler.java
@@ -5,7 +5,9 @@ import java.time.Instant;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -38,6 +40,9 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private static final String FUNDING_ORDERS_ACTIVE_INDEX =
+            "idx_funding_orders_one_active_per_wallet";
 
     private final Clock clock;
 
@@ -183,6 +188,25 @@ public class GlobalExceptionHandler {
             InsufficientBalanceForRefundException ex, HttpServletRequest request) {
         log.warn("Insufficient balance for refund: {}", ex.getMessage());
         return buildResponse("SP-0025", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(
+            DataIntegrityViolationException ex, HttpServletRequest request)
+            throws DataIntegrityViolationException {
+        var rootMessage = ex.getMostSpecificCause().getMessage();
+        if (rootMessage != null
+                && rootMessage.contains(FUNDING_ORDERS_ACTIVE_INDEX)) {
+            log.warn("Concurrent funding attempt violates {}: {}",
+                    FUNDING_ORDERS_ACTIVE_INDEX, rootMessage);
+            return ResponseEntity
+                    .status(HttpStatus.CONFLICT)
+                    .body(buildResponse(
+                            "SP-0022",
+                            "Funding already in progress for this wallet",
+                            request));
+        }
+        throw ex;
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
@@ -1,6 +1,8 @@
 package com.stablepay.application.config;
 
 import static com.stablepay.testutil.TestClockConfig.FIXED_INSTANT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -16,6 +18,7 @@ import jakarta.validation.constraints.NotBlank;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
@@ -120,6 +123,24 @@ class GlobalExceptionHandlerTest {
 
         @PostMapping("/test/validation")
         public void validation(@Valid @RequestBody ValidationRequest request) {}
+
+        @GetMapping("/test/funding-active-index-violation")
+        public void fundingActiveIndexViolation() {
+            throw new DataIntegrityViolationException(
+                    "could not execute statement",
+                    new RuntimeException(
+                            "ERROR: duplicate key value violates unique constraint "
+                                    + "\"idx_funding_orders_one_active_per_wallet\""));
+        }
+
+        @GetMapping("/test/unrelated-data-integrity-violation")
+        public void unrelatedDataIntegrityViolation() {
+            throw new DataIntegrityViolationException(
+                    "could not execute statement",
+                    new RuntimeException(
+                            "ERROR: duplicate key value violates unique constraint "
+                                    + "\"some_other_unique_index\""));
+        }
 
         record ValidationRequest(@NotBlank String name) {}
     }
@@ -271,6 +292,32 @@ class GlobalExceptionHandlerTest {
                         "SP-0010: Remittance not found: 11111111-1111-1111-1111-111111111111"))
                 .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
                 .andExpect(jsonPath("$.path").value("/test/remittance-not-found"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn409WithFundingAlreadyInProgressWhenPartialUniqueIndexViolated() {
+        // given — stub throws DataIntegrityViolationException mentioning the funding_orders active index
+
+        // when / then
+        mockMvc.perform(get("/test/funding-active-index-violation"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("SP-0022"))
+                .andExpect(jsonPath("$.message").value(
+                        "Funding already in progress for this wallet"))
+                .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
+                .andExpect(jsonPath("$.path").value("/test/funding-active-index-violation"));
+    }
+
+    @Test
+    void shouldBubbleUpDataIntegrityViolationWhenConstraintIsUnrelated() {
+        // given — stub throws DataIntegrityViolationException for an unrelated constraint
+
+        // when / then
+        assertThatThrownBy(() -> mockMvc.perform(get("/test/unrelated-data-integrity-violation")))
+                .satisfies(thrown -> assertThat(thrown)
+                        .rootCause()
+                        .hasMessageContaining("some_other_unique_index"));
     }
 
     @Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,9 @@ services:
       STABLEPAY_MPC_PEER_SIDECARS: 1=mpc-sidecar-1:50051:mpc-sidecar-0:7000
       STABLEPAY_ESCROW_PROGRAM_ID: 6G9X8RArxw6f6n41wRKZMsgzRtHuUgPSkYipyjQu8NXD
       CLAIM_AUTHORITY_PRIVATE_KEY: 2JxcWkDJuBPCexd2hyWpZ3HXMBQLDkWWGWuRzkHmDvqoBNBBqC9jsnr1d5bznamozwVrrj7A5hLomkHhZYaP6SbY
+      STRIPE_API_KEY: ${STRIPE_API_KEY}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+      TREASURY_PRIVATE_KEY: ${TREASURY_PRIVATE_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/StablePay.postman_collection.json
+++ b/docs/StablePay.postman_collection.json
@@ -30,6 +30,11 @@
 			"key": "userId",
 			"value": "user-001",
 			"type": "string"
+		},
+		{
+			"key": "fundingId",
+			"value": "",
+			"type": "string"
 		}
 	],
 	"item": [
@@ -73,8 +78,13 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/wallets",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "wallets"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"wallets"
+							]
 						},
 						"description": "Creates an MPC-backed Solana wallet for the given user.\n\n**Response:** 201 Created\n\n**Errors:**\n- 400 (SP-0003): Validation error\n- 409 (SP-0008): Wallet already exists for this user"
 					}
@@ -87,13 +97,17 @@
 							"script": {
 								"type": "text/javascript",
 								"exec": [
-									"if (pm.response.code === 200) {",
+									"pm.test('Funding order created', function () {",
+									"    pm.response.to.have.status(201);",
 									"    var json = pm.response.json();",
-									"    pm.test('Wallet funded successfully', function () {",
-									"        pm.expect(json.availableBalance).to.be.a('number');",
-									"        pm.expect(json.totalBalance).to.be.a('number');",
-									"    });",
-									"}"
+									"    pm.expect(json.fundingId).to.be.a('string');",
+									"    pm.expect(json.walletId).to.be.a('number');",
+									"    pm.expect(json.amountUsdc).to.be.a('number');",
+									"    pm.expect(json.status).to.equal('PAYMENT_CONFIRMED');",
+									"    pm.expect(json.stripePaymentIntentId).to.be.a('string');",
+									"    pm.expect(json.stripeClientSecret).to.be.a('string');",
+									"    pm.collectionVariables.set('fundingId', json.fundingId);",
+									"});"
 								]
 							}
 						}
@@ -112,10 +126,94 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/wallets/{{walletId}}/fund",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "wallets", "{{walletId}}", "fund"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"wallets",
+								"{{walletId}}",
+								"fund"
+							]
 						},
-						"description": "Adds demo USDC from the treasury to the wallet.\n\n**Errors:**\n- 404 (SP-0006): Wallet not found\n- 503 (SP-0007): Treasury depleted"
+						"description": "Creates a Stripe PaymentIntent and returns a funding order reference plus a one-time Stripe client secret. The wallet is actually credited only after Stripe confirms the payment via webhook (`/webhooks/stripe`).\n\n**Errors:**\n- 400 (SP-0003): Amount validation failed\n- 404 (SP-0006): Wallet not found\n- 409 (SP-0022): Funding already in progress for this wallet\n- 502 (SP-0021): Stripe PaymentIntent creation failed"
+					}
+				}
+			]
+		},
+		{
+			"name": "Funding",
+			"description": "Stripe-backed funding order status + refund",
+			"item": [
+				{
+					"name": "Get Funding Order",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test('Funding order returned', function () {",
+									"    pm.response.to.have.status(200);",
+									"    var json = pm.response.json();",
+									"    pm.expect(json.fundingId).to.be.a('string');",
+									"    pm.expect(json.status).to.be.a('string');",
+									"    pm.expect(json.stripeClientSecret).to.be.undefined;",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/funding-orders/{{fundingId}}",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"funding-orders",
+								"{{fundingId}}"
+							]
+						},
+						"description": "Returns the current status of a funding order. Never returns the Stripe client secret.\n\n**Errors:**\n- 404 (SP-0020): Funding order not found"
+					}
+				},
+				{
+					"name": "Refund Funding",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"pm.test('Funding refunded', function () {",
+									"    pm.response.to.have.status(200);",
+									"    var json = pm.response.json();",
+									"    pm.expect(json.status).to.equal('REFUNDED');",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/funding-orders/{{fundingId}}/refund",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"funding-orders",
+								"{{fundingId}}",
+								"refund"
+							]
+						},
+						"description": "Refunds a FUNDED order via Stripe. Rejects if the sender's on-chain USDC balance or wallet available balance is below the original funding amount. On-chain USDC is not returned — the sender keeps the SPL tokens they received.\n\n**Errors:**\n- 404 (SP-0020): Funding order not found\n- 409 (SP-0023): Refund not allowed for current status\n- 409 (SP-0025): Insufficient balance for refund\n- 502 (SP-0024): Stripe refund failed"
 					}
 				}
 			]
@@ -149,8 +247,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/fx/USD-INR",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "fx", "USD-INR"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"fx",
+								"USD-INR"
+							]
 						},
 						"description": "Returns the current exchange rate for USD → INR.\n\n**Errors:**\n- 400 (SP-0009): Unsupported currency corridor"
 					}
@@ -201,8 +305,13 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances"
+							]
 						},
 						"description": "Initiates a new USD → INR remittance with a locked FX rate.\n\n**Response:** 201 Created\n\n**Errors:**\n- 400 (SP-0003): Validation error\n- 400 (SP-0002): Insufficient balance"
 					}
@@ -230,8 +339,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances/{{remittanceId}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances", "{{remittanceId}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances",
+								"{{remittanceId}}"
+							]
 						},
 						"description": "Retrieves a remittance by its unique identifier.\n\n**Errors:**\n- 404 (SP-0010): Remittance not found"
 					}
@@ -259,8 +374,13 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances?senderId={{userId}}&page=0&size=20&sort=createdAt,desc",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances"],
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances"
+							],
 							"query": [
 								{
 									"key": "senderId",
@@ -315,8 +435,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/claims/{{claimToken}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "claims", "{{claimToken}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"claims",
+								"{{claimToken}}"
+							]
 						},
 						"description": "Retrieves remittance claim details by the claim token sent via SMS.\n\n**Errors:**\n- 404 (SP-0011): Claim token not found\n- 410 (SP-0013): Claim token expired"
 					}
@@ -352,8 +478,14 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/claims/{{claimToken}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "claims", "{{claimToken}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"claims",
+								"{{claimToken}}"
+							]
 						},
 						"description": "Submits a claim with the recipient's UPI ID to receive INR payout.\n\n**Errors:**\n- 404 (SP-0011): Claim token not found\n- 409 (SP-0012): Claim already submitted\n- 410 (SP-0013): Claim token expired"
 					}
@@ -407,8 +539,13 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/wallets",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "wallets"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"wallets"
+							]
 						}
 					}
 				},
@@ -444,8 +581,15 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/wallets/{{walletId}}/fund",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "wallets", "{{walletId}}", "fund"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"wallets",
+								"{{walletId}}",
+								"fund"
+							]
 						}
 					}
 				},
@@ -472,8 +616,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/fx/USD-INR",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "fx", "USD-INR"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"fx",
+								"USD-INR"
+							]
 						}
 					}
 				},
@@ -516,8 +666,13 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances"
+							]
 						}
 					}
 				},
@@ -545,8 +700,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances/{{remittanceId}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances", "{{remittanceId}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances",
+								"{{remittanceId}}"
+							]
 						},
 						"description": "Poll this endpoint to watch status progression:\nINITIATED → ESCROWED → CLAIMED → DELIVERED\n\nWith Temporal running, status should advance to ESCROWED within seconds."
 					}
@@ -576,8 +737,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/claims/{{claimToken}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "claims", "{{claimToken}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"claims",
+								"{{claimToken}}"
+							]
 						},
 						"description": "The claimToken is automatically captured from the Create Remittance response."
 					}
@@ -613,8 +780,14 @@
 						},
 						"url": {
 							"raw": "{{baseUrl}}/api/claims/{{claimToken}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "claims", "{{claimToken}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"claims",
+								"{{claimToken}}"
+							]
 						},
 						"description": "Submits the claim with a UPI ID. After this, the Temporal workflow will release escrow and disburse INR."
 					}
@@ -642,8 +815,14 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances/{{remittanceId}}",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances", "{{remittanceId}}"]
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances",
+								"{{remittanceId}}"
+							]
 						},
 						"description": "After claim submission, poll for DELIVERED status.\nWith Temporal running: ESCROWED → CLAIMED → DELIVERED.\nWithout Temporal: status stays as-is (workflow not running)."
 					}
@@ -672,8 +851,13 @@
 						"header": [],
 						"url": {
 							"raw": "{{baseUrl}}/api/remittances?senderId=demo-user&page=0&size=20",
-							"host": ["{{baseUrl}}"],
-							"path": ["api", "remittances"],
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"remittances"
+							],
 							"query": [
 								{
 									"key": "senderId",


### PR DESCRIPTION
## STA Issue
Closes #158

## Summary

Most of STA-81 was already landed by STA-76/77/79/80: all 6 funding exception handlers (`SP-0020`–`SP-0025`), the Stripe webhook `SecurityConfig` TODO comment, and the removal of the legacy synchronous fund tests from `WalletControllerTest` / `WalletApiIntegrationTest`. This PR wires up the remaining cross-cutting glue.

## Changes

- **DataIntegrityViolationException handler** (`GlobalExceptionHandler`): narrowly-scoped — inspects the root cause message and maps `idx_funding_orders_one_active_per_wallet` violations to `409 SP-0022` (funding already in progress). All other `DataIntegrityViolationException`s are rethrown so the default error handling still applies.
- **Tests**: 2 new `GlobalExceptionHandlerTest` cases — one asserts the partial-index path returns the enriched `SP-0022` body, the other asserts an unrelated constraint bubbles up unchanged.
- **`.env.example`**: documents `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, `TREASURY_PRIVATE_KEY`.
- **`docker-compose.yml`**: forwards the three Stripe/treasury vars to the backend container via `${VAR}`.
- **`Makefile`**: adds `make stripe-listen` to forward Stripe webhook events to `localhost:8080/webhooks/stripe`.
- **`docs/StablePay.postman_collection.json`**:
  - `Wallets → Fund Wallet` now asserts `201` + the `FundingOrderResponse` schema and captures `fundingId` into a collection variable.
  - New `Funding` folder: `Get Funding Order` (`GET /api/funding-orders/{id}`) and `Refund Funding` (`POST /api/funding-orders/{id}/refund`).
  - New `fundingId` collection variable.

## Out of scope

The `E2E Flow` folder in the Postman collection still uses the legacy synchronous fund flow. That folder requires Stripe webhook simulation to be meaningful end-to-end, which belongs to **STA-82: Tests and E2E devnet verification**.

## Checklist

- [x] `./gradlew build` passes (1m 6s)
- [x] `./gradlew integrationTest` passes (37s)
- [x] Unit tests added for the new `DataIntegrityViolationException` handler
- [x] Spotless formatting applied (enforced by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)