### PR TITLE
STA-82: add FundingApiMapper + finalizeFunding idempotency tests and E2E log

### DIFF
--- a/backend/src/test/java/com/stablepay/application/controller/funding/mapper/FundingApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/mapper/FundingApiMapperTest.java
@@ -1,0 +1,58 @@
+package com.stablepay.application.controller.funding.mapper;
+
+import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.application.dto.FundingOrderResponse;
+
+class FundingApiMapperTest {
+
+    private static final String SOME_CLIENT_SECRET = "pi_3MnTest_secret_abc";
+
+    private final FundingApiMapper mapper = new FundingApiMapperImpl();
+
+    @Test
+    void shouldMapFundingOrderToResponseWithoutClientSecret() {
+        // given
+        var order = fundingOrderBuilder().build();
+
+        // when
+        var response = mapper.toResponse(order);
+
+        // then
+        var expected = FundingOrderResponse.builder()
+                .fundingId(order.fundingId())
+                .walletId(order.walletId())
+                .amountUsdc(order.amountUsdc())
+                .status(order.status())
+                .stripePaymentIntentId(order.stripePaymentIntentId())
+                .createdAt(order.createdAt())
+                .build();
+
+        assertThat(response).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldMapFundingOrderToResponseWithClientSecretWhenProvided() {
+        // given
+        var order = fundingOrderBuilder().build();
+
+        // when
+        var response = mapper.toResponseWithClientSecret(order, SOME_CLIENT_SECRET);
+
+        // then
+        var expected = FundingOrderResponse.builder()
+                .fundingId(order.fundingId())
+                .walletId(order.walletId())
+                .amountUsdc(order.amountUsdc())
+                .status(order.status())
+                .stripePaymentIntentId(order.stripePaymentIntentId())
+                .stripeClientSecret(SOME_CLIENT_SECRET)
+                .createdAt(order.createdAt())
+                .build();
+
+        assertThat(response).usingRecursiveComparison().isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/funding/mapper/FundingApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/mapper/FundingApiMapperTest.java
@@ -1,6 +1,7 @@
 package com.stablepay.application.controller.funding.mapper;
 
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.StripeFixtures.SOME_STRIPE_CLIENT_SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -8,8 +9,6 @@ import org.junit.jupiter.api.Test;
 import com.stablepay.application.dto.FundingOrderResponse;
 
 class FundingApiMapperTest {
-
-    private static final String SOME_CLIENT_SECRET = "pi_3MnTest_secret_abc";
 
     private final FundingApiMapper mapper = new FundingApiMapperImpl();
 
@@ -40,7 +39,7 @@ class FundingApiMapperTest {
         var order = fundingOrderBuilder().build();
 
         // when
-        var response = mapper.toResponseWithClientSecret(order, SOME_CLIENT_SECRET);
+        var response = mapper.toResponseWithClientSecret(order, SOME_STRIPE_CLIENT_SECRET);
 
         // then
         var expected = FundingOrderResponse.builder()
@@ -49,7 +48,7 @@ class FundingApiMapperTest {
                 .amountUsdc(order.amountUsdc())
                 .status(order.status())
                 .stripePaymentIntentId(order.stripePaymentIntentId())
-                .stripeClientSecret(SOME_CLIENT_SECRET)
+                .stripeClientSecret(SOME_STRIPE_CLIENT_SECRET)
                 .createdAt(order.createdAt())
                 .build();
 

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
@@ -108,14 +108,15 @@ class FinalizeFundingHandlerTest {
     @Test
     void shouldBeIdempotentAcrossDoubleInvocationSoBalanceIsCreditedOnlyOnce() {
         // given
+        var initialBalance = new BigDecimal("10.000000");
         var initialWallet = walletBuilder()
                 .id(SOME_WALLET_ID)
-                .availableBalance(new BigDecimal("10.000000"))
-                .totalBalance(new BigDecimal("10.000000"))
+                .availableBalance(initialBalance)
+                .totalBalance(initialBalance)
                 .build();
         var creditedWallet = initialWallet.toBuilder()
-                .availableBalance(new BigDecimal("35.000000"))
-                .totalBalance(new BigDecimal("35.000000"))
+                .availableBalance(initialBalance.add(SOME_AMOUNT_USDC))
+                .totalBalance(initialBalance.add(SOME_AMOUNT_USDC))
                 .build();
         var pendingOrder = FundingOrderFixtures.fundingOrderBuilder()
                 .walletId(SOME_WALLET_ID)
@@ -137,13 +138,11 @@ class FinalizeFundingHandlerTest {
 
         // then
         then(walletRepository).should().save(walletCaptor.capture());
-        assertThat(walletCaptor.getAllValues()).hasSize(1);
         assertThat(walletCaptor.getValue())
                 .usingRecursiveComparison()
                 .isEqualTo(creditedWallet);
 
         then(fundingOrderRepository).should().save(orderCaptor.capture());
-        assertThat(orderCaptor.getAllValues()).hasSize(1);
         assertThat(orderCaptor.getValue())
                 .usingRecursiveComparison()
                 .isEqualTo(fundedOrder);

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerTest.java
@@ -106,6 +106,50 @@ class FinalizeFundingHandlerTest {
     }
 
     @Test
+    void shouldBeIdempotentAcrossDoubleInvocationSoBalanceIsCreditedOnlyOnce() {
+        // given
+        var initialWallet = walletBuilder()
+                .id(SOME_WALLET_ID)
+                .availableBalance(new BigDecimal("10.000000"))
+                .totalBalance(new BigDecimal("10.000000"))
+                .build();
+        var creditedWallet = initialWallet.toBuilder()
+                .availableBalance(new BigDecimal("35.000000"))
+                .totalBalance(new BigDecimal("35.000000"))
+                .build();
+        var pendingOrder = FundingOrderFixtures.fundingOrderBuilder()
+                .walletId(SOME_WALLET_ID)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .status(FundingStatus.PAYMENT_CONFIRMED)
+                .build();
+        var fundedOrder = pendingOrder.toBuilder().status(FundingStatus.FUNDED).build();
+
+        given(walletRepository.findById(SOME_WALLET_ID))
+                .willReturn(Optional.of(initialWallet))
+                .willReturn(Optional.of(creditedWallet));
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID))
+                .willReturn(Optional.of(pendingOrder))
+                .willReturn(Optional.of(fundedOrder));
+
+        // when
+        handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+        handler.handle(SOME_FUNDING_ID, SOME_WALLET_ID, SOME_AMOUNT_USDC);
+
+        // then
+        then(walletRepository).should().save(walletCaptor.capture());
+        assertThat(walletCaptor.getAllValues()).hasSize(1);
+        assertThat(walletCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(creditedWallet);
+
+        then(fundingOrderRepository).should().save(orderCaptor.capture());
+        assertThat(orderCaptor.getAllValues()).hasSize(1);
+        assertThat(orderCaptor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(fundedOrder);
+    }
+
+    @Test
     void shouldThrowWhenWalletNotFound() {
         // given
         given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());

--- a/docs/E2E_DEVNET_TEST_LOG.md
+++ b/docs/E2E_DEVNET_TEST_LOG.md
@@ -500,3 +500,69 @@ Claim Authority USDC:  3  (received from second escrow claim)
 | Claim #1 (bug) | `27N4KAjf1nt9hkcvQR2aJQVfFByuiEM8TiBGLnCjW7BW8UFhkxCExQGbZmvqnV33WyRcuMEaCZ3YTqm7YmenqZRj` | Failed (0xbbf) |
 | Deposit #2 (3 USDC) | `4wcFXRXQmsRqVgQAMvQARzdvj9es65AYjv85eNVF1Q22spbXt1SFDk3PGMWbuvnDYE6E4WXoZDHChm4cPd7L9noK` | Finalized |
 | Claim #2 (fixed) | `61uQZbjb6YPxXC5Gcp46dGTLQ7VwwE49YSRoDgg5HDKtM4wX4KwUui14aF16458G6DJtNBcGdJSUq2Zrr9Va1WDf` | **Finalized (Ok)** |
+
+---
+
+## Stripe On-Ramp E2E (STA-82)
+
+Validates the full Stripe on-ramp funding flow on devnet:
+Stripe test payment → webhook → Temporal `WalletFundingWorkflow` →
+real on-chain USDC + SOL transfers → DB balance credit.
+
+### Prerequisites
+
+- Stripe test-mode keys in `.env`: `STRIPE_API_KEY=sk_test_…`, `STRIPE_WEBHOOK_SECRET=whsec_…`
+- Treasury devnet wallet funded with USDC + SOL, `TREASURY_PRIVATE_KEY` in `.env`
+- Stripe CLI installed, authenticated against the test account
+- Docker stack running: `make up`
+- Webhook forwarder: `make stripe-listen` (keep this terminal open)
+
+### Happy Path — Fund → Workflow → On-chain credit
+
+1. Create MPC wallet: `POST /api/wallets` → capture `{walletId, solanaAddress}`
+2. Initiate funding: `POST /api/wallets/{walletId}/fund` body `{"amount": 25.00}`
+   → expect `201` + `FundingOrderResponse` with `status=PAYMENT_CONFIRMED`,
+   `stripePaymentIntentId`, `stripeClientSecret` — capture `fundingId`
+3. Confirm the PI via Stripe CLI in test mode (auto-confirm is already wired in
+   `StripePaymentAdapter` when `stripe.auto-confirm=true`) — `stripe listen`
+   forwards `payment_intent.succeeded` back to `/webhooks/stripe`
+4. Poll `GET /api/funding-orders/{fundingId}` — expect status transition
+   `PAYMENT_CONFIRMED → FUNDED` within ~15s (workflow executes 5 activities)
+5. Verify sender ATA on devnet holds 25.000000 USDC (Solana Explorer)
+6. Verify sender has enough SOL (auto top-up ≥ 0.01 SOL if below threshold)
+7. Verify DB: wallet `available_balance` = 25, `funding_orders.status = FUNDED`
+
+Expected workflow signature: `checkTreasuryBalance → ensureSolBalance →
+createAtaIfNeeded → transferUsdc → finalizeFunding`.
+
+### Refund Path (Stripe-only — SPL stays in sender ATA)
+
+1. Create a fresh wallet, fund it `10.00` and wait for FUNDED
+2. `POST /api/funding-orders/{fundingId}/refund` → expect `200` + status `REFUNDED`
+3. Verify Stripe dashboard: refund visible, original PI shows refunded amount
+4. Verify DB: wallet balance decremented by 10.00, order status `REFUNDED`
+5. **Invariant:** sender ATA still holds 10 USDC on-chain — this is by design
+   (rev-5 spec appendix #20). The refund returns fiat via Stripe; on-chain SPL
+   is not clawed back.
+
+### Refund Rejection Path (SP-0025 balance gate)
+
+1. Create a third wallet, fund it `10.00`, wait for FUNDED
+2. Create a remittance that consumes the USDC
+   (`POST /api/remittances` body `{amountUsdc: 10.00, ...}`) — this moves USDC
+   to escrow and decrements wallet balance
+3. `POST /api/funding-orders/{fundingId}/refund` → expect `409 SP-0025`
+   (`InsufficientBalanceForRefundException`)
+4. Verify DB: order status unchanged (still `FUNDED`), wallet balance unchanged,
+   no Stripe refund attempted
+
+### Completion Checklist
+
+| Scenario | API | Temporal | On-chain | Stripe | Status |
+|----------|-----|----------|----------|--------|--------|
+| Happy path fund | 201/200 | 5 activities | 25 USDC credited | PI succeeded | — |
+| Refund path | 200 REFUNDED | n/a | SPL retained in ATA | Refund created | — |
+| Refund reject (SP-0025) | 409 SP-0025 | n/a | No-op | No refund call | — |
+
+Fill in the Status column and append Stripe PI / refund IDs + devnet signatures
+once the run completes.


### PR DESCRIPTION
## STA Issue
Closes #159

## Summary

STA-82 is a test-coverage audit for the Stripe on-ramp flow. The bulk of the required test classes were already landed by STA-73 through STA-81 (InitiateFundingHandlerTest, CompleteFundingHandlerTest, FailFundingHandlerTest, GetFundingOrderHandlerTest, RefundFundingHandlerTest, StripePaymentAdapterTest, WalletFundingActivitiesImplTest, StripeWebhookControllerTest, FundingOrderEntityMapperTest, FundingControllerTest, WalletFundingWorkflowIntegrationTest, FundingOrderRepositoryIntegrationTest — all present and passing). This PR fills the four remaining gaps.

## Changes

- **`FundingApiMapperTest`** (new, 2 tests): `toResponse` never emits `stripeClientSecret`; `toResponseWithClientSecret` surfaces the secret exactly on POST-mapping.
- **`FinalizeFundingHandlerTest` double-invocation idempotency**: stateful mock replays the real Temporal activity-retry scenario — first call credits the wallet and flips the order to `FUNDED`, second call short-circuits. Asserts `walletRepository.save` and `fundingOrderRepository.save` each invoked exactly once across two `handle` calls, proving balance is credited once and status stays `FUNDED`.
- **`E2E_DEVNET_TEST_LOG.md`**: appended Stripe on-ramp section covering
  - Happy path (Stripe test PI → webhook → 5-activity workflow → on-chain USDC + SOL top-up)
  - Refund path (status → `REFUNDED`, **SPL stays in sender ATA by design — rev-5 spec appendix #20**)
  - Refund-reject path (SP-0025 balance gate when remittance has consumed the USDC)

## Gaps not filled (already covered elsewhere)

- **Concurrent-race via `DataIntegrityViolationException` (SP-0022)** — `InitiateFundingHandlerTest.shouldPropagateFundingAlreadyInProgressFromAdapter` covers the handler-facing view (adapter translates DIVE → `FundingAlreadyInProgressException` before the handler sees it). The adapter-level DB behavior is exercised by `FundingOrderRepositoryIntegrationTest.shouldRejectSecondActiveOrderForSameWallet` (partial unique index).
- **`CompleteFundingHandler` idempotency across all 5 post-payment states** — already 10 tests in place (FUNDED, FAILED, REFUND_INITIATED, REFUNDED, REFUND_FAILED, plus not-found / wallet-missing / null-id / empty-starter cases).
- **`WalletFundingActivitiesImplTest`** — 11 existing tests cover treasury checks, SOL top-up threshold, ATA creation, USDC transfer signature return, and finalize delegation. The atomic-idempotency test lives at the domain handler level (`FinalizeFundingHandler`), where the logic actually sits.

## Verification

- [x] `./gradlew build` passes (1m 7s, includes new tests)
- [x] `./gradlew integrationTest` passes
- [x] Targeted rerun confirms `FundingApiMapperTest` 2/2 + `FinalizeFundingHandlerTest` 5/5 pass; log output shows the balance is credited exactly once across the double invocation
- [x] Spotless + pre-push unit tests pass
- [ ] Live devnet E2E walk-through — not executed (requires `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, funded `TREASURY_PRIVATE_KEY`). Runbook in `docs/E2E_DEVNET_TEST_LOG.md` is ready for the maintainer to execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for funding API response mapping functionality
  * Added test case validating idempotent behavior in funding handler operations to ensure data consistency

* **Documentation**
  * Expanded E2E testing documentation with Stripe On-Ramp test plan including funding, refund, and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->