### PR TITLE
STA-87: evolve FiatDisbursementProvider port to return DisbursementResult

### DIFF
--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.temporal;
 
 import static com.stablepay.infrastructure.temporal.TaskQueue.Constants.TASK_QUEUE_REMITTANCE_LIFECYCLE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_DESTINATION_ADDRESS;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_SENDER_ADDRESS;
@@ -100,7 +101,7 @@ class RemittanceLifecycleWorkflowIntegrationTest {
                             remittanceId.toString(), RemittanceStatus.CLAIMED);
             then(activities)
                     .should()
-                    .disburseInr(SOME_UPI_ID, SOME_AMOUNT_USDC, remittanceId.toString());
+                    .disburseInr(SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, remittanceId.toString());
             then(activities)
                     .should()
                     .updateRemittanceStatus(
@@ -189,7 +190,7 @@ class RemittanceLifecycleWorkflowIntegrationTest {
             // given
             willThrow(new RuntimeException("Disbursement provider unavailable"))
                     .given(activities)
-                    .disburseInr(SOME_UPI_ID, SOME_AMOUNT_USDC, remittanceId.toString());
+                    .disburseInr(SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, remittanceId.toString());
 
             var workflow = startWorkflow();
 

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/DisbursementResult.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/DisbursementResult.java
@@ -1,0 +1,6 @@
+package com.stablepay.domain.remittance.model;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record DisbursementResult(String providerId, String providerStatus) {}

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/DisbursementResult.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/DisbursementResult.java
@@ -1,6 +1,13 @@
 package com.stablepay.domain.remittance.model;
 
+import static java.util.Objects.requireNonNull;
+
 import lombok.Builder;
 
 @Builder(toBuilder = true)
-public record DisbursementResult(String providerId, String providerStatus) {}
+public record DisbursementResult(String providerId, String providerStatus) {
+    public DisbursementResult {
+        requireNonNull(providerId, "providerId cannot be null");
+        requireNonNull(providerStatus, "providerStatus cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/FiatDisbursementProvider.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/FiatDisbursementProvider.java
@@ -2,6 +2,12 @@ package com.stablepay.domain.remittance.port;
 
 import java.math.BigDecimal;
 
+import com.stablepay.domain.remittance.model.DisbursementResult;
+
 public interface FiatDisbursementProvider {
-    void disburse(String upiId, BigDecimal amountUsdc, String remittanceId);
+    DisbursementResult disburse(
+            String upiId,
+            BigDecimal amountUsdc,
+            BigDecimal amountInr,
+            String remittanceId);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapter.java
@@ -1,8 +1,10 @@
 package com.stablepay.infrastructure.disbursement;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import com.stablepay.domain.common.PiiMasking;
+import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.port.FiatDisbursementProvider;
 
 import lombok.extern.slf4j.Slf4j;
@@ -10,10 +12,28 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LoggingDisbursementAdapter implements FiatDisbursementProvider {
 
+    private static final String SIMULATED_STATUS = "SIMULATED";
+
     @Override
-    public void disburse(String upiId, BigDecimal amountUsdc, String remittanceId) {
-        log.info("Simulating INR disbursement: {} USDC to UPI {} for remittance {}",
-                amountUsdc, PiiMasking.maskUpi(upiId), remittanceId);
-        log.info("INR disbursement simulated successfully for remittance {}", remittanceId);
+    public DisbursementResult disburse(
+            String upiId,
+            BigDecimal amountUsdc,
+            BigDecimal amountInr,
+            String remittanceId) {
+        log.info(
+                "Simulating INR disbursement: {} USDC ({} INR) to UPI {} for remittance {}",
+                amountUsdc,
+                amountInr,
+                PiiMasking.maskUpi(upiId),
+                remittanceId);
+        var result = DisbursementResult.builder()
+                .providerId("log_" + UUID.randomUUID())
+                .providerStatus(SIMULATED_STATUS)
+                .build();
+        log.info(
+                "INR disbursement simulated successfully for remittance {} providerId={}",
+                remittanceId,
+                result.providerId());
+        return result;
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
@@ -2,6 +2,7 @@ package com.stablepay.infrastructure.temporal;
 
 import java.math.BigDecimal;
 
+import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 
 import io.temporal.activity.ActivityInterface;
@@ -21,7 +22,11 @@ public interface RemittanceLifecycleActivities {
 
     void sendClaimSms(String recipientPhone, String claimUrl);
 
-    void disburseInr(String upiId, BigDecimal amountUsdc, String remittanceId);
+    DisbursementResult disburseInr(
+            String upiId,
+            BigDecimal amountUsdc,
+            BigDecimal amountInr,
+            String remittanceId);
 
     void updateRemittanceStatus(String remittanceId, RemittanceStatus status);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import com.stablepay.domain.common.PiiMasking;
 import com.stablepay.domain.common.port.SmsProvider;
 import com.stablepay.domain.remittance.handler.UpdateRemittanceStatusHandler;
+import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.FiatDisbursementProvider;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
@@ -78,13 +79,28 @@ public class RemittanceLifecycleActivitiesImpl implements RemittanceLifecycleAct
     }
 
     @Override
-    public void disburseInr(String upiId, BigDecimal amountUsdc, String remittanceId) {
+    public DisbursementResult disburseInr(
+            String upiId,
+            BigDecimal amountUsdc,
+            BigDecimal amountInr,
+            String remittanceId) {
         requireNonNull(upiId, "upiId must not be null");
         requireNonNull(amountUsdc, "amountUsdc must not be null");
+        requireNonNull(amountInr, "amountInr must not be null");
         requireNonNull(remittanceId, "remittanceId must not be null");
-        log.info("Disbursing {} USDC as INR to UPI {} for remittance {}", amountUsdc, PiiMasking.maskUpi(upiId), remittanceId);
-        fiatDisbursementProvider.disburse(upiId, amountUsdc, remittanceId);
-        log.info("INR disbursement completed for remittance {}", remittanceId);
+        log.info(
+                "Disbursing {} USDC ({} INR) as INR to UPI {} for remittance {}",
+                amountUsdc,
+                amountInr,
+                PiiMasking.maskUpi(upiId),
+                remittanceId);
+        var result = fiatDisbursementProvider.disburse(upiId, amountUsdc, amountInr, remittanceId);
+        log.info(
+                "INR disbursement completed for remittance {} providerId={} providerStatus={}",
+                remittanceId,
+                result.providerId(),
+                result.providerStatus());
+        return result;
     }
 
     @Override

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
@@ -94,7 +94,9 @@ public class RemittanceLifecycleActivitiesImpl implements RemittanceLifecycleAct
                 amountInr,
                 PiiMasking.maskUpi(upiId),
                 remittanceId);
-        var result = fiatDisbursementProvider.disburse(upiId, amountUsdc, amountInr, remittanceId);
+        var result = requireNonNull(
+                fiatDisbursementProvider.disburse(upiId, amountUsdc, amountInr, remittanceId),
+                "fiatDisbursementProvider returned null DisbursementResult");
         log.info(
                 "INR disbursement completed for remittance {} providerId={} providerStatus={}",
                 remittanceId,

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -122,6 +122,7 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
             disbursementActivities.disburseInr(
                     pendingClaim.upiId(),
                     request.amountUsdc(),
+                    request.amountInr(),
                     remittanceId.toString());
         } catch (Exception e) {
             log.error("INR disbursement failed for remittanceId={}, escrow already released", remittanceId, e);

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
@@ -12,6 +12,7 @@ public record RemittanceWorkflowRequest(
     String senderAddress,
     String recipientPhone,
     BigDecimal amountUsdc,
+    BigDecimal amountInr,
     String claimToken,
     String claimBaseUrl,
     Duration claimExpiryTimeout,

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceWorkflowRequest.java
@@ -17,4 +17,10 @@ public record RemittanceWorkflowRequest(
     String claimBaseUrl,
     Duration claimExpiryTimeout,
     long escrowExpiryTimestamp
-) {}
+) {
+    public RemittanceWorkflowRequest {
+        if (amountInr == null) {
+            amountInr = BigDecimal.ZERO;
+        }
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarter.java
@@ -43,6 +43,7 @@ public class TemporalRemittanceWorkflowStarter implements RemittanceWorkflowStar
                 .senderAddress(senderAddress)
                 .recipientPhone(recipientPhone)
                 .amountUsdc(amountUsdc)
+                .amountInr(BigDecimal.ZERO)
                 .claimToken(claimToken)
                 .claimBaseUrl(temporal.claimBaseUrl())
                 .claimExpiryTimeout(temporal.claimExpiryTimeout())

--- a/backend/src/test/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapterTest.java
@@ -24,6 +24,7 @@ class LoggingDisbursementAdapterTest {
 
         // then
         var expected = DisbursementResult.builder()
+                .providerId("ignored")
                 .providerStatus("SIMULATED")
                 .build();
         assertThat(result)

--- a/backend/src/test/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/disbursement/LoggingDisbursementAdapterTest.java
@@ -1,25 +1,35 @@
 package com.stablepay.infrastructure.disbursement;
 
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_INR;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_UPI_ID;
-import static org.assertj.core.api.Assertions.assertThatCode;
-
-import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class LoggingDisbursementAdapterTest {
+import com.stablepay.domain.remittance.model.DisbursementResult;
 
-    private static final BigDecimal SOME_AMOUNT_USDC = new BigDecimal("100.00");
+class LoggingDisbursementAdapterTest {
 
     private final LoggingDisbursementAdapter adapter = new LoggingDisbursementAdapter();
 
     @Test
-    void shouldDisburseWithoutError() {
-        // given — logging adapter is a no-op
+    void shouldReturnSyntheticDisbursementResultWithSimulatedStatus() {
+        // given — logging adapter is a no-op simulator
 
-        // when / then
-        assertThatCode(() -> adapter.disburse(SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_REMITTANCE_ID.toString()))
-                .doesNotThrowAnyException();
+        // when
+        var result = adapter.disburse(
+                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString());
+
+        // then
+        var expected = DisbursementResult.builder()
+                .providerStatus("SIMULATED")
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .ignoringFields("providerId")
+                .isEqualTo(expected);
+        assertThat(result.providerId()).matches("^log_[0-9a-f-]{36}$");
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImplTest.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.temporal;
 
 import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_DEPOSIT_TX_SIGNATURE;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_DESTINATION_ADDRESS;
@@ -27,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.stablepay.domain.common.port.SmsProvider;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.remittance.handler.UpdateRemittanceStatusHandler;
+import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.FiatDisbursementProvider;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
@@ -36,6 +38,10 @@ class RemittanceLifecycleActivitiesImplTest {
 
     private static final String SOME_CLAIM_URL = "https://claim.stablepay.app/claim-token-abc-123";
     private static final BigDecimal SOME_DISBURSEMENT_AMOUNT = new BigDecimal("100.00");
+    private static final DisbursementResult SOME_DISBURSEMENT_RESULT = DisbursementResult.builder()
+            .providerId("log_11111111-1111-1111-1111-111111111111")
+            .providerStatus("SIMULATED")
+            .build();
 
     @Mock
     private SolanaTransactionService solanaTransactionService;
@@ -107,14 +113,20 @@ class RemittanceLifecycleActivitiesImplTest {
     }
 
     @Test
-    void shouldDelegateInrDisbursementToProvider() {
-        // given — provider is void, no stubbing needed
+    void shouldDelegateInrDisbursementToProviderAndReturnResult() {
+        // given
+        given(fiatDisbursementProvider.disburse(
+                SOME_UPI_ID, SOME_DISBURSEMENT_AMOUNT, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString()))
+                .willReturn(SOME_DISBURSEMENT_RESULT);
 
         // when
-        activities.disburseInr(SOME_UPI_ID, SOME_DISBURSEMENT_AMOUNT, SOME_REMITTANCE_ID.toString());
+        var result = activities.disburseInr(
+                SOME_UPI_ID, SOME_DISBURSEMENT_AMOUNT, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString());
 
         // then
-        then(fiatDisbursementProvider).should().disburse(SOME_UPI_ID, SOME_DISBURSEMENT_AMOUNT, SOME_REMITTANCE_ID.toString());
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(SOME_DISBURSEMENT_RESULT);
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.infrastructure.temporal;
 
+import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_CLAIM_BASE_URL;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_CLAIM_TOKEN;
@@ -139,7 +140,7 @@ class RemittanceLifecycleWorkflowImplTest {
                 SOME_REMITTANCE_ID.toString(), RemittanceStatus.CLAIMED);
 
         then(activities).should().disburseInr(
-                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_REMITTANCE_ID.toString());
+                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString());
 
         then(activities).should().updateRemittanceStatus(
                 SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
@@ -406,6 +407,7 @@ class RemittanceLifecycleWorkflowImplTest {
                 .given(activities).disburseInr(
                         SOME_UPI_ID,
                         SOME_AMOUNT_USDC,
+                        SOME_AMOUNT_INR,
                         SOME_REMITTANCE_ID.toString());
 
         testEnv.start();

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/TemporalRemittanceWorkflowStarterTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,7 @@ class TemporalRemittanceWorkflowStarterTest {
                 .senderAddress(SOME_SENDER_ADDRESS)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(BigDecimal.ZERO)
                 .claimToken(SOME_CLAIM_TOKEN)
                 .claimBaseUrl("https://claim.stablepay.app/")
                 .claimExpiryTimeout(Duration.ofHours(48))

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WorkflowFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WorkflowFixtures.java
@@ -17,6 +17,7 @@ public final class WorkflowFixtures {
     public static final String SOME_SENDER_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
     public static final String SOME_RECIPIENT_PHONE = "+919876543210";
     public static final BigDecimal SOME_AMOUNT_USDC = BigDecimal.valueOf(100);
+    public static final BigDecimal SOME_AMOUNT_INR = new BigDecimal("8500.00");
     public static final String SOME_CLAIM_TOKEN = "claim-token-abc-123";
     public static final String SOME_ESCROW_PDA = "EsCrOwPdA1234567890AbCdEfGhIjKlMnOpQrStUv";
     public static final String SOME_TX_SIGNATURE = "5wHu1qwD7xQFhkP3L3jE9YmN9mQfTkRzHcGzYqNz";
@@ -35,6 +36,7 @@ public final class WorkflowFixtures {
                 .senderAddress(SOME_SENDER_ADDRESS)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
+                .amountInr(SOME_AMOUNT_INR)
                 .claimToken(SOME_CLAIM_TOKEN)
                 .claimBaseUrl(SOME_CLAIM_BASE_URL)
                 .claimExpiryTimeout(SOME_CLAIM_EXPIRY_TIMEOUT)


### PR DESCRIPTION
## STA Issue
Closes #185

Refs spec: `docs/specs/2026-04-18-001-upi-payout-integration-spec.md` §4.2

## Why

Today the disbursement port returns `void` and takes no INR amount — sufficient for the logging stub, insufficient for a real off-ramp. RazorpayX needs INR (paise), and the workflow must persist the returned `pout_xxx` ID for the demo narrative. This PR is the foundation ticket: every subsequent disbursement piece (STA-88 retry classification, STA-89 writer, STA-90 Razorpay adapter, STA-91 workflow wiring) depends on it.

## Changes

- **New domain model** `DisbursementResult(providerId, providerStatus)` in `domain/remittance/model/`
- **Port signature** — `FiatDisbursementProvider.disburse(...)` now returns `DisbursementResult` and accepts `amountInr: BigDecimal` in addition to `amountUsdc`
- **Logging adapter** returns synthetic `log_<uuid>` / `SIMULATED` (regex `^log_[0-9a-f-]{36}$`) — no behavior change for existing E2E
- **Activity** `RemittanceLifecycleActivities.disburseInr(...)` mirrors the new port signature; impl propagates `amountInr` through to the provider and returns the result
- **Workflow request** carries `amountInr`; `RemittanceLifecycleWorkflowImpl` threads it through to the activity
- **Production starter** `TemporalRemittanceWorkflowStarter` passes `BigDecimal.ZERO` as a placeholder. STA-91 replaces this once `RemittanceWorkflowStarter` port + `CreateRemittanceHandler` are updated to compute and thread the real INR amount upstream
- **Tests + fixtures** — `WorkflowFixtures.SOME_AMOUNT_INR` added; 5 test files updated to the new signatures (3 unit, 1 starter, 1 integration)

## Out of scope (deferred per spec §11)

- `RemittancePayoutWriter` + idempotency guard inside the activity → STA-89/91
- `DisbursementException.NonRetriable` + Temporal `RetryOptions(maxAttempts=3)` → STA-88
- `Workflow.getVersion("disburseInr_amountInr", ...)` versioning gate → STA-91
- `RazorpayUpiDisbursementAdapter` + `@ConditionalOnProperty` wiring → STA-90
- `IntegrationTestConfig` mock returning non-null `DisbursementResult` → STA-93
- Threading `amountInr` from `RemittanceWorkflowStarter` port through `CreateRemittanceHandler` → STA-91

## Checklist

- [x] `./gradlew spotlessApply test` passes
- [x] `./gradlew integrationTest` passes (against running Docker stack)
- [x] Unit tests updated (`LoggingDisbursementAdapterTest`, `RemittanceLifecycleActivitiesImplTest`, `RemittanceLifecycleWorkflowImplTest`, `TemporalRemittanceWorkflowStarterTest`)
- [x] Integration test updated (`RemittanceLifecycleWorkflowIntegrationTest`)
- [x] ArchUnit rules pass (no new domain → infrastructure imports)
- [x] Spotless formatting applied
- [x] Pre-push hook ran tests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disbursement operations now return structured result information including provider status and tracking identifiers.

* **Refactor**
  * Enhanced disbursement workflow to track Indian Rupee amounts in addition to existing currency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->