### PR TITLE
STA-XX: replace stubbed tx confirmation with real getSignatureStatuses polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 # Node
 node_modules/
 
+# Python
+__pycache__/
+*.pyc
+
 # Environment
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Puneethkumarck/stablepay-hackathon/actions/workflows/ci.yml/badge.svg)](https://github.com/Puneethkumarck/stablepay-hackathon/actions/workflows/ci.yml)
 [![Java](https://img.shields.io/badge/Java-25-orange)](https://jdk.java.net/25/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-6DB33F?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
+[![Stripe](https://img.shields.io/badge/Stripe-On--Ramp-635BFF?logo=stripe&logoColor=white)](https://stripe.com/)
 [![Solana](https://img.shields.io/badge/Solana-devnet-9945FF?logo=solana&logoColor=white)](https://solana.com/)
 [![Anchor](https://img.shields.io/badge/Anchor-0.32.1-blue)](https://www.anchor-lang.com/)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://go.dev/)
@@ -54,6 +55,8 @@ graph TB
         A2["/api/remittances"]
         A3["/api/fx"]
         A4["/api/claims"]
+        A5["/api/funding-orders"]
+        A6["/webhooks/stripe"]
     end
 
     subgraph "Domain Layer — Zero Framework Dependencies"
@@ -70,7 +73,8 @@ graph TB
         I[ExchangeRate-API + Redis Cache]
         J[Temporal Workflows]
         K[Twilio SMS]
-        L[Transak Off-Ramp]
+        L[Razorpay UPI Disbursement]
+        S[Stripe Payments]
     end
 
     subgraph "External Systems"
@@ -78,7 +82,8 @@ graph TB
         N[Solana Devnet — Anchor Escrow]
         O[open.er-api.com]
         P[Twilio API]
-        Q[Transak API]
+        Q[Razorpay API]
+        R[Stripe API]
     end
 
     A --> B
@@ -90,11 +95,13 @@ graph TB
     D --> J
     D --> K
     D --> L
+    D --> S
     G --> M
     H --> N
     I --> O
     K --> P
     L --> Q
+    S --> R
 ```
 
 **Dependency rule:** `domain` → nothing. `application` → `domain`. `infrastructure` → `domain`. Never the reverse.
@@ -107,13 +114,14 @@ graph TB
 sequenceDiagram
     participant Sender as Sender (Mobile/API)
     participant API as StablePay API
+    participant Stripe as Stripe
     participant MPC as MPC Sidecar x2
     participant DB as PostgreSQL
     participant Temporal as Temporal Workflow
     participant Solana as Solana Devnet
     participant SMS as Twilio SMS
     participant Recipient as Recipient (Web)
-    participant Transak as Transak Off-Ramp
+    participant Razorpay as Razorpay UPI
 
     Note over Sender,API: Use Case 1 — Create MPC Wallet
     Sender->>API: POST /api/wallets {userId}
@@ -122,17 +130,23 @@ sequenceDiagram
     API->>DB: INSERT wallet
     API-->>Sender: 201 {solanaAddress, balance: 0}
 
-    Note over Sender,API: Use Case 2 — Fund Wallet
+    Note over Sender,Stripe: Use Case 2 — Fund Wallet (Stripe On-Ramp)
     Sender->>API: POST /api/wallets/{id}/fund {amount}
-    API->>DB: UPDATE wallet balance += amount
-    API-->>Sender: 200 {updated balance}
+    API->>Stripe: Create PaymentIntent
+    Stripe-->>API: clientSecret + paymentIntentId
+    API->>DB: INSERT funding_order (PAYMENT_CONFIRMED)
+    API-->>Sender: 201 {fundingId, clientSecret}
+    Stripe->>API: Webhook: payment_intent.succeeded
+    API->>Temporal: Start WalletFundingWorkflow
+    Temporal->>Solana: Transfer SOL (rent) + create ATA + transfer USDC
+    Temporal->>DB: UPDATE funding_order → FUNDED
 
     Note over Sender,API: Use Case 3 — Get FX Rate
     Sender->>API: GET /api/fx/USD-INR
     API->>API: Check Redis cache
     API-->>Sender: {rate: 84.50, source, expiresAt}
 
-    Note over Sender,Transak: Use Case 4 — Send Remittance
+    Note over Sender,Razorpay: Use Case 4 — Send Remittance
     Sender->>API: POST /api/remittances {senderId, phone, amount}
     API->>DB: Reserve sender balance
     API->>API: Lock FX rate, calculate INR
@@ -145,7 +159,10 @@ sequenceDiagram
     Temporal->>MPC: Sign escrow deposit transaction
     MPC-->>Temporal: Ed25519 signature
     Temporal->>Solana: Submit deposit (USDC → PDA vault)
-    Solana-->>Temporal: Transaction confirmed
+    loop Poll getSignatureStatuses (3s interval, max 40 attempts)
+        Temporal->>Solana: Check confirmation status
+        Solana-->>Temporal: PROCESSED / CONFIRMED / FINALIZED
+    end
     Temporal->>DB: UPDATE status → ESCROWED
 
     Note over Temporal,SMS: Workflow Phase 2 — Notify
@@ -155,18 +172,20 @@ sequenceDiagram
     Note over Temporal,Recipient: Workflow Phase 3 — Wait
     Temporal->>Temporal: Await claim signal (48h timeout)
 
-    Note over Recipient,Transak: Use Case 5 — Claim Funds
+    Note over Recipient,Razorpay: Use Case 5 — Claim Funds
     Recipient->>API: GET /api/claims/{token}
     API-->>Recipient: {amountUsdc, amountInr, fxRate}
     Recipient->>API: POST /api/claims/{token} {upiId}
     API->>DB: UPDATE claim_token (claimed=true, upiId)
     API->>Temporal: Signal claimSubmitted(upiId)
 
-    Note over Temporal,Transak: Workflow Phase 4 — Deliver
+    Note over Temporal,Razorpay: Workflow Phase 4 — Deliver
     Temporal->>Solana: Release escrow to recipient
-    Solana-->>Temporal: USDC released
+    loop Poll getSignatureStatuses (3s interval, max 40 attempts)
+        Temporal->>Solana: Check confirmation status
+    end
     Temporal->>DB: UPDATE status → CLAIMED
-    Temporal->>Transak: Disburse INR to UPI
+    Temporal->>Razorpay: Disburse INR to UPI
     Temporal->>DB: UPDATE status → DELIVERED
 ```
 
@@ -267,55 +286,73 @@ Content-Type: application/json
 
 ---
 
-## Use Case 2: Fund Wallet
+## Use Case 2: Fund Wallet (Stripe On-Ramp)
 
-> **Demo treasury funding.** For the hackathon, a pre-funded treasury account transfers USDC to the sender's wallet. The treasury adapter is currently a stub that updates balances in the database.
+> **Real Stripe integration.** The sender pays via Stripe (card), which triggers a webhook. A Temporal workflow then transfers SOL (for rent/fees), creates an Associated Token Account, and transfers USDC from the treasury to the sender's MPC wallet on-chain.
 
 ```mermaid
 sequenceDiagram
     participant Client
-    participant Controller as WalletController
-    participant Handler as FundWalletHandler
-    participant Treasury as TreasuryServiceAdapter
-    participant Repo as WalletRepository
+    participant Controller as FundingController
+    participant Handler as InitiateFundingHandler
+    participant Writer as FundingOrderWriter
+    participant Stripe as StripePaymentAdapter
     participant DB as PostgreSQL
+    participant Webhook as StripeWebhookController
+    participant Complete as CompleteFundingHandler
+    participant Temporal as WalletFundingWorkflow
+    participant Treasury as TreasuryServiceAdapter
+    participant Solana as Solana Devnet
 
-    Client->>Controller: POST /api/wallets/1/fund {amount: 100.00}
+    Client->>Controller: POST /api/wallets/1/fund {amount: 1.00}
+    Controller->>Writer: persist funding order
+    Writer->>DB: INSERT funding_order (PAYMENT_CONFIRMED)
+    Controller->>Handler: initiate funding
+    Handler->>Stripe: Create PaymentIntent ($1.00)
+    Stripe-->>Handler: paymentIntentId + clientSecret
+    Handler-->>Client: 201 {fundingId, clientSecret}
 
-    Controller->>Handler: handle(1, 100.00)
-    Handler->>Repo: findById(1)
-    Repo-->>Handler: Wallet{balance: 0}
+    Note over Stripe,Webhook: Stripe fires webhook
+    Stripe->>Webhook: POST /webhooks/stripe (payment_intent.succeeded)
+    Webhook->>Complete: handle(fundingId)
+    Complete->>Temporal: Start WalletFundingWorkflow
 
-    Handler->>Treasury: getBalance()
-    Treasury-->>Handler: 1,000,000 (stub)
-
-    Handler->>Treasury: transferFromTreasury("7xK...abc", 100.00)
-    Note over Treasury: Logs transfer (stub — no Solana call)
-
-    Handler->>Handler: wallet.availableBalance += 100.00
-    Handler->>Handler: wallet.totalBalance += 100.00
-    Handler->>Repo: save(updatedWallet)
-    Repo->>DB: UPDATE wallets SET available_balance=100, total_balance=100
-
-    Handler-->>Controller: Updated Wallet
-    Controller-->>Client: 200 OK
+    Note over Temporal,Solana: Temporal orchestrates on-chain funding
+    Temporal->>Treasury: checkTreasuryBalance(1.00 USDC)
+    Temporal->>Treasury: ensureSolBalance(senderAddress)
+    Treasury->>Solana: Transfer SOL for rent + fees
+    Temporal->>Treasury: createAtaIfNeeded(senderAddress)
+    Treasury->>Solana: Create Associated Token Account
+    Temporal->>Treasury: transferUsdc(senderAddress, 1.00)
+    Treasury->>Solana: SPL token transfer (treasury → sender ATA)
+    Temporal->>DB: UPDATE funding_order → FUNDED
 ```
 
 ```
 POST /api/wallets/1/fund
 Content-Type: application/json
 
-{ "amount": 100.00 }
+{ "amount": 1.00 }
 ```
 
 ```json
 {
-  "id": 1,
-  "userId": "user-123",
-  "solanaAddress": "7xK...abc",
-  "availableBalance": 100.000000,
-  "totalBalance": 100.000000
+  "fundingId": "b2c8a29a-fcca-487f-979b-bf355c82faeb",
+  "stripePaymentIntentId": "pi_3TO0YZ3nnME1dfOB0dz1SICr",
+  "stripeClientSecret": "pi_...secret_...",
+  "walletId": 1,
+  "amountUsdc": 1.00,
+  "status": "PAYMENT_CONFIRMED"
 }
+```
+
+### Funding Order Status Machine
+
+```
+PAYMENT_CONFIRMED → FUNDED     (webhook + Temporal workflow succeeds)
+PAYMENT_CONFIRMED → FAILED     (webhook: payment_intent.payment_failed)
+FUNDED → REFUND_INITIATED      (manual refund)
+REFUND_INITIATED → REFUNDED    (refund completed)
 ```
 
 ### Error Paths
@@ -324,12 +361,14 @@ Content-Type: application/json
 |---|---|---|
 | Wallet not found | SP-0006 | 404 |
 | Treasury balance insufficient | SP-0007 | 503 |
+| Funding already in progress for wallet | SP-0022 | 409 |
+| Stripe PaymentIntent creation failed | SP-0021 | 502 |
 
 ---
 
 ## Use Case 3: Get FX Rate
 
-> **Real-time rates with fallback.** FX rates come from ExchangeRate-API with Redis caching (60s TTL). If the API is unreachable, a hardcoded fallback rate of 84.50 is used.
+> **Real-time rates with fallback.** FX rates come from ExchangeRate-API with Redis caching (5-minute TTL). If the API is unreachable, a hardcoded fallback rate of 84.50 is used.
 
 ```mermaid
 sequenceDiagram
@@ -350,7 +389,7 @@ sequenceDiagram
     else Cache Miss
         Adapter->>API: GET /v6/latest/USD
         API-->>Adapter: {rates: {INR: 84.50, ...}}
-        Adapter->>Redis: SET fxRate::USD (60s TTL)
+        Adapter->>Redis: SET fxRate::USD (5m TTL)
     else API Failure
         Note over Adapter: Fallback: rate=84.50, source="fallback"
     end
@@ -521,7 +560,12 @@ stateDiagram-v2
 │  │   ├─ Fetch wallet's keyShareData from DB                     │
 │  │   ├─ Build Solana escrow deposit instruction                  │
 │  │   ├─ MPC-sign transaction (gRPC → sidecar)                   │
-│  │   └─ Submit to Solana devnet                                  │
+│  │   └─ Submit to Solana devnet → returns signature              │
+│  ├─ Poll: awaitTransactionConfirmation(signature)                │
+│  │   ├─ Calls getSignatureStatuses RPC every 3 seconds           │
+│  │   ├─ Max 40 attempts (~120s total polling window)             │
+│  │   ├─ Accepts CONFIRMED or FINALIZED as success                │
+│  │   └─ Throws SP-0012 on timeout, SP-0031 on on-chain failure  │
 │  └─ Status Update: INITIATED → ESCROWED                         │
 │                                                                  │
 │  Phase 2: SMS NOTIFICATION                                       │
@@ -535,14 +579,16 @@ stateDiagram-v2
 │  │                                                               │
 │  │   ┌─ PATH A: Claim signal received ──────────────────────┐   │
 │  │   │  Activity: releaseEscrow (60s, 3 retries, 2s backoff)│   │
+│  │   │  Poll: awaitTransactionConfirmation (3s × 40 max)     │   │
 │  │   │  Status Update: ESCROWED → CLAIMED                    │   │
-│  │   │  Activity: disburseInr (45s, NO retry)                │   │
+│  │   │  Activity: disburseInr (45s, NO retry) via Razorpay   │   │
 │  │   │  ├─ Success: Status → DELIVERED                       │   │
 │  │   │  └─ Failure: Status → DISBURSEMENT_FAILED             │   │
 │  │   └──────────────────────────────────────────────────────┘   │
 │  │                                                               │
 │  │   ┌─ PATH B: 48h timeout — no claim ────────────────────┐   │
 │  │   │  Activity: refundEscrow (60s, 3 retries, 2s backoff) │   │
+│  │   │  Poll: awaitTransactionConfirmation (3s × 40 max)     │   │
 │  │   │  Status Update: ESCROWED → REFUNDED                   │   │
 │  │   └──────────────────────────────────────────────────────┘   │
 │  └                                                               │
@@ -648,8 +694,8 @@ Content-Type: application/json
 │  3. Status update: ESCROWED → CLAIMED                          │
 │                                                                │
 │  4. disburseInr activity                                       │
-│     ├─ Call Transak API: createQuote(USDC→INR)                 │
-│     ├─ Call Transak API: createOrder(upiId, amount)            │
+│     ├─ Call Razorpay Payout API                                │
+│     ├─ Transfer INR to recipient's UPI ID                      │
 │     └─ INR credited to recipient's bank via UPI                │
 │                                                                │
 │  5. Status update: CLAIMED → DELIVERED ✓                       │
@@ -859,7 +905,7 @@ Now the actual wallets involved in StablePay:
 
 #### Act 2: 💰 Funding the Wallet
 
-> Before the sender can make a remittance, their MPC wallet needs SOL (for transaction fees) and USDC (the stablecoin to send). In production, this happens via Stripe ACH on-ramp. For the hackathon, we use a pre-funded treasury.
+> Before the sender can make a remittance, their MPC wallet needs SOL (for transaction fees) and USDC (the stablecoin to send). The sender pays via Stripe (card payment), which triggers a Temporal workflow that transfers SOL and USDC from a pre-funded treasury on Solana devnet.
 
 ```
   🏛️ Deployer / Treasury               👤 Sender MPC Wallet
@@ -1055,11 +1101,11 @@ Now the actual wallets involved in StablePay:
 #### Act 7: 🏦 INR Disbursement
 
 ```
-  Temporal Workflow                     Transak API
+  Temporal Workflow                     Razorpay API
   ┌──────────────┐                     ┌──────────────────┐
-  │ disburseInr  │────── API call ────►│ Convert USDC→INR │
+  │ disburseInr  │────── API call ────►│ Create Payout    │
   │ activity     │                     │ Send ₹2,336 to   │
-  └──────────────┘                     │ raj@upi           │
+  └──────────────┘                     │ raj@upi via UPI  │
                                        └──────────────────┘
   Status: CLAIMED → DELIVERED ✅
 ```
@@ -1143,12 +1189,19 @@ Now the actual wallets involved in StablePay:
 | SP-0007 | 503 | TreasuryDepletedException | Treasury has insufficient funds |
 | SP-0008 | 409 | WalletAlreadyExistsException | Wallet already exists for userId |
 | SP-0009 | 400 | UnsupportedCorridorException | Currency pair not supported |
-| SP-0010 | 404 | RemittanceNotFoundException | Remittance not found by ID |
+| SP-0010 | 404/500 | RemittanceNotFoundException / MpcKeyGenerationException | Remittance not found / MPC ceremony failed |
 | SP-0011 | 404 | ClaimTokenNotFoundException | Claim token not found |
-| SP-0012 | 409 | ClaimAlreadyClaimedException | Claim already submitted |
+| SP-0012 | 409/500 | ClaimAlreadyClaimedException / SolanaTransactionException | Claim already submitted / TX confirmation timeout |
 | SP-0013 | 410 | ClaimTokenExpiredException | Claim token past 48h expiry |
 | SP-0014 | 409 | InvalidRemittanceStateException | Invalid state for operation |
+| SP-0016 | 409 | InvalidRemittanceStateException | Invalid status transition |
+| SP-0017 | 500 | SmsDeliveryException | SMS delivery failed |
 | SP-0018 | 502 | DisbursementException | INR disbursement failed |
+| SP-0020 | 404 | FundingOrderNotFoundException | Funding order not found |
+| SP-0021 | 502 | FundingFailedException | Stripe payment / funding failed |
+| SP-0022 | 409 | FundingAlreadyInProgressException | Funding already in progress for wallet |
+| SP-0026 | 400 | InvalidWebhookSignatureException | Stripe webhook signature invalid |
+| SP-0031 | 500 | SolanaTransactionException | Transaction failed on-chain |
 
 ---
 
@@ -1227,10 +1280,10 @@ Interactive Swagger UI: http://localhost:8080/swagger-ui.html
 # Backend: all tests + formatting
 cd backend && ./gradlew build
 
-# Unit tests only (34 test files)
+# Unit tests only
 cd backend && ./gradlew test
 
-# Integration tests with TestContainers (6 test files)
+# Integration tests with TestContainers
 cd backend && ./gradlew integrationTest
 
 # Anchor program tests (799 lines, TypeScript on localnet)
@@ -1267,8 +1320,9 @@ graph TD
 | On-chain | Rust, Anchor 0.32.1, Solana 2.2.7 (devnet) |
 | MPC | Go 1.26, bnb-chain/tss-lib (fystack fork) |
 | Solana SDK | sol4k 0.7.0 |
+| On-ramp | Stripe (card payments + webhooks) |
+| Off-ramp | Razorpay UPI Payouts |
 | SMS | Twilio 11.3.6 |
-| Off-ramp | Transak API |
 | Mapping | MapStruct 1.6.3 |
 | Resilience | Resilience4j 2.3.0 |
 | API Docs | springdoc-openapi 3.0.2 |
@@ -1289,19 +1343,21 @@ stablepay-hackathon/
 │       │   ├── domain/               # Models, handlers, ports
 │       │   │   ├── wallet/           #   MPC wallet management
 │       │   │   ├── remittance/       #   Core remittance flow
+│       │   │   ├── funding/          #   Stripe funding orders
 │       │   │   ├── claim/            #   SMS claim tokens
 │       │   │   ├── fx/               #   FX rate quotes
 │       │   │   └── common/           #   Shared ports (SMS, disbursement)
 │       │   └── infrastructure/       # Adapters
-│       │       ├── db/               #   JPA + Flyway (3 migrations)
-│       │       ├── temporal/         #   Workflow + 6 activities
+│       │       ├── db/               #   JPA + Flyway (7 migrations)
+│       │       ├── temporal/         #   Workflows + activities
 │       │       ├── mpc/              #   gRPC client to sidecars
-│       │       ├── solana/           #   RPC + escrow instruction builder
+│       │       ├── solana/           #   RPC + escrow instruction builder + tx confirmation
+│       │       ├── stripe/           #   Stripe payments + webhook verification
+│       │       ├── razorpay/         #   Razorpay UPI disbursement
 │       │       ├── fx/               #   ExchangeRate-API + Redis cache
-│       │       ├── sms/              #   Twilio + logging fallback
-│       │       └── transak/          #   INR off-ramp adapter
-│       ├── test/                     # 34 unit test files
-│       └── integration-test/         # 6 integration test files
+│       │       └── sms/              #   Twilio + logging fallback
+│       ├── test/                     # 61 unit test files
+│       └── integration-test/         # 18 integration test files
 ├── programs/stablepay-escrow/        # Anchor program (Rust)
 │   └── src/
 │       ├── lib.rs                    # 4 instructions

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.test.TemporalTest;
 
 import io.temporal.client.WorkflowClient;
@@ -49,6 +50,9 @@ class RemittanceLifecycleWorkflowIntegrationTest {
     void setUp() {
         remittanceId = UUID.randomUUID();
         Mockito.reset(activities);
+        Mockito.lenient()
+                .when(activities.checkTransactionStatus(Mockito.anyString()))
+                .thenReturn(TransactionConfirmationStatus.FINALIZED);
     }
 
     private RemittanceLifecycleWorkflow startWorkflow() {

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
@@ -3,12 +3,17 @@ package com.stablepay.infrastructure.temporal;
 import static com.stablepay.infrastructure.temporal.TaskQueue.Constants.TASK_QUEUE_REMITTANCE_LIFECYCLE;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_AMOUNT_USDC;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_DEPOSIT_TX_SIGNATURE;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_DESTINATION_ADDRESS;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_ESCROW_EXPIRY_TIMESTAMP;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_REFUND_TX_SIGNATURE;
+import static com.stablepay.testutil.WorkflowFixtures.SOME_RELEASE_TX_SIGNATURE;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_SENDER_ADDRESS;
 import static com.stablepay.testutil.WorkflowFixtures.SOME_UPI_ID;
 import static com.stablepay.testutil.WorkflowFixtures.claimSignalBuilder;
 import static com.stablepay.testutil.WorkflowFixtures.workflowRequestBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -50,9 +55,27 @@ class RemittanceLifecycleWorkflowIntegrationTest {
     void setUp() {
         remittanceId = UUID.randomUUID();
         Mockito.reset(activities);
-        Mockito.lenient()
-                .when(activities.checkTransactionStatus(Mockito.anyString()))
-                .thenReturn(TransactionConfirmationStatus.FINALIZED);
+        given(activities.depositEscrow(
+                remittanceId.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+        given(activities.releaseEscrow(
+                remittanceId.toString(),
+                SOME_DESTINATION_ADDRESS,
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+        given(activities.refundEscrow(
+                remittanceId.toString(),
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_REFUND_TX_SIGNATURE);
+        given(activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
+        given(activities.checkTransactionStatus(SOME_RELEASE_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
+        given(activities.checkTransactionStatus(SOME_REFUND_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
     }
 
     private RemittanceLifecycleWorkflow startWorkflow() {

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowIntegrationTest.java
@@ -283,6 +283,8 @@ class RemittanceLifecycleWorkflowIntegrationTest {
                     .usingRecursiveComparison()
                     .ignoringFields("escrowPda")
                     .isEqualTo(expected);
+
+            WorkflowStub.fromTyped(workflow).cancel();
         }
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/exception/SolanaTransactionException.java
@@ -39,4 +39,9 @@ public class SolanaTransactionException extends RuntimeException {
         return new SolanaTransactionException(
                 "SP-0015: Treasury private key is not configured");
     }
+
+    public static SolanaTransactionException transactionFailed(String signature) {
+        return new SolanaTransactionException(
+                "SP-0031: Solana transaction failed on-chain for signature: " + signature);
+    }
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/RemittanceStatus.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/RemittanceStatus.java
@@ -9,12 +9,15 @@ public enum RemittanceStatus {
     CLAIMED,
     DELIVERED,
     DISBURSEMENT_FAILED,
+    DEPOSIT_FAILED,
+    CLAIM_FAILED,
+    REFUND_FAILED,
     REFUNDED,
     CANCELLED;
 
     private static final Map<RemittanceStatus, Set<RemittanceStatus>> VALID_TRANSITIONS = Map.of(
-            INITIATED, Set.of(ESCROWED, CANCELLED),
-            ESCROWED, Set.of(CLAIMED, REFUNDED, CANCELLED),
+            INITIATED, Set.of(ESCROWED, CANCELLED, DEPOSIT_FAILED),
+            ESCROWED, Set.of(CLAIMED, REFUNDED, CANCELLED, CLAIM_FAILED, REFUND_FAILED),
             CLAIMED, Set.of(DELIVERED, DISBURSEMENT_FAILED)
     );
 

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/TransactionConfirmationStatus.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/TransactionConfirmationStatus.java
@@ -7,6 +7,10 @@ public enum TransactionConfirmationStatus {
     FINALIZED,
     FAILED_ON_CHAIN;
 
+    public boolean isTerminal() {
+        return this == CONFIRMED || this == FINALIZED || this == FAILED_ON_CHAIN;
+    }
+
     public boolean isConfirmedOrFinalized() {
         return this == CONFIRMED || this == FINALIZED;
     }

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/TransactionConfirmationStatus.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/TransactionConfirmationStatus.java
@@ -1,0 +1,17 @@
+package com.stablepay.domain.remittance.model;
+
+public enum TransactionConfirmationStatus {
+    NOT_FOUND,
+    PROCESSED,
+    CONFIRMED,
+    FINALIZED,
+    FAILED_ON_CHAIN;
+
+    public boolean isConfirmedOrFinalized() {
+        return this == CONFIRMED || this == FINALIZED;
+    }
+
+    public boolean hasError() {
+        return this == FAILED_ON_CHAIN;
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/SolanaTransactionService.java
@@ -3,6 +3,8 @@ package com.stablepay.domain.remittance.port;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
+
 public interface SolanaTransactionService {
 
     String depositEscrow(
@@ -15,5 +17,5 @@ public interface SolanaTransactionService {
 
     String refundEscrow(UUID remittanceId, String senderWalletAddress);
 
-    String getTransactionStatus(String transactionSignature);
+    TransactionConfirmationStatus getTransactionStatus(String transactionSignature);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -16,6 +16,7 @@ import org.sol4k.instruction.Instruction;
 import org.springframework.stereotype.Component;
 
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.domain.wallet.port.WalletRepository;
@@ -175,14 +176,79 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
     }
 
     @Override
-    public String getTransactionStatus(String transactionSignature) {
+    public TransactionConfirmationStatus getTransactionStatus(String transactionSignature) {
         log.debug("Checking status for transaction {}", transactionSignature);
 
-        // sol4k does not expose getSignatureStatuses RPC.
-        // For now, return a stub status. Full confirmation polling
-        // will be implemented via raw JSON-RPC in a follow-up.
-        log.info("Transaction status check for {} (stub: returning CONFIRMED)", transactionSignature);
-        return "CONFIRMED";
+        java.net.HttpURLConnection conn = null;
+        try {
+            var url = new java.net.URI(solanaProperties.rpcUrl()).toURL();
+            conn = (java.net.HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(10_000);
+            conn.setReadTimeout(10_000);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+
+            var body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getSignatureStatuses\","
+                    + "\"params\":[[\"" + transactionSignature
+                    + "\"],{\"searchTransactionHistory\":true}]}";
+
+            try (var os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            try (var is = conn.getInputStream()) {
+                var response = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                if (response.contains("\"error\"")) {
+                    log.warn("RPC error checking tx status for {}: {}", transactionSignature, response);
+                    throw new RuntimeException("RPC error: " + response);
+                }
+                var status = parseSignatureStatusResponse(response);
+                log.info("Transaction {} status: {}", transactionSignature, status);
+                return status;
+            }
+        } catch (SolanaTransactionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw SolanaTransactionException.submissionFailed(
+                    "getSignatureStatuses:" + transactionSignature, e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+
+    static TransactionConfirmationStatus parseSignatureStatusResponse(String json) {
+        var valueIndex = json.indexOf("\"value\"");
+        if (valueIndex < 0) {
+            return TransactionConfirmationStatus.NOT_FOUND;
+        }
+
+        var afterValue = json.substring(valueIndex);
+        if (afterValue.contains("[null]")) {
+            return TransactionConfirmationStatus.NOT_FOUND;
+        }
+
+        if (afterValue.contains("\"err\"") && !afterValue.contains("\"err\":null")) {
+            return TransactionConfirmationStatus.FAILED_ON_CHAIN;
+        }
+
+        var csIndex = afterValue.indexOf("\"confirmationStatus\"");
+        if (csIndex < 0) {
+            return TransactionConfirmationStatus.NOT_FOUND;
+        }
+
+        var csValue = afterValue.substring(csIndex);
+        if (csValue.contains("\"finalized\"")) {
+            return TransactionConfirmationStatus.FINALIZED;
+        } else if (csValue.contains("\"confirmed\"")) {
+            return TransactionConfirmationStatus.CONFIRMED;
+        } else if (csValue.contains("\"processed\"")) {
+            return TransactionConfirmationStatus.PROCESSED;
+        }
+
+        return TransactionConfirmationStatus.NOT_FOUND;
     }
 
     private String sendWithSkipPreflight(byte[] txBytes) {

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -17,6 +17,8 @@ import org.sol4k.instruction.CreateAssociatedTokenAccountInstruction;
 import org.sol4k.instruction.Instruction;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
@@ -30,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class SolanaTransactionServiceAdapter implements SolanaTransactionService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final Connection solanaConnection;
     private final EscrowInstructionBuilder escrowInstructionBuilder;
@@ -213,7 +217,7 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
             throw e;
         } catch (Exception e) {
             throw SolanaTransactionException.submissionFailed(
-                    "getSignatureStatuses:" + transactionSignature, e);
+                    "getSignatureStatuses:" + transactionSignature, readRpcErrorDetails(conn, e));
         } finally {
             if (conn != null) {
                 conn.disconnect();
@@ -222,35 +226,29 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
     }
 
     static TransactionConfirmationStatus parseSignatureStatusResponse(String json) {
-        var valueIndex = json.indexOf("\"value\"");
-        if (valueIndex < 0) {
-            return TransactionConfirmationStatus.NOT_FOUND;
-        }
+        try {
+            var root = MAPPER.readTree(json);
+            var value = root.path("result").path("value");
+            if (!value.isArray() || value.isEmpty() || value.get(0).isNull()) {
+                return TransactionConfirmationStatus.NOT_FOUND;
+            }
 
-        var afterValue = json.substring(valueIndex);
-        if (afterValue.contains("[null]")) {
-            return TransactionConfirmationStatus.NOT_FOUND;
-        }
+            var entry = value.get(0);
+            var err = entry.get("err");
+            if (err != null && !err.isNull()) {
+                return TransactionConfirmationStatus.FAILED_ON_CHAIN;
+            }
 
-        if (afterValue.contains("\"err\"") && !afterValue.contains("\"err\":null")) {
-            return TransactionConfirmationStatus.FAILED_ON_CHAIN;
+            var confirmationStatus = entry.path("confirmationStatus").asText("");
+            return switch (confirmationStatus) {
+                case "finalized" -> TransactionConfirmationStatus.FINALIZED;
+                case "confirmed" -> TransactionConfirmationStatus.CONFIRMED;
+                case "processed" -> TransactionConfirmationStatus.PROCESSED;
+                default -> TransactionConfirmationStatus.NOT_FOUND;
+            };
+        } catch (JsonProcessingException e) {
+            throw SolanaTransactionException.submissionFailed("getSignatureStatuses:parse", e);
         }
-
-        var csIndex = afterValue.indexOf("\"confirmationStatus\"");
-        if (csIndex < 0) {
-            return TransactionConfirmationStatus.NOT_FOUND;
-        }
-
-        var csValue = afterValue.substring(csIndex);
-        if (csValue.contains("\"finalized\"")) {
-            return TransactionConfirmationStatus.FINALIZED;
-        } else if (csValue.contains("\"confirmed\"")) {
-            return TransactionConfirmationStatus.CONFIRMED;
-        } else if (csValue.contains("\"processed\"")) {
-            return TransactionConfirmationStatus.PROCESSED;
-        }
-
-        return TransactionConfirmationStatus.NOT_FOUND;
     }
 
     private String sendWithSkipPreflight(byte[] txBytes) {

--- a/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapter.java
@@ -1,6 +1,8 @@
 package com.stablepay.infrastructure.solana;
 
 import java.math.BigDecimal;
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.UUID;
@@ -179,10 +181,10 @@ public class SolanaTransactionServiceAdapter implements SolanaTransactionService
     public TransactionConfirmationStatus getTransactionStatus(String transactionSignature) {
         log.debug("Checking status for transaction {}", transactionSignature);
 
-        java.net.HttpURLConnection conn = null;
+        HttpURLConnection conn = null;
         try {
-            var url = new java.net.URI(solanaProperties.rpcUrl()).toURL();
-            conn = (java.net.HttpURLConnection) url.openConnection();
+            var url = new URI(solanaProperties.rpcUrl()).toURL();
+            conn = (HttpURLConnection) url.openConnection();
             conn.setConnectTimeout(10_000);
             conn.setReadTimeout(10_000);
             conn.setRequestMethod("POST");

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivities.java
@@ -4,11 +4,14 @@ import java.math.BigDecimal;
 
 import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 
 import io.temporal.activity.ActivityInterface;
 
 @ActivityInterface
 public interface RemittanceLifecycleActivities {
+
+    TransactionConfirmationStatus checkTransactionStatus(String transactionSignature);
 
     String depositEscrow(
             String remittanceId,

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImpl.java
@@ -14,6 +14,7 @@ import com.stablepay.domain.remittance.handler.RemittancePayoutWriter;
 import com.stablepay.domain.remittance.handler.UpdateRemittanceStatusHandler;
 import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.domain.remittance.port.FiatDisbursementProvider;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
 
@@ -30,6 +31,15 @@ public class RemittanceLifecycleActivitiesImpl implements RemittanceLifecycleAct
     private final FiatDisbursementProvider fiatDisbursementProvider;
     private final UpdateRemittanceStatusHandler updateRemittanceStatusHandler;
     private final RemittancePayoutWriter remittancePayoutWriter;
+
+    @Override
+    public TransactionConfirmationStatus checkTransactionStatus(String transactionSignature) {
+        requireNonNull(transactionSignature, "transactionSignature must not be null");
+        log.info("Checking transaction status for signature {}", transactionSignature);
+        var status = solanaTransactionService.getTransactionStatus(transactionSignature);
+        log.info("Transaction {} status: {}", transactionSignature, status);
+        return status;
+    }
 
     @Override
     public String depositEscrow(

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -8,10 +8,12 @@ import org.slf4j.Logger;
 import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.infrastructure.temporal.TaskQueue.Constants;
 
 import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
+import io.temporal.failure.ActivityFailure;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
 
@@ -66,7 +68,7 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
         try {
             awaitTransactionConfirmation(depositSignature);
-        } catch (Exception e) {
+        } catch (SolanaTransactionException e) {
             log.error("Deposit confirmation failed for remittance {}", remittanceId, e);
             statusActivities.updateRemittanceStatus(
                     remittanceId.toString(), RemittanceStatus.DEPOSIT_FAILED);
@@ -137,7 +139,7 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
         try {
             awaitTransactionConfirmation(releaseSignature);
-        } catch (Exception e) {
+        } catch (SolanaTransactionException e) {
             log.error("SP-0031: CRITICAL — release confirmation failed for remittance {},"
                     + " escrow may be released on-chain", remittanceId, e);
             statusActivities.updateRemittanceStatus(
@@ -198,7 +200,7 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
         try {
             awaitTransactionConfirmation(refundSignature);
-        } catch (Exception e) {
+        } catch (SolanaTransactionException e) {
             log.error("Refund confirmation failed for remittance {}", remittanceId, e);
             statusActivities.updateRemittanceStatus(
                     remittanceId.toString(), RemittanceStatus.REFUND_FAILED);
@@ -267,16 +269,27 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
         return ActivityOptions.newBuilder()
                 .setStartToCloseTimeout(TX_CONFIRMATION_ACTIVITY_TIMEOUT)
                 .setRetryOptions(RetryOptions.newBuilder()
-                        .setMaximumAttempts(2)
+                        .setMaximumAttempts(SOLANA_MAX_ATTEMPTS)
                         .setInitialInterval(Duration.ofSeconds(1))
                         .setBackoffCoefficient(1.5)
+                        .setDoNotRetry(IllegalArgumentException.class.getName())
                         .build())
                 .build();
     }
 
     private void awaitTransactionConfirmation(String signature) {
         for (var attempt = 1; attempt <= TX_CONFIRMATION_MAX_ATTEMPTS; attempt++) {
-            var status = confirmationActivities.checkTransactionStatus(signature);
+            TransactionConfirmationStatus status;
+            try {
+                status = confirmationActivities.checkTransactionStatus(signature);
+            } catch (ActivityFailure e) {
+                log.warn("Activity failure polling tx {} (attempt={}/{}), retrying",
+                        signature, attempt, TX_CONFIRMATION_MAX_ATTEMPTS, e);
+                if (attempt < TX_CONFIRMATION_MAX_ATTEMPTS) {
+                    Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
+                }
+                continue;
+            }
 
             if (status.hasError()) {
                 throw SolanaTransactionException.transactionFailed(signature);
@@ -289,7 +302,9 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
             log.info("Transaction {} not yet confirmed (status={}, attempt={}/{})",
                     signature, status, attempt, TX_CONFIRMATION_MAX_ATTEMPTS);
-            Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
+            if (attempt < TX_CONFIRMATION_MAX_ATTEMPTS) {
+                Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
+            }
         }
 
         throw SolanaTransactionException.confirmationTimeout(signature);

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 
 import com.stablepay.domain.remittance.exception.DisbursementException;
+import com.stablepay.domain.remittance.exception.SolanaTransactionException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.infrastructure.temporal.TaskQueue.Constants;
 
@@ -23,9 +24,12 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
     private static final Duration DISBURSEMENT_ACTIVITY_TIMEOUT = Duration.ofSeconds(45);
     private static final Duration SMS_ACTIVITY_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration STATUS_UPDATE_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TX_CONFIRMATION_ACTIVITY_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration TX_CONFIRMATION_POLL_INTERVAL = Duration.ofSeconds(3);
     private static final int SOLANA_MAX_ATTEMPTS = 3;
     private static final int SMS_MAX_ATTEMPTS = 3;
     private static final int DISBURSEMENT_MAX_ATTEMPTS = 3;
+    private static final int TX_CONFIRMATION_MAX_ATTEMPTS = 40;
     private static final String DISBURSEMENT_NON_RETRIABLE_TYPE =
             DisbursementException.NonRetriable.class.getName();
 
@@ -40,6 +44,9 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
     private final RemittanceLifecycleActivities statusActivities =
             Workflow.newActivityStub(RemittanceLifecycleActivities.class, statusUpdateActivityOptions());
+
+    private final RemittanceLifecycleActivities confirmationActivities =
+            Workflow.newActivityStub(RemittanceLifecycleActivities.class, confirmationActivityOptions());
 
     private UUID remittanceId;
     private RemittanceStatus currentStatus = RemittanceStatus.INITIATED;
@@ -56,6 +63,16 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
 
         var depositSignature = depositEscrow(request);
         this.escrowTxSignature = depositSignature;
+
+        try {
+            awaitTransactionConfirmation(depositSignature);
+        } catch (Exception e) {
+            log.error("Deposit confirmation failed for remittance {}", remittanceId, e);
+            statusActivities.updateRemittanceStatus(
+                    remittanceId.toString(), RemittanceStatus.DEPOSIT_FAILED);
+            currentStatus = RemittanceStatus.DEPOSIT_FAILED;
+            return failedResult(RemittanceStatus.DEPOSIT_FAILED, depositSignature);
+        }
 
         statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.ESCROWED);
         currentStatus = RemittanceStatus.ESCROWED;
@@ -118,6 +135,17 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
                 pendingClaim.destinationAddress(),
                 request.senderAddress());
 
+        try {
+            awaitTransactionConfirmation(releaseSignature);
+        } catch (Exception e) {
+            log.error("SP-0031: CRITICAL — release confirmation failed for remittance {},"
+                    + " escrow may be released on-chain", remittanceId, e);
+            statusActivities.updateRemittanceStatus(
+                    remittanceId.toString(), RemittanceStatus.CLAIM_FAILED);
+            currentStatus = RemittanceStatus.CLAIM_FAILED;
+            return failedResult(RemittanceStatus.CLAIM_FAILED, releaseSignature);
+        }
+
         statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.CLAIMED);
         currentStatus = RemittanceStatus.CLAIMED;
         log.info("Escrow released for remittanceId={} with tx={}", remittanceId, releaseSignature);
@@ -167,6 +195,16 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
         var refundSignature = solanaActivities.refundEscrow(
                 remittanceId.toString(),
                 request.senderAddress());
+
+        try {
+            awaitTransactionConfirmation(refundSignature);
+        } catch (Exception e) {
+            log.error("Refund confirmation failed for remittance {}", remittanceId, e);
+            statusActivities.updateRemittanceStatus(
+                    remittanceId.toString(), RemittanceStatus.REFUND_FAILED);
+            currentStatus = RemittanceStatus.REFUND_FAILED;
+            return failedResult(RemittanceStatus.REFUND_FAILED, refundSignature);
+        }
 
         statusActivities.updateRemittanceStatus(remittanceId.toString(), RemittanceStatus.REFUNDED);
         currentStatus = RemittanceStatus.REFUNDED;
@@ -222,6 +260,47 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
                         .setInitialInterval(Duration.ofSeconds(1))
                         .setBackoffCoefficient(2.0)
                         .build())
+                .build();
+    }
+
+    private static ActivityOptions confirmationActivityOptions() {
+        return ActivityOptions.newBuilder()
+                .setStartToCloseTimeout(TX_CONFIRMATION_ACTIVITY_TIMEOUT)
+                .setRetryOptions(RetryOptions.newBuilder()
+                        .setMaximumAttempts(2)
+                        .setInitialInterval(Duration.ofSeconds(1))
+                        .setBackoffCoefficient(1.5)
+                        .build())
+                .build();
+    }
+
+    private void awaitTransactionConfirmation(String signature) {
+        for (var attempt = 1; attempt <= TX_CONFIRMATION_MAX_ATTEMPTS; attempt++) {
+            var status = confirmationActivities.checkTransactionStatus(signature);
+
+            if (status.hasError()) {
+                throw SolanaTransactionException.transactionFailed(signature);
+            }
+            if (status.isConfirmedOrFinalized()) {
+                log.info("Transaction {} confirmed (status={}, attempt={})",
+                        signature, status, attempt);
+                return;
+            }
+
+            log.info("Transaction {} not yet confirmed (status={}, attempt={}/{})",
+                    signature, status, attempt, TX_CONFIRMATION_MAX_ATTEMPTS);
+            Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
+        }
+
+        throw SolanaTransactionException.confirmationTimeout(signature);
+    }
+
+    private RemittanceWorkflowResult failedResult(RemittanceStatus status, String txSignature) {
+        return RemittanceWorkflowResult.builder()
+                .remittanceId(remittanceId)
+                .finalStatus(status.name())
+                .escrowPda(escrowTxSignature)
+                .txSignature(txSignature)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImpl.java
@@ -13,7 +13,6 @@ import com.stablepay.infrastructure.temporal.TaskQueue.Constants;
 
 import io.temporal.activity.ActivityOptions;
 import io.temporal.common.RetryOptions;
-import io.temporal.failure.ActivityFailure;
 import io.temporal.spring.boot.WorkflowImpl;
 import io.temporal.workflow.Workflow;
 
@@ -28,10 +27,10 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
     private static final Duration STATUS_UPDATE_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration TX_CONFIRMATION_ACTIVITY_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration TX_CONFIRMATION_POLL_INTERVAL = Duration.ofSeconds(3);
+    private static final Duration TX_CONFIRMATION_TIMEOUT = Duration.ofMinutes(2);
     private static final int SOLANA_MAX_ATTEMPTS = 3;
     private static final int SMS_MAX_ATTEMPTS = 3;
     private static final int DISBURSEMENT_MAX_ATTEMPTS = 3;
-    private static final int TX_CONFIRMATION_MAX_ATTEMPTS = 40;
     private static final String DISBURSEMENT_NON_RETRIABLE_TYPE =
             DisbursementException.NonRetriable.class.getName();
 
@@ -278,36 +277,27 @@ public class RemittanceLifecycleWorkflowImpl implements RemittanceLifecycleWorkf
     }
 
     private void awaitTransactionConfirmation(String signature) {
-        for (var attempt = 1; attempt <= TX_CONFIRMATION_MAX_ATTEMPTS; attempt++) {
-            TransactionConfirmationStatus status;
-            try {
-                status = confirmationActivities.checkTransactionStatus(signature);
-            } catch (ActivityFailure e) {
-                log.warn("Activity failure polling tx {} (attempt={}/{}), retrying",
-                        signature, attempt, TX_CONFIRMATION_MAX_ATTEMPTS, e);
-                if (attempt < TX_CONFIRMATION_MAX_ATTEMPTS) {
+        var deadline = Workflow.currentTimeMillis() + TX_CONFIRMATION_TIMEOUT.toMillis();
+        var status = TransactionConfirmationStatus.NOT_FOUND;
+
+        while (!status.isTerminal()) {
+            if (Workflow.currentTimeMillis() >= deadline) {
+                throw SolanaTransactionException.confirmationTimeout(signature);
+            }
+
+            status = confirmationActivities.checkTransactionStatus(signature);
+
+            switch (status) {
+                case CONFIRMED, FINALIZED ->
+                    log.info("Transaction {} confirmed (status={})", signature, status);
+                case FAILED_ON_CHAIN ->
+                    throw SolanaTransactionException.transactionFailed(signature);
+                default -> {
+                    log.info("Transaction {} pending (status={})", signature, status);
                     Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
                 }
-                continue;
-            }
-
-            if (status.hasError()) {
-                throw SolanaTransactionException.transactionFailed(signature);
-            }
-            if (status.isConfirmedOrFinalized()) {
-                log.info("Transaction {} confirmed (status={}, attempt={})",
-                        signature, status, attempt);
-                return;
-            }
-
-            log.info("Transaction {} not yet confirmed (status={}, attempt={}/{})",
-                    signature, status, attempt, TX_CONFIRMATION_MAX_ATTEMPTS);
-            if (attempt < TX_CONFIRMATION_MAX_ATTEMPTS) {
-                Workflow.sleep(TX_CONFIRMATION_POLL_INTERVAL);
             }
         }
-
-        throw SolanaTransactionException.confirmationTimeout(signature);
     }
 
     private RemittanceWorkflowResult failedResult(RemittanceStatus status, String txSignature) {

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -87,9 +87,21 @@ class SolanaTransactionServiceAdapterTest {
         @Test
         void shouldReturnFinalizedForFinalizedResponse() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
-                    + "\"value\":[{\"slot\":123,\"confirmations\":null,"
-                    + "\"err\":null,\"confirmationStatus\":\"finalized\"}]},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [{
+                          "slot": 123,
+                          "confirmations": null,
+                          "err": null,
+                          "confirmationStatus": "finalized"
+                        }]
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
@@ -101,9 +113,21 @@ class SolanaTransactionServiceAdapterTest {
         @Test
         void shouldReturnConfirmedForConfirmedResponse() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
-                    + "\"value\":[{\"slot\":123,\"confirmations\":5,"
-                    + "\"err\":null,\"confirmationStatus\":\"confirmed\"}]},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [{
+                          "slot": 123,
+                          "confirmations": 5,
+                          "err": null,
+                          "confirmationStatus": "confirmed"
+                        }]
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
@@ -115,9 +139,21 @@ class SolanaTransactionServiceAdapterTest {
         @Test
         void shouldReturnProcessedForProcessedResponse() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
-                    + "\"value\":[{\"slot\":123,\"confirmations\":0,"
-                    + "\"err\":null,\"confirmationStatus\":\"processed\"}]},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [{
+                          "slot": 123,
+                          "confirmations": 0,
+                          "err": null,
+                          "confirmationStatus": "processed"
+                        }]
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
@@ -129,8 +165,16 @@ class SolanaTransactionServiceAdapterTest {
         @Test
         void shouldReturnNotFoundWhenValueIsNull() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
-                    + "\"value\":[null]},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [null]
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
@@ -142,10 +186,21 @@ class SolanaTransactionServiceAdapterTest {
         @Test
         void shouldReturnFailedOnChainWhenErrIsPresent() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
-                    + "\"value\":[{\"slot\":123,\"confirmations\":null,"
-                    + "\"err\":{\"InstructionError\":[0,\"Custom\"]},"
-                    + "\"confirmationStatus\":\"finalized\"}]},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [{
+                          "slot": 123,
+                          "confirmations": null,
+                          "err": {"InstructionError": [0, "Custom"]},
+                          "confirmationStatus": "finalized"
+                        }]
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
@@ -155,9 +210,43 @@ class SolanaTransactionServiceAdapterTest {
         }
 
         @Test
+        void shouldReturnFinalizedWhenErrIsNullWithWhitespace() {
+            // given
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123},
+                        "value": [{
+                          "slot": 123,
+                          "confirmations": null,
+                          "err":   null,
+                          "confirmationStatus": "finalized"
+                        }]
+                      },
+                      "id": 1
+                    }
+                    """;
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.FINALIZED);
+        }
+
+        @Test
         void shouldReturnNotFoundWhenResponseHasNoValueField() {
             // given
-            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123}},\"id\":1}";
+            var json = """
+                    {
+                      "jsonrpc": "2.0",
+                      "result": {
+                        "context": {"slot": 123}
+                      },
+                      "id": 1
+                    }
+                    """;
 
             // when
             var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);

--- a/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/solana/SolanaTransactionServiceAdapterTest.java
@@ -33,6 +33,7 @@ import org.sol4k.PublicKey;
 import org.sol4k.instruction.BaseInstruction;
 
 import com.stablepay.domain.remittance.exception.SolanaTransactionException;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.domain.wallet.port.WalletRepository;
 
@@ -81,20 +82,88 @@ class SolanaTransactionServiceAdapterTest {
     }
 
     @Nested
-    class GetTransactionStatus {
+    class ParseSignatureStatusResponse {
 
         @Test
-        void shouldReturnConfirmedForTransactionStatusStub() {
+        void shouldReturnFinalizedForFinalizedResponse() {
             // given
-            var adapter = new SolanaTransactionServiceAdapter(
-                    solanaConnection, escrowInstructionBuilder, propertiesWithKey,
-                    mpcWalletClient, walletRepository);
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
+                    + "\"value\":[{\"slot\":123,\"confirmations\":null,"
+                    + "\"err\":null,\"confirmationStatus\":\"finalized\"}]},\"id\":1}";
 
             // when
-            var result = adapter.getTransactionStatus(SOME_TRANSACTION_SIGNATURE);
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
 
             // then
-            assertThat(result).isEqualTo("CONFIRMED");
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.FINALIZED);
+        }
+
+        @Test
+        void shouldReturnConfirmedForConfirmedResponse() {
+            // given
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
+                    + "\"value\":[{\"slot\":123,\"confirmations\":5,"
+                    + "\"err\":null,\"confirmationStatus\":\"confirmed\"}]},\"id\":1}";
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.CONFIRMED);
+        }
+
+        @Test
+        void shouldReturnProcessedForProcessedResponse() {
+            // given
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
+                    + "\"value\":[{\"slot\":123,\"confirmations\":0,"
+                    + "\"err\":null,\"confirmationStatus\":\"processed\"}]},\"id\":1}";
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.PROCESSED);
+        }
+
+        @Test
+        void shouldReturnNotFoundWhenValueIsNull() {
+            // given
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
+                    + "\"value\":[null]},\"id\":1}";
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.NOT_FOUND);
+        }
+
+        @Test
+        void shouldReturnFailedOnChainWhenErrIsPresent() {
+            // given
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123},"
+                    + "\"value\":[{\"slot\":123,\"confirmations\":null,"
+                    + "\"err\":{\"InstructionError\":[0,\"Custom\"]},"
+                    + "\"confirmationStatus\":\"finalized\"}]},\"id\":1}";
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.FAILED_ON_CHAIN);
+        }
+
+        @Test
+        void shouldReturnNotFoundWhenResponseHasNoValueField() {
+            // given
+            var json = "{\"jsonrpc\":\"2.0\",\"result\":{\"context\":{\"slot\":123}},\"id\":1}";
+
+            // when
+            var result = SolanaTransactionServiceAdapter.parseSignatureStatusResponse(json);
+
+            // then
+            assertThat(result).isEqualTo(TransactionConfirmationStatus.NOT_FOUND);
         }
     }
 

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleActivitiesImplTest.java
@@ -34,6 +34,7 @@ import com.stablepay.domain.remittance.handler.RemittancePayoutWriter;
 import com.stablepay.domain.remittance.handler.UpdateRemittanceStatusHandler;
 import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 import com.stablepay.domain.remittance.port.FiatDisbursementProvider;
 import com.stablepay.domain.remittance.port.SolanaTransactionService;
 
@@ -68,6 +69,19 @@ class RemittanceLifecycleActivitiesImplTest {
 
     @InjectMocks
     private RemittanceLifecycleActivitiesImpl activities;
+
+    @Test
+    void shouldCheckTransactionStatusViaSolanaService() {
+        // given
+        given(solanaTransactionService.getTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
+
+        // when
+        var result = activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE);
+
+        // then
+        assertThat(result).isEqualTo(TransactionConfirmationStatus.FINALIZED);
+    }
 
     @Test
     void shouldDepositEscrowViaSolanaService() {

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import com.stablepay.domain.remittance.exception.DisbursementException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
+import com.stablepay.domain.remittance.model.TransactionConfirmationStatus;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -54,6 +55,12 @@ class RemittanceLifecycleWorkflowImplTest {
         worker.registerWorkflowImplementationTypes(RemittanceLifecycleWorkflowImpl.class);
 
         activities = mock(RemittanceLifecycleActivities.class);
+        given(activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
+        given(activities.checkTransactionStatus(SOME_RELEASE_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
+        given(activities.checkTransactionStatus(SOME_REFUND_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FINALIZED);
         worker.registerActivitiesImplementations(activities);
 
         client = testEnv.getWorkflowClient();
@@ -696,5 +703,254 @@ class RemittanceLifecycleWorkflowImplTest {
 
         then(activities).should(never()).updateRemittanceStatus(
                 SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
+    }
+
+    @Test
+    void shouldTransitionToDepositFailedWhenConfirmationTimesOut() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.NOT_FOUND);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DEPOSIT_FAILED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_DEPOSIT_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DEPOSIT_FAILED);
+
+        then(activities).should(never()).updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
+    }
+
+    @Test
+    void shouldTransitionToDepositFailedWhenTransactionFailsOnChain() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FAILED_ON_CHAIN);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.DEPOSIT_FAILED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_DEPOSIT_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.DEPOSIT_FAILED);
+    }
+
+    @Test
+    void shouldTransitionToClaimFailedWhenReleaseConfirmationFails() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofHours(48))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.releaseEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_DESTINATION_ADDRESS,
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_RELEASE_TX_SIGNATURE);
+
+        given(activities.checkTransactionStatus(SOME_RELEASE_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FAILED_ON_CHAIN);
+
+        testEnv.start();
+
+        var workflowId = "claim-fail-" + SOME_REMITTANCE_ID;
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder()
+                        .setTaskQueue(TASK_QUEUE)
+                        .setWorkflowId(workflowId)
+                        .build());
+
+        var claimSignal = ClaimSignal.builder()
+                .claimToken(SOME_CLAIM_TOKEN)
+                .upiId(SOME_UPI_ID)
+                .destinationAddress(SOME_DESTINATION_ADDRESS)
+                .build();
+
+        testEnv.registerDelayedCallback(Duration.ofMinutes(1), () -> {
+            var signalStub = client.newWorkflowStub(
+                    RemittanceLifecycleWorkflow.class, workflowId);
+            signalStub.claimSubmitted(claimSignal);
+        });
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.CLAIM_FAILED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_RELEASE_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.CLAIM_FAILED);
+
+        then(activities).should(never()).disburseInr(
+                SOME_UPI_ID, SOME_AMOUNT_USDC, SOME_AMOUNT_INR, SOME_REMITTANCE_ID.toString());
+    }
+
+    @Test
+    void shouldTransitionToRefundFailedWhenRefundConfirmationFails() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofSeconds(1))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        given(activities.refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_REFUND_TX_SIGNATURE);
+
+        given(activities.checkTransactionStatus(SOME_REFUND_TX_SIGNATURE))
+                .willReturn(TransactionConfirmationStatus.FAILED_ON_CHAIN);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.REFUND_FAILED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_REFUND_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.REFUND_FAILED);
+
+        then(activities).should(never()).updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.REFUNDED);
+    }
+
+    @Test
+    void shouldConfirmDepositBeforeMarkingEscrowed() {
+        // given
+        var request = workflowRequestBuilder()
+                .claimExpiryTimeout(Duration.ofSeconds(1))
+                .build();
+
+        given(activities.depositEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS,
+                SOME_AMOUNT_USDC,
+                SOME_ESCROW_EXPIRY_TIMESTAMP))
+                .willReturn(SOME_DEPOSIT_TX_SIGNATURE);
+
+        var attempts = new AtomicInteger(0);
+        given(activities.checkTransactionStatus(SOME_DEPOSIT_TX_SIGNATURE))
+                .willAnswer(invocation -> {
+                    if (attempts.incrementAndGet() < 3) {
+                        return TransactionConfirmationStatus.PROCESSED;
+                    }
+                    return TransactionConfirmationStatus.FINALIZED;
+                });
+
+        given(activities.refundEscrow(
+                SOME_REMITTANCE_ID.toString(),
+                SOME_SENDER_ADDRESS))
+                .willReturn(SOME_REFUND_TX_SIGNATURE);
+
+        testEnv.start();
+
+        var workflow = client.newWorkflowStub(
+                RemittanceLifecycleWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build());
+
+        // when
+        var result = workflow.execute(request);
+
+        // then
+        assertThat(result.finalStatus()).isEqualTo(RemittanceStatus.REFUNDED.name());
+        assertThat(attempts.get()).isGreaterThanOrEqualTo(3);
+
+        then(activities).should().updateRemittanceStatus(
+                SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/temporal/RemittanceLifecycleWorkflowImplTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.stablepay.domain.remittance.exception.DisbursementException;
@@ -705,8 +706,11 @@ class RemittanceLifecycleWorkflowImplTest {
                 SOME_REMITTANCE_ID.toString(), RemittanceStatus.DELIVERED);
     }
 
-    @Test
-    void shouldTransitionToDepositFailedWhenConfirmationTimesOut() {
+    @Nested
+    class TransactionConfirmation {
+
+        @Test
+        void shouldTransitionToDepositFailedWhenConfirmationTimesOut() {
         // given
         var request = workflowRequestBuilder()
                 .claimExpiryTimeout(Duration.ofHours(48))
@@ -947,10 +951,20 @@ class RemittanceLifecycleWorkflowImplTest {
         var result = workflow.execute(request);
 
         // then
-        assertThat(result.finalStatus()).isEqualTo(RemittanceStatus.REFUNDED.name());
+        var expected = RemittanceWorkflowResult.builder()
+                .remittanceId(SOME_REMITTANCE_ID)
+                .finalStatus(RemittanceStatus.REFUNDED.name())
+                .escrowPda(SOME_DEPOSIT_TX_SIGNATURE)
+                .txSignature(SOME_REFUND_TX_SIGNATURE)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
         assertThat(attempts.get()).isGreaterThanOrEqualTo(3);
 
         then(activities).should().updateRemittanceStatus(
                 SOME_REMITTANCE_ID.toString(), RemittanceStatus.ESCROWED);
+    }
     }
 }

--- a/docs/E2E_10_CUSTOMER_RUN.md
+++ b/docs/E2E_10_CUSTOMER_RUN.md
@@ -1,38 +1,37 @@
 # 10-Customer Full E2E Run — $1.00 USDC per customer
 
-Generated: 2026-04-19 11:30:09 UTC
+Generated: 2026-04-19 19:08:26 UTC
 
 ## Summary
 
 - Customers attempted: 10
-- Passed: 10
-- Failed: 0
+- Passed: 6
+- Failed: 4
 - Per-customer amount: $1.00 USDC
 
-| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | payout_id | elapsed (s) | PASS |
-|---|--------|----------|---------|-----------|--------------|-------|-----------------|-----------|-------------|------|
-| 1 | `e2e-10x-1776597783066-1` | 8 | `38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj` | `c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28` | `24eb9ede-3bd3-40c2-9630-951ada545130` | DELIVERED | 1 | `pout_wm_1afbxunzb5mb` | 16.9 | ✅ |
-| 2 | `e2e-10x-1776597799939-2` | 9 | `HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht` | `51d94938-615d-4587-ba12-851cea5710af` | `c7f52cb1-9965-40d8-9e1a-927008dd9da6` | DELIVERED | 1 | `pout_wm_4fgovobnrnkj` | 49.1 | ✅ |
-| 3 | `e2e-10x-1776597849019-3` | 10 | `GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ` | `6f108599-3f3a-4e1c-bf41-d3e5b5c9d488` | `53c43ad7-6fda-4b0d-8c6f-310d6218cecc` | DELIVERED | 1 | `pout_wm_gyf0zd8q7idy` | 46.4 | ✅ |
-| 4 | `e2e-10x-1776597895402-4` | 11 | `UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR` | `f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f` | `3b296846-fe40-41a3-ade8-eda73f5e8af2` | DELIVERED | 1 | `pout_wm_kvrbr3peaes8` | 16.7 | ✅ |
-| 5 | `e2e-10x-1776597912110-5` | 12 | `9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g` | `4d43b24a-0f9b-4f01-8b98-3c8342e80f53` | `721ffdb1-9f30-426b-97ee-565f197549d2` | DELIVERED | 1 | `pout_wm_tg980vmggklj` | 113.0 | ✅ |
-| 6 | `e2e-10x-1776598025160-6` | 13 | `51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV` | `108dfcb4-9e95-47ee-a7c1-7b5c60c0e437` | `b9d7812a-aae2-448e-8b40-368810451de6` | DELIVERED | 1 | `pout_wm_pqbbwa8babew` | 50.8 | ✅ |
-| 7 | `e2e-10x-1776598075964-7` | 14 | `Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY` | `8ee040a8-a3a6-459d-a90f-71138b3d65bd` | `1dee3072-adc6-4872-8fbb-593675866249` | DELIVERED | 1 | `pout_wm_6jarhbmk9wio` | 22.9 | ✅ |
-| 8 | `e2e-10x-1776598098872-8` | 15 | `CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3` | `99f047f0-ab7f-415c-9960-66de2917cb54` | `9c6d725f-32dc-42df-bc00-3eaff10f8c9d` | DELIVERED | 1 | `pout_wm_u5hmkb1zwkd0` | 16.3 | ✅ |
-| 9 | `e2e-10x-1776598115130-9` | 16 | `74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4` | `32466a08-4bcc-4b60-9e98-4919e12ad5a0` | `af3b0178-7931-4d19-9721-bb3e96727a1c` | DELIVERED | 1 | `pout_wm_pfi0ubnabdur` | 46.8 | ✅ |
-| 10 | `e2e-10x-1776598161943-10` | 17 | `G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9` | `7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca` | `5138141b-9a20-461f-b7df-e4dbf27d6d46` | DELIVERED | 1 | `pout_wm_mmxjbzzuhsnk` | 47.4 | ✅ |
+| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | elapsed (s) | PASS |
+|---|--------|----------|---------|-----------|--------------|-------|-----------------|-------------|------|
+| 1 | `e2e-10x-1776625135759-1` | 19 | `Gvw75z4HiSAuuysi5kLXUfpDCNptBv4f9pSYqwSAqsgv` | `b2c8a29a-fcca-487f-979b-bf355c82faeb` | `None` | - | - | 95.0 | ❌ fund not FUNDED: status=PAYMENT_CONFIRMED |
+| 2 | `e2e-10x-1776625230787-2` | 20 | `EJ5nmbwLXZtVZqcRriH4ZzZHnvPt8p31BFxNYdjonfrs` | `e10e7206-4523-4156-ab1b-20a6bb92dbed` | `None` | - | - | 92.9 | ❌ fund not FUNDED: status=PAYMENT_CONFIRMED |
+| 3 | `e2e-10x-1776625323684-3` | 21 | `7ZWifM27D53pukKjEDkqNHZiZUuUjVXEJcqcfiaEaseN` | `a5f32227-179e-4181-9f81-25cdcbbd367e` | `None` | - | - | 125.3 | ❌ fund not FUNDED: status=PAYMENT_CONFIRMED |
+| 4 | `e2e-10x-1776625448980-4` | 22 | `26u5KveR5nty1h4oyXsEqvJ5arBfox9Zp8k1Eop9tgyi` | `a8f04346-bba5-4bf3-905a-f8746a959921` | `None` | - | - | 93.0 | ❌ fund not FUNDED: status=PAYMENT_CONFIRMED |
+| 5 | `e2e-10x-1776625541994-5` | 23 | `BHBm4cN3ZveqboS2i93nNvsgGkYU8tfKDpj1nTcMEJth` | `bfc25787-1cfd-41d9-906c-b18493afa79d` | `b26db8dd-8330-4071-8b30-dde2051dcb9c` | DELIVERED | 1 | 23.4 | ✅ |
+| 6 | `e2e-10x-1776625565425-6` | 24 | `Hp3jRdvzsQkC9icQmZJSTqQ2Jty516XsLd6TEF3D2YK1` | `edf93bd6-8407-46a0-a995-f9d2705e2cbe` | `5c3ef5af-8e44-42f3-97d0-0d64adb728d2` | DELIVERED | 1 | 22.1 | ✅ |
+| 7 | `e2e-10x-1776625587534-7` | 25 | `2EJTtS636CELwrdh6oBzF37LGMgYsNe9vu3BCxjxgvLP` | `8d16860c-ae69-499a-aad3-74a5b6cea6a3` | `29e02376-179f-43eb-905c-0b2272bc029f` | DELIVERED | 1 | 22.3 | ✅ |
+| 8 | `e2e-10x-1776625609866-8` | 26 | `EvuvHjCFj6bNpeM9e3q6o6T6GE4KzvHaDgiS5tB4WjQ6` | `12aa01d4-9eba-4e87-9a0d-f69290de94fb` | `8925ec59-c663-4298-a627-a6736cabc5e5` | DELIVERED | 1 | 22.3 | ✅ |
+| 9 | `e2e-10x-1776625632190-9` | 27 | `F2muFfMgmKXfqkMvS8V5CZgPNYmCxWR6bxvJs2MRYBg2` | `99a0ab3a-18ab-4664-9ac2-23f5e896d24e` | `23c1a361-dea3-4f9f-870b-0de778ef4355` | DELIVERED | 1 | 22.3 | ✅ |
+| 10 | `e2e-10x-1776625654515-10` | 28 | `CAWjqf8mm5XRicmmWYYmNEaNYpJhAvoieVdTXwW1Ehre` | `4860ae81-8fb1-4156-a782-0fc7cdeee786` | `cf5346df-80ba-4f6c-81d7-7a9dd2fa1418` | DELIVERED | 1 | 52.4 | ✅ |
 
 ## Per-customer request / response log
 
-### Customer 1 — `e2e-10x-1776597783066-1`
+### Customer 1 — `e2e-10x-1776625135759-1`
 
-- walletId: `8`  solanaAddress: `38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj`
-- fundingId: `c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28`  paymentIntentId: `pi_3TNtRM3nnME1dfOB1jvCcDMS`
-- remittanceId: `24eb9ede-3bd3-40c2-9630-951ada545130`  claimTokenId: `60e97f79-f86d-4227-aa13-532400e8f7db`
-- final status: **DELIVERED**  elapsed: 16.9s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 27
-- Payout: id=`pout_wm_1afbxunzb5mb` status=`processing`
+- walletId: `19`  solanaAddress: `Gvw75z4HiSAuuysi5kLXUfpDCNptBv4f9pSYqwSAqsgv`
+- fundingId: `b2c8a29a-fcca-487f-979b-bf355c82faeb`  paymentIntentId: `pi_3TO0YZ3nnME1dfOB0dz1SICr`
+- remittanceId: `None`  claimTokenId: `None`
+- final status: **None**  elapsed: 95.0s  **FAIL: fund not FUNDED: status=PAYMENT_CONFIRMED**
+- On-chain USDC after fund: None
+- Claim authority USDC after claim: None
 
 #### 1-create-wallet
 
@@ -41,26 +40,26 @@ Generated: 2026-04-19 11:30:09 UTC
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776597783066-1"
+  "userId": "e2e-10x-1776625135759-1"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 8,
-  "userId": "e2e-10x-1776597783066-1",
-  "solanaAddress": "38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj",
+  "id": 19,
+  "userId": "e2e-10x-1776625135759-1",
+  "solanaAddress": "Gvw75z4HiSAuuysi5kLXUfpDCNptBv4f9pSYqwSAqsgv",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:23:03.237617654Z",
-  "updatedAt": "2026-04-19T11:23:03.237617654Z"
+  "createdAt": "2026-04-19T18:58:57.518704602Z",
+  "updatedAt": "2026-04-19T18:58:57.518704602Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/8/fund`  → **HTTP 201**
+`POST /api/wallets/19/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -72,19 +71,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28",
-  "walletId": 8,
+  "fundingId": "b2c8a29a-fcca-487f-979b-bf355c82faeb",
+  "walletId": 19,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtRM3nnME1dfOB1jvCcDMS",
+  "stripePaymentIntentId": "pi_3TO0YZ3nnME1dfOB0dz1SICr",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:23:03.262730811Z"
+  "createdAt": "2026-04-19T18:58:57.689975209Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28`  → **HTTP 200**
+`GET /api/funding-orders/b2c8a29a-fcca-487f-979b-bf355c82faeb`  → **HTTP 200**
 
 Request:
 ```json
@@ -94,165 +93,25 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28",
-  "walletId": 8,
+  "fundingId": "b2c8a29a-fcca-487f-979b-bf355c82faeb",
+  "walletId": 19,
   "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtRM3nnME1dfOB1jvCcDMS",
-  "createdAt": "2026-04-19T11:23:03.262731Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776597783066-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
-  "senderId": "e2e-10x-1776597783066-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:23:12.893929266Z",
-  "updatedAt": "2026-04-19T11:23:12.897653796Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/24eb9ede-3bd3-40c2-9630-951ada545130`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
-  "senderId": "e2e-10x-1776597783066-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:23:12.893929Z",
-  "updatedAt": "2026-04-19T11:23:13.765042Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/60e97f79-f86d-4227-aa13-532400e8f7db`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
-  "senderId": "e2e-10x-1776597783066-1",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-21T11:23:12.896743Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/60e97f79-f86d-4227-aa13-532400e8f7db`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
-  "senderId": "e2e-10x-1776597783066-1",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-21T11:23:12.896743Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/24eb9ede-3bd3-40c2-9630-951ada545130`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
-  "senderId": "e2e-10x-1776597783066-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:23:12.893929Z",
-  "updatedAt": "2026-04-19T11:23:17.783516Z",
-  "expiresAt": null
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0YZ3nnME1dfOB0dz1SICr",
+  "createdAt": "2026-04-19T18:58:57.689975Z"
 }
 ```
 
 ---
 
-### Customer 2 — `e2e-10x-1776597799939-2`
+### Customer 2 — `e2e-10x-1776625230787-2`
 
-- walletId: `9`  solanaAddress: `HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht`
-- fundingId: `51d94938-615d-4587-ba12-851cea5710af`  paymentIntentId: `pi_3TNtS93nnME1dfOB0r2lPGyp`
-- remittanceId: `c7f52cb1-9965-40d8-9e1a-927008dd9da6`  claimTokenId: `44d16798-e4fa-4530-aa6d-1e0a6d81c767`
-- final status: **DELIVERED**  elapsed: 49.1s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 28
-- Payout: id=`pout_wm_4fgovobnrnkj` status=`processing`
+- walletId: `20`  solanaAddress: `EJ5nmbwLXZtVZqcRriH4ZzZHnvPt8p31BFxNYdjonfrs`
+- fundingId: `e10e7206-4523-4156-ab1b-20a6bb92dbed`  paymentIntentId: `pi_3TO0a43nnME1dfOB0MrYiKky`
+- remittanceId: `None`  claimTokenId: `None`
+- final status: **None**  elapsed: 92.9s  **FAIL: fund not FUNDED: status=PAYMENT_CONFIRMED**
+- On-chain USDC after fund: None
+- Claim authority USDC after claim: None
 
 #### 1-create-wallet
 
@@ -261,26 +120,26 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776597799939-2"
+  "userId": "e2e-10x-1776625230787-2"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 9,
-  "userId": "e2e-10x-1776597799939-2",
-  "solanaAddress": "HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht",
+  "id": 20,
+  "userId": "e2e-10x-1776625230787-2",
+  "solanaAddress": "EJ5nmbwLXZtVZqcRriH4ZzZHnvPt8p31BFxNYdjonfrs",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:23:52.149506393Z",
-  "updatedAt": "2026-04-19T11:23:52.149506393Z"
+  "createdAt": "2026-04-19T19:00:30.951370297Z",
+  "updatedAt": "2026-04-19T19:00:30.951370297Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/9/fund`  → **HTTP 201**
+`POST /api/wallets/20/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -292,19 +151,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "51d94938-615d-4587-ba12-851cea5710af",
-  "walletId": 9,
+  "fundingId": "e10e7206-4523-4156-ab1b-20a6bb92dbed",
+  "walletId": 20,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtS93nnME1dfOB0r2lPGyp",
+  "stripePaymentIntentId": "pi_3TO0a43nnME1dfOB0MrYiKky",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:23:52.226785757Z"
+  "createdAt": "2026-04-19T19:00:30.985332093Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/51d94938-615d-4587-ba12-851cea5710af`  → **HTTP 200**
+`GET /api/funding-orders/e10e7206-4523-4156-ab1b-20a6bb92dbed`  → **HTTP 200**
 
 Request:
 ```json
@@ -314,165 +173,25 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "51d94938-615d-4587-ba12-851cea5710af",
-  "walletId": 9,
+  "fundingId": "e10e7206-4523-4156-ab1b-20a6bb92dbed",
+  "walletId": 20,
   "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtS93nnME1dfOB0r2lPGyp",
-  "createdAt": "2026-04-19T11:23:52.226786Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776597799939-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
-  "senderId": "e2e-10x-1776597799939-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:01.942099622Z",
-  "updatedAt": "2026-04-19T11:24:01.946288239Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/c7f52cb1-9965-40d8-9e1a-927008dd9da6`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
-  "senderId": "e2e-10x-1776597799939-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:01.942100Z",
-  "updatedAt": "2026-04-19T11:24:03.070156Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/44d16798-e4fa-4530-aa6d-1e0a6d81c767`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
-  "senderId": "e2e-10x-1776597799939-2",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-21T11:24:01.945198Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/44d16798-e4fa-4530-aa6d-1e0a6d81c767`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
-  "senderId": "e2e-10x-1776597799939-2",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-21T11:24:01.945198Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/c7f52cb1-9965-40d8-9e1a-927008dd9da6`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
-  "senderId": "e2e-10x-1776597799939-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:01.942100Z",
-  "updatedAt": "2026-04-19T11:24:06.602173Z",
-  "expiresAt": null
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0a43nnME1dfOB0MrYiKky",
+  "createdAt": "2026-04-19T19:00:30.985332Z"
 }
 ```
 
 ---
 
-### Customer 3 — `e2e-10x-1776597849019-3`
+### Customer 3 — `e2e-10x-1776625323684-3`
 
-- walletId: `10`  solanaAddress: `GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ`
-- fundingId: `6f108599-3f3a-4e1c-bf41-d3e5b5c9d488`  paymentIntentId: `pi_3TNtSQ3nnME1dfOB0siozHXF`
-- remittanceId: `53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  claimTokenId: `88d625be-bb00-4fb2-be56-f2d2b452683e`
-- final status: **DELIVERED**  elapsed: 46.4s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 29
-- Payout: id=`pout_wm_gyf0zd8q7idy` status=`processing`
+- walletId: `21`  solanaAddress: `7ZWifM27D53pukKjEDkqNHZiZUuUjVXEJcqcfiaEaseN`
+- fundingId: `a5f32227-179e-4181-9f81-25cdcbbd367e`  paymentIntentId: `pi_3TO0c53nnME1dfOB0tm13xXf`
+- remittanceId: `None`  claimTokenId: `None`
+- final status: **None**  elapsed: 125.3s  **FAIL: fund not FUNDED: status=PAYMENT_CONFIRMED**
+- On-chain USDC after fund: None
+- Claim authority USDC after claim: None
 
 #### 1-create-wallet
 
@@ -481,26 +200,26 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776597849019-3"
+  "userId": "e2e-10x-1776625323684-3"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 10,
-  "userId": "e2e-10x-1776597849019-3",
-  "solanaAddress": "GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ",
+  "id": 21,
+  "userId": "e2e-10x-1776625323684-3",
+  "solanaAddress": "7ZWifM27D53pukKjEDkqNHZiZUuUjVXEJcqcfiaEaseN",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:24:09.110994670Z",
-  "updatedAt": "2026-04-19T11:24:09.110994670Z"
+  "createdAt": "2026-04-19T19:02:35.997741733Z",
+  "updatedAt": "2026-04-19T19:02:35.997741733Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/10/fund`  → **HTTP 201**
+`POST /api/wallets/21/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -512,19 +231,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "6f108599-3f3a-4e1c-bf41-d3e5b5c9d488",
-  "walletId": 10,
+  "fundingId": "a5f32227-179e-4181-9f81-25cdcbbd367e",
+  "walletId": 21,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtSQ3nnME1dfOB0siozHXF",
+  "stripePaymentIntentId": "pi_3TO0c53nnME1dfOB0tm13xXf",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:24:09.128502434Z"
+  "createdAt": "2026-04-19T19:02:36.044561385Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/6f108599-3f3a-4e1c-bf41-d3e5b5c9d488`  → **HTTP 200**
+`GET /api/funding-orders/a5f32227-179e-4181-9f81-25cdcbbd367e`  → **HTTP 200**
 
 Request:
 ```json
@@ -534,165 +253,25 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "6f108599-3f3a-4e1c-bf41-d3e5b5c9d488",
-  "walletId": 10,
+  "fundingId": "a5f32227-179e-4181-9f81-25cdcbbd367e",
+  "walletId": 21,
   "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtSQ3nnME1dfOB0siozHXF",
-  "createdAt": "2026-04-19T11:24:09.128502Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776597849019-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
-  "senderId": "e2e-10x-1776597849019-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:18.065621408Z",
-  "updatedAt": "2026-04-19T11:24:18.069339354Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
-  "senderId": "e2e-10x-1776597849019-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:18.065621Z",
-  "updatedAt": "2026-04-19T11:24:49.479968Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/88d625be-bb00-4fb2-be56-f2d2b452683e`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
-  "senderId": "e2e-10x-1776597849019-3",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-21T11:24:18.068118Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/88d625be-bb00-4fb2-be56-f2d2b452683e`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
-  "senderId": "e2e-10x-1776597849019-3",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-21T11:24:18.068118Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
-  "senderId": "e2e-10x-1776597849019-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:24:18.065621Z",
-  "updatedAt": "2026-04-19T11:24:52.866001Z",
-  "expiresAt": null
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0c53nnME1dfOB0tm13xXf",
+  "createdAt": "2026-04-19T19:02:36.044561Z"
 }
 ```
 
 ---
 
-### Customer 4 — `e2e-10x-1776597895402-4`
+### Customer 4 — `e2e-10x-1776625448980-4`
 
-- walletId: `11`  solanaAddress: `UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR`
-- fundingId: `f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f`  paymentIntentId: `pi_3TNtTA3nnME1dfOB06dB2yza`
-- remittanceId: `3b296846-fe40-41a3-ade8-eda73f5e8af2`  claimTokenId: `607e544f-2ec9-4d08-a684-947c25a2c1be`
-- final status: **DELIVERED**  elapsed: 16.7s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 30
-- Payout: id=`pout_wm_kvrbr3peaes8` status=`processing`
+- walletId: `22`  solanaAddress: `26u5KveR5nty1h4oyXsEqvJ5arBfox9Zp8k1Eop9tgyi`
+- fundingId: `a8f04346-bba5-4bf3-905a-f8746a959921`  paymentIntentId: `pi_3TO0da3nnME1dfOB1VxP75xo`
+- remittanceId: `None`  claimTokenId: `None`
+- final status: **None**  elapsed: 93.0s  **FAIL: fund not FUNDED: status=PAYMENT_CONFIRMED**
+- On-chain USDC after fund: None
+- Claim authority USDC after claim: None
 
 #### 1-create-wallet
 
@@ -701,26 +280,26 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776597895402-4"
+  "userId": "e2e-10x-1776625448980-4"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 11,
-  "userId": "e2e-10x-1776597895402-4",
-  "solanaAddress": "UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR",
+  "id": 22,
+  "userId": "e2e-10x-1776625448980-4",
+  "solanaAddress": "26u5KveR5nty1h4oyXsEqvJ5arBfox9Zp8k1Eop9tgyi",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:24:55.485703917Z",
-  "updatedAt": "2026-04-19T11:24:55.485703917Z"
+  "createdAt": "2026-04-19T19:04:09.207185794Z",
+  "updatedAt": "2026-04-19T19:04:09.207185794Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/11/fund`  → **HTTP 201**
+`POST /api/wallets/22/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -732,19 +311,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f",
-  "walletId": 11,
+  "fundingId": "a8f04346-bba5-4bf3-905a-f8746a959921",
+  "walletId": 22,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtTA3nnME1dfOB06dB2yza",
+  "stripePaymentIntentId": "pi_3TO0da3nnME1dfOB1VxP75xo",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:24:55.503511475Z"
+  "createdAt": "2026-04-19T19:04:09.248421368Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f`  → **HTTP 200**
+`GET /api/funding-orders/a8f04346-bba5-4bf3-905a-f8746a959921`  → **HTTP 200**
 
 Request:
 ```json
@@ -754,165 +333,25 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f",
-  "walletId": 11,
+  "fundingId": "a8f04346-bba5-4bf3-905a-f8746a959921",
+  "walletId": 22,
   "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtTA3nnME1dfOB06dB2yza",
-  "createdAt": "2026-04-19T11:24:55.503511Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776597895402-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
-  "senderId": "e2e-10x-1776597895402-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:05.082749926Z",
-  "updatedAt": "2026-04-19T11:25:05.090090234Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/3b296846-fe40-41a3-ade8-eda73f5e8af2`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
-  "senderId": "e2e-10x-1776597895402-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:05.082750Z",
-  "updatedAt": "2026-04-19T11:25:06.166160Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/607e544f-2ec9-4d08-a684-947c25a2c1be`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
-  "senderId": "e2e-10x-1776597895402-4",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-21T11:25:05.087736Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/607e544f-2ec9-4d08-a684-947c25a2c1be`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
-  "senderId": "e2e-10x-1776597895402-4",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-21T11:25:05.087736Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/3b296846-fe40-41a3-ade8-eda73f5e8af2`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
-  "senderId": "e2e-10x-1776597895402-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:05.082750Z",
-  "updatedAt": "2026-04-19T11:25:09.402940Z",
-  "expiresAt": null
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0da3nnME1dfOB1VxP75xo",
+  "createdAt": "2026-04-19T19:04:09.248421Z"
 }
 ```
 
 ---
 
-### Customer 5 — `e2e-10x-1776597912110-5`
+### Customer 5 — `e2e-10x-1776625541994-5`
 
-- walletId: `12`  solanaAddress: `9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g`
-- fundingId: `4d43b24a-0f9b-4f01-8b98-3c8342e80f53`  paymentIntentId: `pi_3TNtTy3nnME1dfOB1uBLkSQH`
-- remittanceId: `721ffdb1-9f30-426b-97ee-565f197549d2`  claimTokenId: `fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`
-- final status: **DELIVERED**  elapsed: 113.0s  **PASS**
+- walletId: `23`  solanaAddress: `BHBm4cN3ZveqboS2i93nNvsgGkYU8tfKDpj1nTcMEJth`
+- fundingId: `bfc25787-1cfd-41d9-906c-b18493afa79d`  paymentIntentId: `pi_3TO0f53nnME1dfOB0HeZyeRu`
+- remittanceId: `b26db8dd-8330-4071-8b30-dde2051dcb9c`  claimTokenId: `188d3d81-4871-4751-959a-ca13bddb4ae5`
+- final status: **DELIVERED**  elapsed: 23.4s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 31
-- Payout: id=`pout_wm_tg980vmggklj` status=`processing`
+- Claim authority USDC after claim: 38
 
 #### 1-create-wallet
 
@@ -921,26 +360,26 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776597912110-5"
+  "userId": "e2e-10x-1776625541994-5"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 12,
-  "userId": "e2e-10x-1776597912110-5",
-  "solanaAddress": "9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g",
+  "id": 23,
+  "userId": "e2e-10x-1776625541994-5",
+  "solanaAddress": "BHBm4cN3ZveqboS2i93nNvsgGkYU8tfKDpj1nTcMEJth",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:25:44.274575379Z",
-  "updatedAt": "2026-04-19T11:25:44.274575379Z"
+  "createdAt": "2026-04-19T19:05:42.160330871Z",
+  "updatedAt": "2026-04-19T19:05:42.160330871Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/12/fund`  → **HTTP 201**
+`POST /api/wallets/23/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -952,19 +391,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "4d43b24a-0f9b-4f01-8b98-3c8342e80f53",
-  "walletId": 12,
+  "fundingId": "bfc25787-1cfd-41d9-906c-b18493afa79d",
+  "walletId": 23,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtTy3nnME1dfOB1uBLkSQH",
+  "stripePaymentIntentId": "pi_3TO0f53nnME1dfOB0HeZyeRu",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:25:44.340020702Z"
+  "createdAt": "2026-04-19T19:05:42.182085132Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/4d43b24a-0f9b-4f01-8b98-3c8342e80f53`  → **HTTP 200**
+`GET /api/funding-orders/bfc25787-1cfd-41d9-906c-b18493afa79d`  → **HTTP 200**
 
 Request:
 ```json
@@ -974,12 +413,12 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "4d43b24a-0f9b-4f01-8b98-3c8342e80f53",
-  "walletId": 12,
+  "fundingId": "bfc25787-1cfd-41d9-906c-b18493afa79d",
+  "walletId": 23,
   "amountUsdc": 1.0,
   "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtTy3nnME1dfOB1uBLkSQH",
-  "createdAt": "2026-04-19T11:25:44.340021Z"
+  "stripePaymentIntentId": "pi_3TO0f53nnME1dfOB0HeZyeRu",
+  "createdAt": "2026-04-19T19:05:42.182085Z"
 }
 ```
 
@@ -990,158 +429,9 @@ Response:
 Request:
 ```json
 {
-  "senderId": "e2e-10x-1776597912110-5",
+  "senderId": "e2e-10x-1776625541994-5",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
-  "senderId": "e2e-10x-1776597912110-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:54.292973907Z",
-  "updatedAt": "2026-04-19T11:25:54.302824570Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/721ffdb1-9f30-426b-97ee-565f197549d2`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
-  "senderId": "e2e-10x-1776597912110-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:54.292974Z",
-  "updatedAt": "2026-04-19T11:26:58.460790Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
-  "senderId": "e2e-10x-1776597912110-5",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-21T11:25:54.297624Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
-  "senderId": "e2e-10x-1776597912110-5",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-21T11:25:54.297624Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/721ffdb1-9f30-426b-97ee-565f197549d2`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
-  "senderId": "e2e-10x-1776597912110-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.92,
-  "fxRate": 92.922391,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:25:54.292974Z",
-  "updatedAt": "2026-04-19T11:27:02.456120Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 6 — `e2e-10x-1776598025160-6`
-
-- walletId: `13`  solanaAddress: `51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV`
-- fundingId: `108dfcb4-9e95-47ee-a7c1-7b5c60c0e437`  paymentIntentId: `pi_3TNtVG3nnME1dfOB1t6dXwZU`
-- remittanceId: `b9d7812a-aae2-448e-8b40-368810451de6`  claimTokenId: `9aea7175-5647-4f1d-90f4-80126fdc28a7`
-- final status: **DELIVERED**  elapsed: 50.8s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 32
-- Payout: id=`pout_wm_pqbbwa8babew` status=`processing`
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776598025160-6"
 }
 ```
 
@@ -1149,96 +439,25 @@ Response:
 ```json
 {
   "id": 13,
-  "userId": "e2e-10x-1776598025160-6",
-  "solanaAddress": "51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-19T11:27:05.320014949Z",
-  "updatedAt": "2026-04-19T11:27:05.320014949Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/13/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "108dfcb4-9e95-47ee-a7c1-7b5c60c0e437",
-  "walletId": 13,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtVG3nnME1dfOB1t6dXwZU",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:27:05.352018460Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/108dfcb4-9e95-47ee-a7c1-7b5c60c0e437`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "108dfcb4-9e95-47ee-a7c1-7b5c60c0e437",
-  "walletId": 13,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtVG3nnME1dfOB1t6dXwZU",
-  "createdAt": "2026-04-19T11:27:05.352018Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776598025160-6",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 7,
-  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
-  "senderId": "e2e-10x-1776598025160-6",
+  "remittanceId": "b26db8dd-8330-4071-8b30-dde2051dcb9c",
+  "senderId": "e2e-10x-1776625541994-5",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "claimTokenId": "188d3d81-4871-4751-959a-ca13bddb4ae5",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:27:15.108897695Z",
-  "updatedAt": "2026-04-19T11:27:15.118965735Z",
+  "createdAt": "2026-04-19T19:05:52.315181754Z",
+  "updatedAt": "2026-04-19T19:05:52.330885107Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/b9d7812a-aae2-448e-8b40-368810451de6`  → **HTTP 200**
+`GET /api/remittances/b26db8dd-8330-4071-8b30-dde2051dcb9c`  → **HTTP 200**
 
 Request:
 ```json
@@ -1248,26 +467,26 @@ Request:
 Response:
 ```json
 {
-  "id": 7,
-  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
-  "senderId": "e2e-10x-1776598025160-6",
+  "id": 13,
+  "remittanceId": "b26db8dd-8330-4071-8b30-dde2051dcb9c",
+  "senderId": "e2e-10x-1776625541994-5",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "claimTokenId": "188d3d81-4871-4751-959a-ca13bddb4ae5",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:27:15.108898Z",
-  "updatedAt": "2026-04-19T11:27:48.830549Z",
+  "createdAt": "2026-04-19T19:05:52.315182Z",
+  "updatedAt": "2026-04-19T19:05:56.930484Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/9aea7175-5647-4f1d-90f4-80126fdc28a7`  → **HTTP 200**
+`GET /api/claims/188d3d81-4871-4751-959a-ca13bddb4ae5`  → **HTTP 200**
 
 Request:
 ```json
@@ -1277,20 +496,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
-  "senderId": "e2e-10x-1776598025160-6",
+  "remittanceId": "b26db8dd-8330-4071-8b30-dde2051dcb9c",
+  "senderId": "e2e-10x-1776625541994-5",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-21T11:27:15.116943Z"
+  "expiresAt": "2026-04-21T19:05:52.325623Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/9aea7175-5647-4f1d-90f4-80126fdc28a7`  → **HTTP 200**
+`POST /api/claims/188d3d81-4871-4751-959a-ca13bddb4ae5`  → **HTTP 200**
 
 Request:
 ```json
@@ -1302,20 +521,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
-  "senderId": "e2e-10x-1776598025160-6",
+  "remittanceId": "b26db8dd-8330-4071-8b30-dde2051dcb9c",
+  "senderId": "e2e-10x-1776625541994-5",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-21T11:27:15.116943Z"
+  "expiresAt": "2026-04-21T19:05:52.325623Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/b9d7812a-aae2-448e-8b40-368810451de6`  → **HTTP 200**
+`GET /api/remittances/b26db8dd-8330-4071-8b30-dde2051dcb9c`  → **HTTP 200**
 
 Request:
 ```json
@@ -1325,34 +544,33 @@ Request:
 Response:
 ```json
 {
-  "id": 7,
-  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
-  "senderId": "e2e-10x-1776598025160-6",
+  "id": 13,
+  "remittanceId": "b26db8dd-8330-4071-8b30-dde2051dcb9c",
+  "senderId": "e2e-10x-1776625541994-5",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "claimTokenId": "188d3d81-4871-4751-959a-ca13bddb4ae5",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:27:15.108898Z",
-  "updatedAt": "2026-04-19T11:27:53.242882Z",
+  "createdAt": "2026-04-19T19:05:52.315182Z",
+  "updatedAt": "2026-04-19T19:06:03.622223Z",
   "expiresAt": null
 }
 ```
 
 ---
 
-### Customer 7 — `e2e-10x-1776598075964-7`
+### Customer 6 — `e2e-10x-1776625565425-6`
 
-- walletId: `14`  solanaAddress: `Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY`
-- fundingId: `8ee040a8-a3a6-459d-a90f-71138b3d65bd`  paymentIntentId: `pi_3TNtW53nnME1dfOB1KfgIqZa`
-- remittanceId: `1dee3072-adc6-4872-8fbb-593675866249`  claimTokenId: `ac5d8a94-830f-4cf2-802a-24f064e08681`
-- final status: **DELIVERED**  elapsed: 22.9s  **PASS**
+- walletId: `24`  solanaAddress: `Hp3jRdvzsQkC9icQmZJSTqQ2Jty516XsLd6TEF3D2YK1`
+- fundingId: `edf93bd6-8407-46a0-a995-f9d2705e2cbe`  paymentIntentId: `pi_3TO0fS3nnME1dfOB1T93KrgL`
+- remittanceId: `5c3ef5af-8e44-42f3-97d0-0d64adb728d2`  claimTokenId: `5d7849b3-eef4-4105-a2a1-60b6b9c61209`
+- final status: **DELIVERED**  elapsed: 22.1s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 33
-- Payout: id=`pout_wm_6jarhbmk9wio` status=`processing`
+- Claim authority USDC after claim: 39
 
 #### 1-create-wallet
 
@@ -1361,7 +579,78 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776598075964-7"
+  "userId": "e2e-10x-1776625565425-6"
+}
+```
+
+Response:
+```json
+{
+  "id": 24,
+  "userId": "e2e-10x-1776625565425-6",
+  "solanaAddress": "Hp3jRdvzsQkC9icQmZJSTqQ2Jty516XsLd6TEF3D2YK1",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T19:06:05.572299827Z",
+  "updatedAt": "2026-04-19T19:06:05.572299827Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/24/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "edf93bd6-8407-46a0-a995-f9d2705e2cbe",
+  "walletId": 24,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0fS3nnME1dfOB1T93KrgL",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T19:06:05.589472678Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/edf93bd6-8407-46a0-a995-f9d2705e2cbe`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "edf93bd6-8407-46a0-a995-f9d2705e2cbe",
+  "walletId": 24,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TO0fS3nnME1dfOB1T93KrgL",
+  "createdAt": "2026-04-19T19:06:05.589473Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776625565425-6",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
 }
 ```
 
@@ -1369,96 +658,25 @@ Response:
 ```json
 {
   "id": 14,
-  "userId": "e2e-10x-1776598075964-7",
-  "solanaAddress": "Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-19T11:27:56.061156720Z",
-  "updatedAt": "2026-04-19T11:27:56.061156720Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/14/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "8ee040a8-a3a6-459d-a90f-71138b3d65bd",
-  "walletId": 14,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtW53nnME1dfOB1KfgIqZa",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:27:56.084879579Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/8ee040a8-a3a6-459d-a90f-71138b3d65bd`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "8ee040a8-a3a6-459d-a90f-71138b3d65bd",
-  "walletId": 14,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtW53nnME1dfOB1KfgIqZa",
-  "createdAt": "2026-04-19T11:27:56.084880Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776598075964-7",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 8,
-  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
-  "senderId": "e2e-10x-1776598075964-7",
+  "remittanceId": "5c3ef5af-8e44-42f3-97d0-0d64adb728d2",
+  "senderId": "e2e-10x-1776625565425-6",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "claimTokenId": "5d7849b3-eef4-4105-a2a1-60b6b9c61209",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:11.801409970Z",
-  "updatedAt": "2026-04-19T11:28:11.808384151Z",
+  "createdAt": "2026-04-19T19:06:14.316230063Z",
+  "updatedAt": "2026-04-19T19:06:14.321558639Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/1dee3072-adc6-4872-8fbb-593675866249`  → **HTTP 200**
+`GET /api/remittances/5c3ef5af-8e44-42f3-97d0-0d64adb728d2`  → **HTTP 200**
 
 Request:
 ```json
@@ -1468,26 +686,26 @@ Request:
 Response:
 ```json
 {
-  "id": 8,
-  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
-  "senderId": "e2e-10x-1776598075964-7",
+  "id": 14,
+  "remittanceId": "5c3ef5af-8e44-42f3-97d0-0d64adb728d2",
+  "senderId": "e2e-10x-1776625565425-6",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "claimTokenId": "5d7849b3-eef4-4105-a2a1-60b6b9c61209",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:11.801410Z",
-  "updatedAt": "2026-04-19T11:28:12.958556Z",
+  "createdAt": "2026-04-19T19:06:14.316230Z",
+  "updatedAt": "2026-04-19T19:06:18.909359Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/ac5d8a94-830f-4cf2-802a-24f064e08681`  → **HTTP 200**
+`GET /api/claims/5d7849b3-eef4-4105-a2a1-60b6b9c61209`  → **HTTP 200**
 
 Request:
 ```json
@@ -1497,20 +715,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
-  "senderId": "e2e-10x-1776598075964-7",
+  "remittanceId": "5c3ef5af-8e44-42f3-97d0-0d64adb728d2",
+  "senderId": "e2e-10x-1776625565425-6",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-21T11:28:11.805796Z"
+  "expiresAt": "2026-04-21T19:06:14.319893Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/ac5d8a94-830f-4cf2-802a-24f064e08681`  → **HTTP 200**
+`POST /api/claims/5d7849b3-eef4-4105-a2a1-60b6b9c61209`  → **HTTP 200**
 
 Request:
 ```json
@@ -1522,20 +740,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
-  "senderId": "e2e-10x-1776598075964-7",
+  "remittanceId": "5c3ef5af-8e44-42f3-97d0-0d64adb728d2",
+  "senderId": "e2e-10x-1776625565425-6",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-21T11:28:11.805796Z"
+  "expiresAt": "2026-04-21T19:06:14.319893Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/1dee3072-adc6-4872-8fbb-593675866249`  → **HTTP 200**
+`GET /api/remittances/5c3ef5af-8e44-42f3-97d0-0d64adb728d2`  → **HTTP 200**
 
 Request:
 ```json
@@ -1545,34 +763,33 @@ Request:
 Response:
 ```json
 {
-  "id": 8,
-  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
-  "senderId": "e2e-10x-1776598075964-7",
+  "id": 14,
+  "remittanceId": "5c3ef5af-8e44-42f3-97d0-0d64adb728d2",
+  "senderId": "e2e-10x-1776625565425-6",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "claimTokenId": "5d7849b3-eef4-4105-a2a1-60b6b9c61209",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:11.801410Z",
-  "updatedAt": "2026-04-19T11:28:16.173532Z",
+  "createdAt": "2026-04-19T19:06:14.316230Z",
+  "updatedAt": "2026-04-19T19:06:25.791184Z",
   "expiresAt": null
 }
 ```
 
 ---
 
-### Customer 8 — `e2e-10x-1776598098872-8`
+### Customer 7 — `e2e-10x-1776625587534-7`
 
-- walletId: `15`  solanaAddress: `CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3`
-- fundingId: `99f047f0-ab7f-415c-9960-66de2917cb54`  paymentIntentId: `pi_3TNtWS3nnME1dfOB1oC0Ax7k`
-- remittanceId: `9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  claimTokenId: `73835f3a-0c6e-4d91-9fc4-0f76391e46ac`
-- final status: **DELIVERED**  elapsed: 16.3s  **PASS**
+- walletId: `25`  solanaAddress: `2EJTtS636CELwrdh6oBzF37LGMgYsNe9vu3BCxjxgvLP`
+- fundingId: `8d16860c-ae69-499a-aad3-74a5b6cea6a3`  paymentIntentId: `pi_3TO0fp3nnME1dfOB1doaELNR`
+- remittanceId: `29e02376-179f-43eb-905c-0b2272bc029f`  claimTokenId: `70f4b9ba-c26a-49f1-873f-498f8483bebf`
+- final status: **DELIVERED**  elapsed: 22.3s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 34
-- Payout: id=`pout_wm_u5hmkb1zwkd0` status=`processing`
+- Claim authority USDC after claim: 40
 
 #### 1-create-wallet
 
@@ -1581,7 +798,78 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776598098872-8"
+  "userId": "e2e-10x-1776625587534-7"
+}
+```
+
+Response:
+```json
+{
+  "id": 25,
+  "userId": "e2e-10x-1776625587534-7",
+  "solanaAddress": "2EJTtS636CELwrdh6oBzF37LGMgYsNe9vu3BCxjxgvLP",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T19:06:27.646606450Z",
+  "updatedAt": "2026-04-19T19:06:27.646606450Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/25/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "8d16860c-ae69-499a-aad3-74a5b6cea6a3",
+  "walletId": 25,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0fp3nnME1dfOB1doaELNR",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T19:06:27.659964640Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/8d16860c-ae69-499a-aad3-74a5b6cea6a3`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "8d16860c-ae69-499a-aad3-74a5b6cea6a3",
+  "walletId": 25,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TO0fp3nnME1dfOB1doaELNR",
+  "createdAt": "2026-04-19T19:06:27.659965Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776625587534-7",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
 }
 ```
 
@@ -1589,96 +877,25 @@ Response:
 ```json
 {
   "id": 15,
-  "userId": "e2e-10x-1776598098872-8",
-  "solanaAddress": "CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-19T11:28:18.977911813Z",
-  "updatedAt": "2026-04-19T11:28:18.977911813Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/15/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "99f047f0-ab7f-415c-9960-66de2917cb54",
-  "walletId": 15,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtWS3nnME1dfOB1oC0Ax7k",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:28:18.997408221Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/99f047f0-ab7f-415c-9960-66de2917cb54`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "99f047f0-ab7f-415c-9960-66de2917cb54",
-  "walletId": 15,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtWS3nnME1dfOB1oC0Ax7k",
-  "createdAt": "2026-04-19T11:28:18.997408Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776598098872-8",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 9,
-  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
-  "senderId": "e2e-10x-1776598098872-8",
+  "remittanceId": "29e02376-179f-43eb-905c-0b2272bc029f",
+  "senderId": "e2e-10x-1776625587534-7",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
+  "claimTokenId": "70f4b9ba-c26a-49f1-873f-498f8483bebf",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:27.892978521Z",
-  "updatedAt": "2026-04-19T11:28:27.912344928Z",
+  "createdAt": "2026-04-19T19:06:36.814173551Z",
+  "updatedAt": "2026-04-19T19:06:36.822497664Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  → **HTTP 200**
+`GET /api/remittances/29e02376-179f-43eb-905c-0b2272bc029f`  → **HTTP 200**
 
 Request:
 ```json
@@ -1688,26 +905,26 @@ Request:
 Response:
 ```json
 {
-  "id": 9,
-  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
-  "senderId": "e2e-10x-1776598098872-8",
+  "id": 15,
+  "remittanceId": "29e02376-179f-43eb-905c-0b2272bc029f",
+  "senderId": "e2e-10x-1776625587534-7",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
+  "claimTokenId": "70f4b9ba-c26a-49f1-873f-498f8483bebf",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:27.892979Z",
-  "updatedAt": "2026-04-19T11:28:28.804371Z",
+  "createdAt": "2026-04-19T19:06:36.814174Z",
+  "updatedAt": "2026-04-19T19:06:41.809937Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/73835f3a-0c6e-4d91-9fc4-0f76391e46ac`  → **HTTP 200**
+`GET /api/claims/70f4b9ba-c26a-49f1-873f-498f8483bebf`  → **HTTP 200**
 
 Request:
 ```json
@@ -1717,20 +934,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
-  "senderId": "e2e-10x-1776598098872-8",
+  "remittanceId": "29e02376-179f-43eb-905c-0b2272bc029f",
+  "senderId": "e2e-10x-1776625587534-7",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-21T11:28:27.908348Z"
+  "expiresAt": "2026-04-21T19:06:36.820068Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/73835f3a-0c6e-4d91-9fc4-0f76391e46ac`  → **HTTP 200**
+`POST /api/claims/70f4b9ba-c26a-49f1-873f-498f8483bebf`  → **HTTP 200**
 
 Request:
 ```json
@@ -1742,20 +959,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
-  "senderId": "e2e-10x-1776598098872-8",
+  "remittanceId": "29e02376-179f-43eb-905c-0b2272bc029f",
+  "senderId": "e2e-10x-1776625587534-7",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-21T11:28:27.908348Z"
+  "expiresAt": "2026-04-21T19:06:36.820068Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  → **HTTP 200**
+`GET /api/remittances/29e02376-179f-43eb-905c-0b2272bc029f`  → **HTTP 200**
 
 Request:
 ```json
@@ -1765,34 +982,33 @@ Request:
 Response:
 ```json
 {
-  "id": 9,
-  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
-  "senderId": "e2e-10x-1776598098872-8",
+  "id": 15,
+  "remittanceId": "29e02376-179f-43eb-905c-0b2272bc029f",
+  "senderId": "e2e-10x-1776625587534-7",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
+  "claimTokenId": "70f4b9ba-c26a-49f1-873f-498f8483bebf",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:27.892979Z",
-  "updatedAt": "2026-04-19T11:28:32.418422Z",
+  "createdAt": "2026-04-19T19:06:36.814174Z",
+  "updatedAt": "2026-04-19T19:06:48.098718Z",
   "expiresAt": null
 }
 ```
 
 ---
 
-### Customer 9 — `e2e-10x-1776598115130-9`
+### Customer 8 — `e2e-10x-1776625609866-8`
 
-- walletId: `16`  solanaAddress: `74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4`
-- fundingId: `32466a08-4bcc-4b60-9e98-4919e12ad5a0`  paymentIntentId: `pi_3TNtWi3nnME1dfOB0Yevm0QL`
-- remittanceId: `af3b0178-7931-4d19-9721-bb3e96727a1c`  claimTokenId: `131682fa-885a-4dab-b44b-7b9cf65c791e`
-- final status: **DELIVERED**  elapsed: 46.8s  **PASS**
+- walletId: `26`  solanaAddress: `EvuvHjCFj6bNpeM9e3q6o6T6GE4KzvHaDgiS5tB4WjQ6`
+- fundingId: `12aa01d4-9eba-4e87-9a0d-f69290de94fb`  paymentIntentId: `pi_3TO0gB3nnME1dfOB1fg2vQKt`
+- remittanceId: `8925ec59-c663-4298-a627-a6736cabc5e5`  claimTokenId: `3485830d-5f46-40fd-b70e-c619e30bdc4c`
+- final status: **DELIVERED**  elapsed: 22.3s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 35
-- Payout: id=`pout_wm_pfi0ubnabdur` status=`processing`
+- Claim authority USDC after claim: 41
 
 #### 1-create-wallet
 
@@ -1801,7 +1017,78 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776598115130-9"
+  "userId": "e2e-10x-1776625609866-8"
+}
+```
+
+Response:
+```json
+{
+  "id": 26,
+  "userId": "e2e-10x-1776625609866-8",
+  "solanaAddress": "EvuvHjCFj6bNpeM9e3q6o6T6GE4KzvHaDgiS5tB4WjQ6",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T19:06:49.969699599Z",
+  "updatedAt": "2026-04-19T19:06:49.969699599Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/26/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "12aa01d4-9eba-4e87-9a0d-f69290de94fb",
+  "walletId": 26,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0gB3nnME1dfOB1fg2vQKt",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T19:06:49.988436740Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/12aa01d4-9eba-4e87-9a0d-f69290de94fb`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "12aa01d4-9eba-4e87-9a0d-f69290de94fb",
+  "walletId": 26,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TO0gB3nnME1dfOB1fg2vQKt",
+  "createdAt": "2026-04-19T19:06:49.988437Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776625609866-8",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
 }
 ```
 
@@ -1809,96 +1096,25 @@ Response:
 ```json
 {
   "id": 16,
-  "userId": "e2e-10x-1776598115130-9",
-  "solanaAddress": "74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-19T11:28:35.330552520Z",
-  "updatedAt": "2026-04-19T11:28:35.330552520Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/16/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "32466a08-4bcc-4b60-9e98-4919e12ad5a0",
-  "walletId": 16,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtWi3nnME1dfOB0Yevm0QL",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:28:35.375705052Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/32466a08-4bcc-4b60-9e98-4919e12ad5a0`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "32466a08-4bcc-4b60-9e98-4919e12ad5a0",
-  "walletId": 16,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtWi3nnME1dfOB0Yevm0QL",
-  "createdAt": "2026-04-19T11:28:35.375705Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776598115130-9",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 10,
-  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
-  "senderId": "e2e-10x-1776598115130-9",
+  "remittanceId": "8925ec59-c663-4298-a627-a6736cabc5e5",
+  "senderId": "e2e-10x-1776625609866-8",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "claimTokenId": "3485830d-5f46-40fd-b70e-c619e30bdc4c",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:44.550884574Z",
-  "updatedAt": "2026-04-19T11:28:44.556493453Z",
+  "createdAt": "2026-04-19T19:06:58.777742412Z",
+  "updatedAt": "2026-04-19T19:06:58.787357774Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/af3b0178-7931-4d19-9721-bb3e96727a1c`  → **HTTP 200**
+`GET /api/remittances/8925ec59-c663-4298-a627-a6736cabc5e5`  → **HTTP 200**
 
 Request:
 ```json
@@ -1908,26 +1124,26 @@ Request:
 Response:
 ```json
 {
-  "id": 10,
-  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
-  "senderId": "e2e-10x-1776598115130-9",
+  "id": 16,
+  "remittanceId": "8925ec59-c663-4298-a627-a6736cabc5e5",
+  "senderId": "e2e-10x-1776625609866-8",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "claimTokenId": "3485830d-5f46-40fd-b70e-c619e30bdc4c",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:44.550885Z",
-  "updatedAt": "2026-04-19T11:29:15.976473Z",
+  "createdAt": "2026-04-19T19:06:58.777742Z",
+  "updatedAt": "2026-04-19T19:07:03.492727Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/131682fa-885a-4dab-b44b-7b9cf65c791e`  → **HTTP 200**
+`GET /api/claims/3485830d-5f46-40fd-b70e-c619e30bdc4c`  → **HTTP 200**
 
 Request:
 ```json
@@ -1937,20 +1153,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
-  "senderId": "e2e-10x-1776598115130-9",
+  "remittanceId": "8925ec59-c663-4298-a627-a6736cabc5e5",
+  "senderId": "e2e-10x-1776625609866-8",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-21T11:28:44.555437Z"
+  "expiresAt": "2026-04-21T19:06:58.781537Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/131682fa-885a-4dab-b44b-7b9cf65c791e`  → **HTTP 200**
+`POST /api/claims/3485830d-5f46-40fd-b70e-c619e30bdc4c`  → **HTTP 200**
 
 Request:
 ```json
@@ -1962,20 +1178,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
-  "senderId": "e2e-10x-1776598115130-9",
+  "remittanceId": "8925ec59-c663-4298-a627-a6736cabc5e5",
+  "senderId": "e2e-10x-1776625609866-8",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-21T11:28:44.555437Z"
+  "expiresAt": "2026-04-21T19:06:58.781537Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/af3b0178-7931-4d19-9721-bb3e96727a1c`  → **HTTP 200**
+`GET /api/remittances/8925ec59-c663-4298-a627-a6736cabc5e5`  → **HTTP 200**
 
 Request:
 ```json
@@ -1985,34 +1201,33 @@ Request:
 Response:
 ```json
 {
-  "id": 10,
-  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
-  "senderId": "e2e-10x-1776598115130-9",
+  "id": 16,
+  "remittanceId": "8925ec59-c663-4298-a627-a6736cabc5e5",
+  "senderId": "e2e-10x-1776625609866-8",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "claimTokenId": "3485830d-5f46-40fd-b70e-c619e30bdc4c",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:28:44.550885Z",
-  "updatedAt": "2026-04-19T11:29:19.498799Z",
+  "createdAt": "2026-04-19T19:06:58.777742Z",
+  "updatedAt": "2026-04-19T19:07:09.774656Z",
   "expiresAt": null
 }
 ```
 
 ---
 
-### Customer 10 — `e2e-10x-1776598161943-10`
+### Customer 9 — `e2e-10x-1776625632190-9`
 
-- walletId: `17`  solanaAddress: `G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9`
-- fundingId: `7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca`  paymentIntentId: `pi_3TNtXT3nnME1dfOB0n69tF9W`
-- remittanceId: `5138141b-9a20-461f-b7df-e4dbf27d6d46`  claimTokenId: `765aac14-5e5f-49b1-9943-08806535ed75`
-- final status: **DELIVERED**  elapsed: 47.4s  **PASS**
+- walletId: `27`  solanaAddress: `F2muFfMgmKXfqkMvS8V5CZgPNYmCxWR6bxvJs2MRYBg2`
+- fundingId: `99a0ab3a-18ab-4664-9ac2-23f5e896d24e`  paymentIntentId: `pi_3TO0gX3nnME1dfOB065tNPzK`
+- remittanceId: `23c1a361-dea3-4f9f-870b-0de778ef4355`  claimTokenId: `499a5e65-84a8-4ddb-8258-d8c60dda9f88`
+- final status: **DELIVERED**  elapsed: 22.3s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 36
-- Payout: id=`pout_wm_mmxjbzzuhsnk` status=`processing`
+- Claim authority USDC after claim: 42
 
 #### 1-create-wallet
 
@@ -2021,26 +1236,26 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776598161943-10"
+  "userId": "e2e-10x-1776625632190-9"
 }
 ```
 
 Response:
 ```json
 {
-  "id": 17,
-  "userId": "e2e-10x-1776598161943-10",
-  "solanaAddress": "G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9",
+  "id": 27,
+  "userId": "e2e-10x-1776625632190-9",
+  "solanaAddress": "F2muFfMgmKXfqkMvS8V5CZgPNYmCxWR6bxvJs2MRYBg2",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-19T11:29:22.027111483Z",
-  "updatedAt": "2026-04-19T11:29:22.027111483Z"
+  "createdAt": "2026-04-19T19:07:12.344890426Z",
+  "updatedAt": "2026-04-19T19:07:12.344890426Z"
 }
 ```
 
 #### 2-initiate-fund
 
-`POST /api/wallets/17/fund`  → **HTTP 201**
+`POST /api/wallets/27/fund`  → **HTTP 201**
 
 Request:
 ```json
@@ -2052,19 +1267,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca",
-  "walletId": 17,
+  "fundingId": "99a0ab3a-18ab-4664-9ac2-23f5e896d24e",
+  "walletId": 27,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNtXT3nnME1dfOB0n69tF9W",
+  "stripePaymentIntentId": "pi_3TO0gX3nnME1dfOB065tNPzK",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-19T11:29:22.040386216Z"
+  "createdAt": "2026-04-19T19:07:12.373961260Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca`  → **HTTP 200**
+`GET /api/funding-orders/99a0ab3a-18ab-4664-9ac2-23f5e896d24e`  → **HTTP 200**
 
 Request:
 ```json
@@ -2074,12 +1289,12 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca",
-  "walletId": 17,
+  "fundingId": "99a0ab3a-18ab-4664-9ac2-23f5e896d24e",
+  "walletId": 27,
   "amountUsdc": 1.0,
   "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNtXT3nnME1dfOB0n69tF9W",
-  "createdAt": "2026-04-19T11:29:22.040386Z"
+  "stripePaymentIntentId": "pi_3TO0gX3nnME1dfOB065tNPzK",
+  "createdAt": "2026-04-19T19:07:12.373961Z"
 }
 ```
 
@@ -2090,7 +1305,7 @@ Response:
 Request:
 ```json
 {
-  "senderId": "e2e-10x-1776598161943-10",
+  "senderId": "e2e-10x-1776625632190-9",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0
 }
@@ -2099,26 +1314,26 @@ Request:
 Response:
 ```json
 {
-  "id": 11,
-  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
-  "senderId": "e2e-10x-1776598161943-10",
+  "id": 17,
+  "remittanceId": "23c1a361-dea3-4f9f-870b-0de778ef4355",
+  "senderId": "e2e-10x-1776625632190-9",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "claimTokenId": "499a5e65-84a8-4ddb-8258-d8c60dda9f88",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:29:31.785075306Z",
-  "updatedAt": "2026-04-19T11:29:31.790060930Z",
+  "createdAt": "2026-04-19T19:07:21.424828857Z",
+  "updatedAt": "2026-04-19T19:07:21.438793004Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/5138141b-9a20-461f-b7df-e4dbf27d6d46`  → **HTTP 200**
+`GET /api/remittances/23c1a361-dea3-4f9f-870b-0de778ef4355`  → **HTTP 200**
 
 Request:
 ```json
@@ -2128,26 +1343,26 @@ Request:
 Response:
 ```json
 {
-  "id": 11,
-  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
-  "senderId": "e2e-10x-1776598161943-10",
+  "id": 17,
+  "remittanceId": "23c1a361-dea3-4f9f-870b-0de778ef4355",
+  "senderId": "e2e-10x-1776625632190-9",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "claimTokenId": "499a5e65-84a8-4ddb-8258-d8c60dda9f88",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:29:31.785075Z",
-  "updatedAt": "2026-04-19T11:30:03.054652Z",
+  "createdAt": "2026-04-19T19:07:21.424829Z",
+  "updatedAt": "2026-04-19T19:07:26.434834Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/765aac14-5e5f-49b1-9943-08806535ed75`  → **HTTP 200**
+`GET /api/claims/499a5e65-84a8-4ddb-8258-d8c60dda9f88`  → **HTTP 200**
 
 Request:
 ```json
@@ -2157,20 +1372,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
-  "senderId": "e2e-10x-1776598161943-10",
+  "remittanceId": "23c1a361-dea3-4f9f-870b-0de778ef4355",
+  "senderId": "e2e-10x-1776625632190-9",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-21T11:29:31.788423Z"
+  "expiresAt": "2026-04-21T19:07:21.435853Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/765aac14-5e5f-49b1-9943-08806535ed75`  → **HTTP 200**
+`POST /api/claims/499a5e65-84a8-4ddb-8258-d8c60dda9f88`  → **HTTP 200**
 
 Request:
 ```json
@@ -2182,20 +1397,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
-  "senderId": "e2e-10x-1776598161943-10",
+  "remittanceId": "23c1a361-dea3-4f9f-870b-0de778ef4355",
+  "senderId": "e2e-10x-1776625632190-9",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-21T11:29:31.788423Z"
+  "expiresAt": "2026-04-21T19:07:21.435853Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/5138141b-9a20-461f-b7df-e4dbf27d6d46`  → **HTTP 200**
+`GET /api/remittances/23c1a361-dea3-4f9f-870b-0de778ef4355`  → **HTTP 200**
 
 Request:
 ```json
@@ -2205,19 +1420,238 @@ Request:
 Response:
 ```json
 {
-  "id": 11,
-  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
-  "senderId": "e2e-10x-1776598161943-10",
+  "id": 17,
+  "remittanceId": "23c1a361-dea3-4f9f-870b-0de778ef4355",
+  "senderId": "e2e-10x-1776625632190-9",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
   "amountInr": 92.92,
   "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "claimTokenId": "499a5e65-84a8-4ddb-8258-d8c60dda9f88",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-19T11:29:31.785075Z",
-  "updatedAt": "2026-04-19T11:30:06.334869Z",
+  "createdAt": "2026-04-19T19:07:21.424829Z",
+  "updatedAt": "2026-04-19T19:07:32.502073Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 10 — `e2e-10x-1776625654515-10`
+
+- walletId: `28`  solanaAddress: `CAWjqf8mm5XRicmmWYYmNEaNYpJhAvoieVdTXwW1Ehre`
+- fundingId: `4860ae81-8fb1-4156-a782-0fc7cdeee786`  paymentIntentId: `pi_3TO0gu3nnME1dfOB1MBgLKRc`
+- remittanceId: `cf5346df-80ba-4f6c-81d7-7a9dd2fa1418`  claimTokenId: `6a931f2e-c22e-4c60-b2c5-ada5d4872c5d`
+- final status: **DELIVERED**  elapsed: 52.4s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 43
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776625654515-10"
+}
+```
+
+Response:
+```json
+{
+  "id": 28,
+  "userId": "e2e-10x-1776625654515-10",
+  "solanaAddress": "CAWjqf8mm5XRicmmWYYmNEaNYpJhAvoieVdTXwW1Ehre",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T19:07:34.634291456Z",
+  "updatedAt": "2026-04-19T19:07:34.634291456Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/28/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "4860ae81-8fb1-4156-a782-0fc7cdeee786",
+  "walletId": 28,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TO0gu3nnME1dfOB1MBgLKRc",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T19:07:34.656950049Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/4860ae81-8fb1-4156-a782-0fc7cdeee786`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "4860ae81-8fb1-4156-a782-0fc7cdeee786",
+  "walletId": 28,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TO0gu3nnME1dfOB1MBgLKRc",
+  "createdAt": "2026-04-19T19:07:34.656950Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776625654515-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 18,
+  "remittanceId": "cf5346df-80ba-4f6c-81d7-7a9dd2fa1418",
+  "senderId": "e2e-10x-1776625654515-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "6a931f2e-c22e-4c60-b2c5-ada5d4872c5d",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T19:07:43.466338785Z",
+  "updatedAt": "2026-04-19T19:07:43.479094974Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/cf5346df-80ba-4f6c-81d7-7a9dd2fa1418`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 18,
+  "remittanceId": "cf5346df-80ba-4f6c-81d7-7a9dd2fa1418",
+  "senderId": "e2e-10x-1776625654515-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "6a931f2e-c22e-4c60-b2c5-ada5d4872c5d",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T19:07:43.466339Z",
+  "updatedAt": "2026-04-19T19:08:18.559514Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/6a931f2e-c22e-4c60-b2c5-ada5d4872c5d`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "cf5346df-80ba-4f6c-81d7-7a9dd2fa1418",
+  "senderId": "e2e-10x-1776625654515-10",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T19:07:43.473649Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/6a931f2e-c22e-4c60-b2c5-ada5d4872c5d`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "cf5346df-80ba-4f6c-81d7-7a9dd2fa1418",
+  "senderId": "e2e-10x-1776625654515-10",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T19:07:43.473649Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/cf5346df-80ba-4f6c-81d7-7a9dd2fa1418`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 18,
+  "remittanceId": "cf5346df-80ba-4f6c-81d7-7a9dd2fa1418",
+  "senderId": "e2e-10x-1776625654515-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "6a931f2e-c22e-4c60-b2c5-ada5d4872c5d",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T19:07:43.466339Z",
+  "updatedAt": "2026-04-19T19:08:24.868512Z",
   "expiresAt": null
 }
 ```


### PR DESCRIPTION
## Summary

- Port transaction confirmation pattern from stablebridge-tx-recovery to replace the hardcoded `"CONFIRMED"` stub with real Solana `getSignatureStatuses` JSON-RPC polling
- Add `TransactionConfirmationStatus` enum with domain-safe mapping of Solana confirmation states
- Implement Temporal-idiomatic polling: single-check activity + `Workflow.sleep()` loop (3s interval, 40 max attempts = 120s)
- Each confirmation point (deposit, release, refund) catches failures and transitions to a dedicated failure status (`DEPOSIT_FAILED`, `CLAIM_FAILED`, `REFUND_FAILED`)
- Add `SP-0031: transactionFailed` exception factory for on-chain transaction errors

## Test plan

- [x] Unit tests for JSON-RPC response parsing (finalized, confirmed, processed, not-found, failed-on-chain, missing value)
- [x] Unit test for `checkTransactionStatus` activity delegation
- [x] Workflow test: deposit confirmation timeout → `DEPOSIT_FAILED`
- [x] Workflow test: on-chain failure → `DEPOSIT_FAILED`
- [x] Workflow test: release confirmation failure → `CLAIM_FAILED` (fiat disbursement skipped)
- [x] Workflow test: refund confirmation failure → `REFUND_FAILED`
- [x] Workflow test: multi-poll (PROCESSED → PROCESSED → FINALIZED) before confirmation
- [x] All existing workflow tests pass with default FINALIZED stubs
- [x] `./gradlew build -x integrationTest` passes (Spotless + ArchUnit + all unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction confirmation now polls on-chain for real-time status updates with automatic retry logic (3-second intervals)
  * Added new transaction failure states (Deposit Failed, Claim Failed, Refund Failed)
  * Integrated Stripe for remittance funding
  * Integrated Razorpay UPI for remittance disbursement

* **Bug Fixes**
  * Enhanced transaction status tracking with live on-chain lookups instead of stub behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->