### PR TITLE
STA-88: Add DisbursementException.NonRetriable and enable Temporal retry on 5xx

### DIFF
--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.test.TemporalTest;
 
@@ -188,7 +189,7 @@ class RemittanceLifecycleWorkflowIntegrationTest {
         @Test
         void shouldTransitionToDisbursementFailedWhenDisbursementThrows() {
             // given
-            willThrow(new RuntimeException("Disbursement provider unavailable"))
+            willThrow(DisbursementException.nonRetriable(SOME_UPI_ID, "invalid UPI"))
                     .given(activities)
                     .disburseInr(SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, remittanceId.toString());
 

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/DisbursementException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/DisbursementException.java
@@ -5,21 +5,38 @@ import com.stablepay.domain.common.PiiMasking;
 public class DisbursementException extends RuntimeException {
 
     public static DisbursementException forRecipient(String upiId, Throwable cause) {
-        return new DisbursementException(
-                "SP-0018: INR disbursement failed for UPI: " + PiiMasking.maskUpi(upiId),
-                cause);
+        return new DisbursementException(buildMessage(upiId, null), cause);
     }
 
     public static DisbursementException forRecipient(String upiId, String reason) {
-        return new DisbursementException(
-                "SP-0018: INR disbursement failed for UPI: " + PiiMasking.maskUpi(upiId) + " - " + reason);
+        return new DisbursementException(buildMessage(upiId, reason));
     }
 
-    private DisbursementException(String message) {
+    public static DisbursementException retriable(String upiId, Throwable cause) {
+        return new DisbursementException(buildMessage(upiId, null), cause);
+    }
+
+    public static NonRetriable nonRetriable(String upiId, String reason) {
+        return new NonRetriable(buildMessage(upiId, reason));
+    }
+
+    protected DisbursementException(String message) {
         super(message);
     }
 
-    private DisbursementException(String message, Throwable cause) {
+    protected DisbursementException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    private static String buildMessage(String upiId, String reason) {
+        var base = "SP-0018: INR disbursement failed for UPI: " + PiiMasking.maskUpi(upiId);
+        return reason == null ? base : base + " - " + reason;
+    }
+
+    public static class NonRetriable extends DisbursementException {
+
+        private NonRetriable(String message) {
+            super(message);
+        }
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/DisbursementException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/DisbursementException.java
@@ -20,11 +20,11 @@ public class DisbursementException extends RuntimeException {
         return new NonRetriable(buildMessage(upiId, reason));
     }
 
-    protected DisbursementException(String message) {
+    private DisbursementException(String message) {
         super(message);
     }
 
-    protected DisbursementException(String message, Throwable cause) {
+    private DisbursementException(String message, Throwable cause) {
         super(message, cause);
     }
 

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 
+import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.infrastructure.temporal.TaskQueue.Constants;
 
@@ -26,7 +27,7 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
     private static final int SMS_MAX_ATTEMPTS = 3;
     private static final int DISBURSEMENT_MAX_ATTEMPTS = 3;
     private static final String DISBURSEMENT_NON_RETRIABLE_TYPE =
-            "com.stablepay.domain.remittance.exception.DisbursementException$NonRetriable";
+            DisbursementException.NonRetriable.class.getName();
 
     private final RemittanceLifecycleActivities solanaActivities =
             Workflow.newActivityStub(RemittanceLifecycleActivities.class, solanaActivityOptions());

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -24,6 +24,9 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
     private static final Duration STATUS_UPDATE_TIMEOUT = Duration.ofSeconds(10);
     private static final int SOLANA_MAX_ATTEMPTS = 3;
     private static final int SMS_MAX_ATTEMPTS = 3;
+    private static final int DISBURSEMENT_MAX_ATTEMPTS = 3;
+    private static final String DISBURSEMENT_NON_RETRIABLE_TYPE =
+            "com.stablepay.domain.remittance.exception.DisbursementException$NonRetriable";
 
     private final RemittanceLifecycleActivities solanaActivities =
             Workflow.newActivityStub(RemittanceLifecycleActivities.class, solanaActivityOptions());
@@ -187,13 +190,14 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
                 .build();
     }
 
-    private static ActivityOptions disbursementActivityOptions() {
+    static ActivityOptions disbursementActivityOptions() {
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(DISBURSEMENT_ACTIVITY_TIMEOUT)
                 .setRetryOptions(RetryOptions.newBuilder()
-                        .setMaximumAttempts(1)
-                        .setDoNotRetry(
-                                "com.stablepay.domain.remittance.exception.DisbursementException")
+                        .setMaximumAttempts(DISBURSEMENT_MAX_ATTEMPTS)
+                        .setInitialInterval(Duration.ofSeconds(2))
+                        .setBackoffCoefficient(2.0)
+                        .setDoNotRetry(DISBURSEMENT_NON_RETRIABLE_TYPE)
                         .build())
                 .build();
     }

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
@@ -23,15 +23,18 @@ import static org.mockito.Mockito.never;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.common.RetryOptions;
 import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 
@@ -403,7 +406,7 @@ class RemittanceLifecycleWorkflowImplTest {
                 SOME_SENDER_ADDRESS))
                 .willReturn(SOME_RELEASE_TX_SIGNATURE);
 
-        willThrow(new RuntimeException("Disbursement provider unavailable"))
+        willThrow(DisbursementException.nonRetriable(SOME_UPI_ID, "invalid UPI"))
                 .given(activities).disburseInr(
                         SOME_UPI_ID,
                         SOME_AMOUNT_USDC,
@@ -522,5 +525,176 @@ class RemittanceLifecycleWorkflowImplTest {
         then(activities).should(never()).refundEscrow(
                 SOME_REMITTANCE_ID.toString(),
                 SOME_SENDER_ADDRESS);
+    }
+
+    @Test
+    void shouldConfigureDisbursementActivityWithRetryOptionsExcludingNonRetriable() {
+        // given
+        var expected = RetryOptions.newBuilder()
+                .setMaximumAttempts(3)
+                .setInitialInterval(Duration.ofSeconds(2))
+                .setBackoffCoefficient(2.0)
+                .setDoNotRetry(
+                        "com.stablepay.domain.remittance.exception.DisbursementException$NonRetriable")
+                .build();
+
+        // when
+        var retryOptions = RemittanceLifecycleWorkflowImpl.disbursementActivityOptions().getRetryOptions();
+
+        // then
+        assertThat(retryOptions)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRetryTransientDisbursementFailureAndReachDelivered() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS,
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        var attempts = new AtomicInteger(0);
+        given(activities.disburseInr(
+                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString()))
+                .willAnswer(invocation -> {
+                    if (attempts.incrementAndGet() < 3) {
+                        throw DisbursementException.retriable(
+                                SOME_UPI_ID, new RuntimeException("Razorpay 5xx"));
+                    }
+                    return null;
+                });
+
+        testEnv.start();
+
+        var workflowId = "disbursement-retry-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofMinutes(1), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DELIVERED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        assertThat(attempts.get()).isEqualTo(3);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
+
+        then(activities).should(never()).updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DISBURSEMENT_FAILED);
+    }
+
+    @Test
+    void shouldNotRetryWhenDisbursementExceptionIsNonRetriable() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS,
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        var attempts = new AtomicInteger(0);
+        given(activities.disburseInr(
+                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString()))
+                .willAnswer(invocation -> {
+                    attempts.incrementAndGet();
+                    throw DisbursementException.nonRetriable(SOME_UPI_ID, "invalid UPI");
+                });
+
+        testEnv.start();
+
+        var workflowId = "disbursement-non-retriable-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofMinutes(1), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DISBURSEMENT_FAILED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        assertThat(attempts.get()).isEqualTo(1);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DISBURSEMENT_FAILED);
+
+        then(activities).should(never()).updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
     }
 }


### PR DESCRIPTION
## STA Issue
Closes #186

## Summary

The spec (§2 US-3) promises "guaranteed delivery" via retry on transient failures, but the disbursement activity was configured with `setMaximumAttempts(1)` and `setDoNotRetry("DisbursementException")` — any Razorpay 5xx or network blip permanently failed the remittance.

This PR splits disbursement failures into two classes so Temporal's `setDoNotRetry(...)` can target the right one:

- **Retriable**: HTTP 5xx, connection/read timeouts — Temporal retries up to 3 times with exponential backoff (2s → 4s → 8s).
- **Non-retriable**: HTTP 4xx, caller-side validation (invalid UPI, bad amount) — short-circuits immediately.

## Changes

- `domain/remittance/exception/DisbursementException.java`
  - Added `public static class NonRetriable extends DisbursementException`
  - Added `retriable(String upiId, Throwable cause)` factory
  - Added `nonRetriable(String upiId, String reason)` factory returning `NonRetriable`
  - Kept existing `forRecipient(...)` factories for backward compatibility
- `infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java`
  - `disbursementActivityOptions()`: `maxAttempts=3`, `initialInterval=2s`, `backoffCoefficient=2.0`, `doNotRetry=...DisbursementException$NonRetriable`
  - Changed visibility from `private static` to package-private `static` so the test can assert options directly

## Tests

- `RemittanceLifecycleWorkflowImplTest` (3 new cases + 1 updated)
  - `shouldConfigureDisbursementActivityWithRetryOptionsExcludingNonRetriable` — builds an expected `RetryOptions` and asserts via single `usingRecursiveComparison()` (golden rule)
  - `shouldRetryTransientDisbursementFailureAndReachDelivered` — 2 failures + 1 success reaches `DELIVERED`, `attempts == 3`
  - `shouldNotRetryWhenDisbursementExceptionIsNonRetriable` — single attempt, workflow transitions to `DISBURSEMENT_FAILED`
  - `shouldTransitionToDisbursementFailedWhenDisbursementThrows` — updated to throw `nonRetriable(...)` to preserve single-attempt intent under the new retry policy
- `RemittanceLifecycleWorkflowIntegrationTest` — same substitution in the disbursement-failure case

## Checklist

- [x] `./gradlew build` passes (unit + spotless + ArchUnit)
- [x] `./gradlew integrationTest --tests RemittanceLifecycleWorkflowIntegrationTest` passes
- [x] Unit tests added/updated
- [x] Integration tests updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied