### PR TITLE
chore: add WireMock for Razorpay-contract E2E + refresh 10-customer report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,21 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 # Treasury wallet secret key (base58-encoded). Funds SPL USDC + SOL rent transfers
 # to user wallets after a confirmed Stripe PaymentIntent. Devnet only.
 TREASURY_PRIVATE_KEY=
+
+# INR disbursement adapter selector. Valid values: logging (default, synthetic
+# log_<uuid> result — used by the existing 10-customer E2E) or razorpay (real
+# RazorpayX test-mode HTTP call — produces a pout_xxx ID visible in the
+# RazorpayX dashboard). Leave unset for default logging behaviour.
+STABLEPAY_DISBURSEMENT_PROVIDER=logging
+
+# RazorpayX test-mode credentials. Required only when
+# STABLEPAY_DISBURSEMENT_PROVIDER=razorpay. Test mode does not require KYC —
+# sign up at https://razorpay.com and switch the dashboard toggle to Test Mode.
+RAZORPAY_KEY_ID=rzp_test_REPLACE_ME
+RAZORPAY_KEY_SECRET=REPLACE_ME
+RAZORPAY_ACCOUNT_NUMBER=REPLACE_ME
+
+# Optional Razorpay overrides. Defaults are production base URL + 10-second
+# per-call timeout; override only for local sandboxing.
+# RAZORPAY_BASE_URL=https://api.razorpay.com/v1
+# RAZORPAY_REQUEST_TIMEOUT=PT10S

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,20 @@ services:
       timeout: 5s
       retries: 5
 
+  wiremock:
+    image: wiremock/wiremock:3.9.2
+    ports:
+      - "8089:8080"
+    volumes:
+      - ./wiremock/mappings:/home/wiremock/mappings:ro
+    command: ["--global-response-templating", "--verbose"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/__admin/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
   mpc-sidecar-0:
     build:
       context: ./mpc-sidecar
@@ -112,6 +126,12 @@ services:
       STRIPE_AUTO_CONFIRM: ${STRIPE_AUTO_CONFIRM:-false}
       STRIPE_TEST_PAYMENT_METHOD: ${STRIPE_TEST_PAYMENT_METHOD:-pm_card_visa}
       TREASURY_PRIVATE_KEY: ${TREASURY_PRIVATE_KEY}
+      STABLEPAY_DISBURSEMENT_PROVIDER: ${STABLEPAY_DISBURSEMENT_PROVIDER:-logging}
+      RAZORPAY_KEY_ID: ${RAZORPAY_KEY_ID:-}
+      RAZORPAY_KEY_SECRET: ${RAZORPAY_KEY_SECRET:-}
+      RAZORPAY_ACCOUNT_NUMBER: ${RAZORPAY_ACCOUNT_NUMBER:-}
+      RAZORPAY_BASE_URL: ${RAZORPAY_BASE_URL:-http://wiremock:8080}
+      RAZORPAY_REQUEST_TIMEOUT: ${RAZORPAY_REQUEST_TIMEOUT:-PT10S}
     depends_on:
       postgres:
         condition: service_healthy
@@ -122,6 +142,8 @@ services:
       mpc-sidecar-0:
         condition: service_healthy
       mpc-sidecar-1:
+        condition: service_healthy
+      wiremock:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]

--- a/docs/E2E_10_CUSTOMER_RUN.md
+++ b/docs/E2E_10_CUSTOMER_RUN.md
@@ -1,37 +1,38 @@
 # 10-Customer Full E2E Run — $1.00 USDC per customer
 
-Generated: 2026-04-18 20:44:06 UTC
+Generated: 2026-04-19 11:30:09 UTC
 
 ## Summary
 
 - Customers attempted: 10
-- Passed: 9
-- Failed: 1
+- Passed: 10
+- Failed: 0
 - Per-customer amount: $1.00 USDC
 
-| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | elapsed (s) | PASS |
-|---|--------|----------|---------|-----------|--------------|-------|-----------------|-------------|------|
-| 1 | `e2e-10x-1776544675726-1` | 1 | `8MpRJTD42yxdSDzeQ8QVuKwa8aVihMsSZZxdD6qoHj6n` | `2bf23f57-c1a8-4be5-a5ec-d474e0ac7b8a` | `878de78d-f782-4ba3-9ae4-9034290c343e` | DELIVERED | 1 | 18.7 | ✅ |
-| 2 | `e2e-10x-1776544694458-2` | 2 | `HLtcpujz48wv33HsFjfRUwAmNzRQLSAJZEExgWa2Mcws` | `91c602f9-5750-413e-94e4-cd80fabc445c` | `bd9e7996-7263-4eca-9dc6-99bf41e18260` | DELIVERED | 1 | 49.1 | ✅ |
-| 3 | `e2e-10x-1776544743600-3` | 3 | `5AgBvzyrag2VzWpVFAk85a31bqk9t2p5zdT6mpUDu8kc` | `a1ef2cdb-09f1-40a3-a83c-b8e263a21431` | `db92a65c-7250-48a4-bd43-6c8433014f29` | DELIVERED | 1 | 16.1 | ✅ |
-| 4 | `e2e-10x-1776544759716-4` | 4 | `7MgfRxGAhfwZJuE1qVXjiSJxSjBRXSuSAgamHLhHueAv` | `6806d8a1-76b4-474f-8fdb-6c8cf42056c1` | `4d37df17-1f5a-4866-aec4-4592d2de7360` | DELIVERED | 1 | 46.9 | ✅ |
-| 5 | `e2e-10x-1776544806648-5` | 5 | `9xUbYQy64AvxvVUPLkHVugaFTZn6hnjeL4QbPs8WmkKF` | `9c37eed4-01bb-42ae-b890-b9946a50531b` | `22cf8aae-42cb-4180-a602-c2a2ab0ec79b` | DELIVERED | 1 | 16.6 | ✅ |
-| 6 | `e2e-10x-1776544823207-6` | 6 | `CG8ikGdacGfxyaiJVedGf5agz28ffYgkmt4PN1JF4NF2` | `eb0bc73a-a30e-4d31-96d4-f443a823d6cc` | `2c417e26-74eb-41b9-85c7-04a2bb10a70d` | DELIVERED | 1 | 79.2 | ✅ |
-| 7 | `e2e-10x-1776544902383-7` | 7 | `pdx3wUFtVSVESU8deMy71FX2jKF1z7faXU1UaE94C2V` | `32accf8d-9eff-4a83-8aa6-8ed39c4b00ab` | `65cc4519-b784-4ca2-8488-84d4cadb246f` | DELIVERED | 1 | 80.3 | ✅ |
-| 8 | `e2e-10x-1776544982690-8` | 8 | `H3m2y6zyjoReYq287YMPt8zY7pzyRQNgWpAVdFW8V6o4` | `2185ee8c-4040-483a-9fbd-74fae37f2b67` | `9daf9188-9192-453f-894b-73e3b300f51e` | DELIVERED | 1 | 16.8 | ✅ |
-| 9 | `e2e-10x-1776544999530-9` | None | `None` | `None` | `None` | - | - | 30.1 | ❌ create wallet failed — expected 201, see detail log |
-| 10 | `e2e-10x-1776545029653-10` | 9 | `DD8Ac8hTuwkjFauRJ9NkLgDazTSC3LRXPJgKsAyzgvNy` | `25591127-3111-4ee8-a877-c00bc0f331f0` | `8749a570-a49d-435b-ae49-c1ae8e6b64b1` | DELIVERED | 1 | 16.8 | ✅ |
+| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | payout_id | elapsed (s) | PASS |
+|---|--------|----------|---------|-----------|--------------|-------|-----------------|-----------|-------------|------|
+| 1 | `e2e-10x-1776597783066-1` | 8 | `38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj` | `c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28` | `24eb9ede-3bd3-40c2-9630-951ada545130` | DELIVERED | 1 | `pout_wm_1afbxunzb5mb` | 16.9 | ✅ |
+| 2 | `e2e-10x-1776597799939-2` | 9 | `HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht` | `51d94938-615d-4587-ba12-851cea5710af` | `c7f52cb1-9965-40d8-9e1a-927008dd9da6` | DELIVERED | 1 | `pout_wm_4fgovobnrnkj` | 49.1 | ✅ |
+| 3 | `e2e-10x-1776597849019-3` | 10 | `GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ` | `6f108599-3f3a-4e1c-bf41-d3e5b5c9d488` | `53c43ad7-6fda-4b0d-8c6f-310d6218cecc` | DELIVERED | 1 | `pout_wm_gyf0zd8q7idy` | 46.4 | ✅ |
+| 4 | `e2e-10x-1776597895402-4` | 11 | `UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR` | `f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f` | `3b296846-fe40-41a3-ade8-eda73f5e8af2` | DELIVERED | 1 | `pout_wm_kvrbr3peaes8` | 16.7 | ✅ |
+| 5 | `e2e-10x-1776597912110-5` | 12 | `9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g` | `4d43b24a-0f9b-4f01-8b98-3c8342e80f53` | `721ffdb1-9f30-426b-97ee-565f197549d2` | DELIVERED | 1 | `pout_wm_tg980vmggklj` | 113.0 | ✅ |
+| 6 | `e2e-10x-1776598025160-6` | 13 | `51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV` | `108dfcb4-9e95-47ee-a7c1-7b5c60c0e437` | `b9d7812a-aae2-448e-8b40-368810451de6` | DELIVERED | 1 | `pout_wm_pqbbwa8babew` | 50.8 | ✅ |
+| 7 | `e2e-10x-1776598075964-7` | 14 | `Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY` | `8ee040a8-a3a6-459d-a90f-71138b3d65bd` | `1dee3072-adc6-4872-8fbb-593675866249` | DELIVERED | 1 | `pout_wm_6jarhbmk9wio` | 22.9 | ✅ |
+| 8 | `e2e-10x-1776598098872-8` | 15 | `CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3` | `99f047f0-ab7f-415c-9960-66de2917cb54` | `9c6d725f-32dc-42df-bc00-3eaff10f8c9d` | DELIVERED | 1 | `pout_wm_u5hmkb1zwkd0` | 16.3 | ✅ |
+| 9 | `e2e-10x-1776598115130-9` | 16 | `74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4` | `32466a08-4bcc-4b60-9e98-4919e12ad5a0` | `af3b0178-7931-4d19-9721-bb3e96727a1c` | DELIVERED | 1 | `pout_wm_pfi0ubnabdur` | 46.8 | ✅ |
+| 10 | `e2e-10x-1776598161943-10` | 17 | `G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9` | `7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca` | `5138141b-9a20-461f-b7df-e4dbf27d6d46` | DELIVERED | 1 | `pout_wm_mmxjbzzuhsnk` | 47.4 | ✅ |
 
 ## Per-customer request / response log
 
-### Customer 1 — `e2e-10x-1776544675726-1`
+### Customer 1 — `e2e-10x-1776597783066-1`
 
-- walletId: `1`  solanaAddress: `8MpRJTD42yxdSDzeQ8QVuKwa8aVihMsSZZxdD6qoHj6n`
-- fundingId: `2bf23f57-c1a8-4be5-a5ec-d474e0ac7b8a`  paymentIntentId: `pi_3TNfco3nnME1dfOB1g2sbyZ2`
-- remittanceId: `878de78d-f782-4ba3-9ae4-9034290c343e`  claimTokenId: `420de909-b6d7-4aea-a44c-f016649b96ca`
-- final status: **DELIVERED**  elapsed: 18.7s  **PASS**
+- walletId: `8`  solanaAddress: `38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj`
+- fundingId: `c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28`  paymentIntentId: `pi_3TNtRM3nnME1dfOB1jvCcDMS`
+- remittanceId: `24eb9ede-3bd3-40c2-9630-951ada545130`  claimTokenId: `60e97f79-f86d-4227-aa13-532400e8f7db`
+- final status: **DELIVERED**  elapsed: 16.9s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 13
+- Claim authority USDC after claim: 27
+- Payout: id=`pout_wm_1afbxunzb5mb` status=`processing`
 
 #### 1-create-wallet
 
@@ -40,1540 +41,7 @@ Generated: 2026-04-18 20:44:06 UTC
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776544675726-1"
-}
-```
-
-Response:
-```json
-{
-  "id": 1,
-  "userId": "e2e-10x-1776544675726-1",
-  "solanaAddress": "8MpRJTD42yxdSDzeQ8QVuKwa8aVihMsSZZxdD6qoHj6n",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:37:56.652488292Z",
-  "updatedAt": "2026-04-18T20:37:56.652488292Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/1/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "2bf23f57-c1a8-4be5-a5ec-d474e0ac7b8a",
-  "walletId": 1,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfco3nnME1dfOB1g2sbyZ2",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:37:56.880208082Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/2bf23f57-c1a8-4be5-a5ec-d474e0ac7b8a`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "2bf23f57-c1a8-4be5-a5ec-d474e0ac7b8a",
-  "walletId": 1,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfco3nnME1dfOB1g2sbyZ2",
-  "createdAt": "2026-04-18T20:37:56.880208Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544675726-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 1,
-  "remittanceId": "878de78d-f782-4ba3-9ae4-9034290c343e",
-  "senderId": "e2e-10x-1776544675726-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "420de909-b6d7-4aea-a44c-f016649b96ca",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:07.388829600Z",
-  "updatedAt": "2026-04-18T20:38:07.398162340Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/878de78d-f782-4ba3-9ae4-9034290c343e`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 1,
-  "remittanceId": "878de78d-f782-4ba3-9ae4-9034290c343e",
-  "senderId": "e2e-10x-1776544675726-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "420de909-b6d7-4aea-a44c-f016649b96ca",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:07.388830Z",
-  "updatedAt": "2026-04-18T20:38:08.311274Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/420de909-b6d7-4aea-a44c-f016649b96ca`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "878de78d-f782-4ba3-9ae4-9034290c343e",
-  "senderId": "e2e-10x-1776544675726-1",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:38:07.394736Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/420de909-b6d7-4aea-a44c-f016649b96ca`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "878de78d-f782-4ba3-9ae4-9034290c343e",
-  "senderId": "e2e-10x-1776544675726-1",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:38:07.394736Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/878de78d-f782-4ba3-9ae4-9034290c343e`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 1,
-  "remittanceId": "878de78d-f782-4ba3-9ae4-9034290c343e",
-  "senderId": "e2e-10x-1776544675726-1",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "420de909-b6d7-4aea-a44c-f016649b96ca",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:07.388830Z",
-  "updatedAt": "2026-04-18T20:38:12.006261Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 2 — `e2e-10x-1776544694458-2`
-
-- walletId: `2`  solanaAddress: `HLtcpujz48wv33HsFjfRUwAmNzRQLSAJZEExgWa2Mcws`
-- fundingId: `91c602f9-5750-413e-94e4-cd80fabc445c`  paymentIntentId: `pi_3TNfdc3nnME1dfOB1WrCleJp`
-- remittanceId: `bd9e7996-7263-4eca-9dc6-99bf41e18260`  claimTokenId: `c6703791-d18f-448b-a235-a7dba3cc66d5`
-- final status: **DELIVERED**  elapsed: 49.1s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 14
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544694458-2"
-}
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "userId": "e2e-10x-1776544694458-2",
-  "solanaAddress": "HLtcpujz48wv33HsFjfRUwAmNzRQLSAJZEExgWa2Mcws",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:38:46.731933066Z",
-  "updatedAt": "2026-04-18T20:38:46.731933066Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/2/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "91c602f9-5750-413e-94e4-cd80fabc445c",
-  "walletId": 2,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfdc3nnME1dfOB1WrCleJp",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:38:46.785892798Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/91c602f9-5750-413e-94e4-cd80fabc445c`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "91c602f9-5750-413e-94e4-cd80fabc445c",
-  "walletId": 2,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfdc3nnME1dfOB1WrCleJp",
-  "createdAt": "2026-04-18T20:38:46.785893Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544694458-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "bd9e7996-7263-4eca-9dc6-99bf41e18260",
-  "senderId": "e2e-10x-1776544694458-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "c6703791-d18f-448b-a235-a7dba3cc66d5",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:56.604519077Z",
-  "updatedAt": "2026-04-18T20:38:56.609345821Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/bd9e7996-7263-4eca-9dc6-99bf41e18260`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "bd9e7996-7263-4eca-9dc6-99bf41e18260",
-  "senderId": "e2e-10x-1776544694458-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "c6703791-d18f-448b-a235-a7dba3cc66d5",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:56.604519Z",
-  "updatedAt": "2026-04-18T20:38:57.738075Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/c6703791-d18f-448b-a235-a7dba3cc66d5`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "bd9e7996-7263-4eca-9dc6-99bf41e18260",
-  "senderId": "e2e-10x-1776544694458-2",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:38:56.607975Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/c6703791-d18f-448b-a235-a7dba3cc66d5`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "bd9e7996-7263-4eca-9dc6-99bf41e18260",
-  "senderId": "e2e-10x-1776544694458-2",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:38:56.607975Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/bd9e7996-7263-4eca-9dc6-99bf41e18260`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 2,
-  "remittanceId": "bd9e7996-7263-4eca-9dc6-99bf41e18260",
-  "senderId": "e2e-10x-1776544694458-2",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "c6703791-d18f-448b-a235-a7dba3cc66d5",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:38:56.604519Z",
-  "updatedAt": "2026-04-18T20:39:01.159921Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 3 — `e2e-10x-1776544743600-3`
-
-- walletId: `3`  solanaAddress: `5AgBvzyrag2VzWpVFAk85a31bqk9t2p5zdT6mpUDu8kc`
-- fundingId: `a1ef2cdb-09f1-40a3-a83c-b8e263a21431`  paymentIntentId: `pi_3TNfdt3nnME1dfOB15aAfHUh`
-- remittanceId: `db92a65c-7250-48a4-bd43-6c8433014f29`  claimTokenId: `dfa83610-7780-4846-9487-654ac2ed4b4a`
-- final status: **DELIVERED**  elapsed: 16.1s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 15
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544743600-3"
-}
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "userId": "e2e-10x-1776544743600-3",
-  "solanaAddress": "5AgBvzyrag2VzWpVFAk85a31bqk9t2p5zdT6mpUDu8kc",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:39:03.706249660Z",
-  "updatedAt": "2026-04-18T20:39:03.706249660Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/3/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "a1ef2cdb-09f1-40a3-a83c-b8e263a21431",
-  "walletId": 3,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfdt3nnME1dfOB15aAfHUh",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:39:03.727390845Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/a1ef2cdb-09f1-40a3-a83c-b8e263a21431`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "a1ef2cdb-09f1-40a3-a83c-b8e263a21431",
-  "walletId": 3,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfdt3nnME1dfOB15aAfHUh",
-  "createdAt": "2026-04-18T20:39:03.727391Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544743600-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "db92a65c-7250-48a4-bd43-6c8433014f29",
-  "senderId": "e2e-10x-1776544743600-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "dfa83610-7780-4846-9487-654ac2ed4b4a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:12.723255245Z",
-  "updatedAt": "2026-04-18T20:39:12.733579567Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/db92a65c-7250-48a4-bd43-6c8433014f29`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "db92a65c-7250-48a4-bd43-6c8433014f29",
-  "senderId": "e2e-10x-1776544743600-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "dfa83610-7780-4846-9487-654ac2ed4b4a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:12.723255Z",
-  "updatedAt": "2026-04-18T20:39:13.675252Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/dfa83610-7780-4846-9487-654ac2ed4b4a`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "db92a65c-7250-48a4-bd43-6c8433014f29",
-  "senderId": "e2e-10x-1776544743600-3",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:39:12.730616Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/dfa83610-7780-4846-9487-654ac2ed4b4a`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "db92a65c-7250-48a4-bd43-6c8433014f29",
-  "senderId": "e2e-10x-1776544743600-3",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:39:12.730616Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/db92a65c-7250-48a4-bd43-6c8433014f29`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 3,
-  "remittanceId": "db92a65c-7250-48a4-bd43-6c8433014f29",
-  "senderId": "e2e-10x-1776544743600-3",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "dfa83610-7780-4846-9487-654ac2ed4b4a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:12.723255Z",
-  "updatedAt": "2026-04-18T20:39:17.010958Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 4 — `e2e-10x-1776544759716-4`
-
-- walletId: `4`  solanaAddress: `7MgfRxGAhfwZJuE1qVXjiSJxSjBRXSuSAgamHLhHueAv`
-- fundingId: `6806d8a1-76b4-474f-8fdb-6c8cf42056c1`  paymentIntentId: `pi_3TNfe93nnME1dfOB1h1PTW0q`
-- remittanceId: `4d37df17-1f5a-4866-aec4-4592d2de7360`  claimTokenId: `82913d08-9c4c-4691-96de-6de874a3b73e`
-- final status: **DELIVERED**  elapsed: 46.9s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 16
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544759716-4"
-}
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "userId": "e2e-10x-1776544759716-4",
-  "solanaAddress": "7MgfRxGAhfwZJuE1qVXjiSJxSjBRXSuSAgamHLhHueAv",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:39:19.855974086Z",
-  "updatedAt": "2026-04-18T20:39:19.855974086Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/4/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "6806d8a1-76b4-474f-8fdb-6c8cf42056c1",
-  "walletId": 4,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfe93nnME1dfOB1h1PTW0q",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:39:19.871769818Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/6806d8a1-76b4-474f-8fdb-6c8cf42056c1`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "6806d8a1-76b4-474f-8fdb-6c8cf42056c1",
-  "walletId": 4,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfe93nnME1dfOB1h1PTW0q",
-  "createdAt": "2026-04-18T20:39:19.871770Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544759716-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "4d37df17-1f5a-4866-aec4-4592d2de7360",
-  "senderId": "e2e-10x-1776544759716-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "82913d08-9c4c-4691-96de-6de874a3b73e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:29.127759305Z",
-  "updatedAt": "2026-04-18T20:39:29.133621965Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/4d37df17-1f5a-4866-aec4-4592d2de7360`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "4d37df17-1f5a-4866-aec4-4592d2de7360",
-  "senderId": "e2e-10x-1776544759716-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "82913d08-9c4c-4691-96de-6de874a3b73e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:29.127759Z",
-  "updatedAt": "2026-04-18T20:40:00.178513Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/82913d08-9c4c-4691-96de-6de874a3b73e`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "4d37df17-1f5a-4866-aec4-4592d2de7360",
-  "senderId": "e2e-10x-1776544759716-4",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:39:29.131885Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/82913d08-9c4c-4691-96de-6de874a3b73e`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "4d37df17-1f5a-4866-aec4-4592d2de7360",
-  "senderId": "e2e-10x-1776544759716-4",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:39:29.131885Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/4d37df17-1f5a-4866-aec4-4592d2de7360`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 4,
-  "remittanceId": "4d37df17-1f5a-4866-aec4-4592d2de7360",
-  "senderId": "e2e-10x-1776544759716-4",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "82913d08-9c4c-4691-96de-6de874a3b73e",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:39:29.127759Z",
-  "updatedAt": "2026-04-18T20:40:04.097028Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 5 — `e2e-10x-1776544806648-5`
-
-- walletId: `5`  solanaAddress: `9xUbYQy64AvxvVUPLkHVugaFTZn6hnjeL4QbPs8WmkKF`
-- fundingId: `9c37eed4-01bb-42ae-b890-b9946a50531b`  paymentIntentId: `pi_3TNfeu3nnME1dfOB0DQil9Ov`
-- remittanceId: `22cf8aae-42cb-4180-a602-c2a2ab0ec79b`  claimTokenId: `b9f65afd-cc42-414c-b37c-29b55acf2b1a`
-- final status: **DELIVERED**  elapsed: 16.6s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 17
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544806648-5"
-}
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "userId": "e2e-10x-1776544806648-5",
-  "solanaAddress": "9xUbYQy64AvxvVUPLkHVugaFTZn6hnjeL4QbPs8WmkKF",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:40:06.732436440Z",
-  "updatedAt": "2026-04-18T20:40:06.732436440Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/5/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "9c37eed4-01bb-42ae-b890-b9946a50531b",
-  "walletId": 5,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfeu3nnME1dfOB0DQil9Ov",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:40:06.745684717Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/9c37eed4-01bb-42ae-b890-b9946a50531b`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "9c37eed4-01bb-42ae-b890-b9946a50531b",
-  "walletId": 5,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfeu3nnME1dfOB0DQil9Ov",
-  "createdAt": "2026-04-18T20:40:06.745685Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544806648-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "22cf8aae-42cb-4180-a602-c2a2ab0ec79b",
-  "senderId": "e2e-10x-1776544806648-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "b9f65afd-cc42-414c-b37c-29b55acf2b1a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:40:16.251870801Z",
-  "updatedAt": "2026-04-18T20:40:16.255556505Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/22cf8aae-42cb-4180-a602-c2a2ab0ec79b`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "22cf8aae-42cb-4180-a602-c2a2ab0ec79b",
-  "senderId": "e2e-10x-1776544806648-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "b9f65afd-cc42-414c-b37c-29b55acf2b1a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:40:16.251871Z",
-  "updatedAt": "2026-04-18T20:40:17.280969Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/b9f65afd-cc42-414c-b37c-29b55acf2b1a`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "22cf8aae-42cb-4180-a602-c2a2ab0ec79b",
-  "senderId": "e2e-10x-1776544806648-5",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:40:16.253890Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/b9f65afd-cc42-414c-b37c-29b55acf2b1a`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "22cf8aae-42cb-4180-a602-c2a2ab0ec79b",
-  "senderId": "e2e-10x-1776544806648-5",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:40:16.253890Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/22cf8aae-42cb-4180-a602-c2a2ab0ec79b`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 5,
-  "remittanceId": "22cf8aae-42cb-4180-a602-c2a2ab0ec79b",
-  "senderId": "e2e-10x-1776544806648-5",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "b9f65afd-cc42-414c-b37c-29b55acf2b1a",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:40:16.251871Z",
-  "updatedAt": "2026-04-18T20:40:20.651686Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 6 — `e2e-10x-1776544823207-6`
-
-- walletId: `6`  solanaAddress: `CG8ikGdacGfxyaiJVedGf5agz28ffYgkmt4PN1JF4NF2`
-- fundingId: `eb0bc73a-a30e-4d31-96d4-f443a823d6cc`  paymentIntentId: `pi_3TNffg3nnME1dfOB1MVsm1VK`
-- remittanceId: `2c417e26-74eb-41b9-85c7-04a2bb10a70d`  claimTokenId: `e0447639-ac9f-47d3-8587-585a52aba94b`
-- final status: **DELIVERED**  elapsed: 79.2s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 18
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544823207-6"
-}
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "userId": "e2e-10x-1776544823207-6",
-  "solanaAddress": "CG8ikGdacGfxyaiJVedGf5agz28ffYgkmt4PN1JF4NF2",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:40:55.363840871Z",
-  "updatedAt": "2026-04-18T20:40:55.363840871Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/6/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "eb0bc73a-a30e-4d31-96d4-f443a823d6cc",
-  "walletId": 6,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNffg3nnME1dfOB1MVsm1VK",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:40:55.409724737Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/eb0bc73a-a30e-4d31-96d4-f443a823d6cc`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "eb0bc73a-a30e-4d31-96d4-f443a823d6cc",
-  "walletId": 6,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNffg3nnME1dfOB1MVsm1VK",
-  "createdAt": "2026-04-18T20:40:55.409725Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544823207-6",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "2c417e26-74eb-41b9-85c7-04a2bb10a70d",
-  "senderId": "e2e-10x-1776544823207-6",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "e0447639-ac9f-47d3-8587-585a52aba94b",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:05.096232361Z",
-  "updatedAt": "2026-04-18T20:41:05.101448231Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/2c417e26-74eb-41b9-85c7-04a2bb10a70d`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "2c417e26-74eb-41b9-85c7-04a2bb10a70d",
-  "senderId": "e2e-10x-1776544823207-6",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "e0447639-ac9f-47d3-8587-585a52aba94b",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:05.096232Z",
-  "updatedAt": "2026-04-18T20:41:36.311689Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/e0447639-ac9f-47d3-8587-585a52aba94b`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "2c417e26-74eb-41b9-85c7-04a2bb10a70d",
-  "senderId": "e2e-10x-1776544823207-6",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:41:05.099944Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/e0447639-ac9f-47d3-8587-585a52aba94b`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "2c417e26-74eb-41b9-85c7-04a2bb10a70d",
-  "senderId": "e2e-10x-1776544823207-6",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:41:05.099944Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/2c417e26-74eb-41b9-85c7-04a2bb10a70d`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 6,
-  "remittanceId": "2c417e26-74eb-41b9-85c7-04a2bb10a70d",
-  "senderId": "e2e-10x-1776544823207-6",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "e0447639-ac9f-47d3-8587-585a52aba94b",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:05.096232Z",
-  "updatedAt": "2026-04-18T20:41:39.855014Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 7 — `e2e-10x-1776544902383-7`
-
-- walletId: `7`  solanaAddress: `pdx3wUFtVSVESU8deMy71FX2jKF1z7faXU1UaE94C2V`
-- fundingId: `32accf8d-9eff-4a83-8aa6-8ed39c4b00ab`  paymentIntentId: `pi_3TNfgS3nnME1dfOB1LqWa8H9`
-- remittanceId: `65cc4519-b784-4ca2-8488-84d4cadb246f`  claimTokenId: `face7b80-45e5-44c4-a200-b7db4fb0065f`
-- final status: **DELIVERED**  elapsed: 80.3s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 19
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544902383-7"
-}
-```
-
-Response:
-```json
-{
-  "id": 7,
-  "userId": "e2e-10x-1776544902383-7",
-  "solanaAddress": "pdx3wUFtVSVESU8deMy71FX2jKF1z7faXU1UaE94C2V",
-  "availableBalance": 0,
-  "totalBalance": 0,
-  "createdAt": "2026-04-18T20:41:42.517385288Z",
-  "updatedAt": "2026-04-18T20:41:42.517385288Z"
-}
-```
-
-#### 2-initiate-fund
-
-`POST /api/wallets/7/fund`  → **HTTP 201**
-
-Request:
-```json
-{
-  "amount": 1.0
-}
-```
-
-Response:
-```json
-{
-  "fundingId": "32accf8d-9eff-4a83-8aa6-8ed39c4b00ab",
-  "walletId": 7,
-  "amountUsdc": 1.0,
-  "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfgS3nnME1dfOB1LqWa8H9",
-  "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:41:42.537205099Z"
-}
-```
-
-#### 3-poll-funded
-
-`GET /api/funding-orders/32accf8d-9eff-4a83-8aa6-8ed39c4b00ab`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "fundingId": "32accf8d-9eff-4a83-8aa6-8ed39c4b00ab",
-  "walletId": 7,
-  "amountUsdc": 1.0,
-  "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfgS3nnME1dfOB1LqWa8H9",
-  "createdAt": "2026-04-18T20:41:42.537205Z"
-}
-```
-
-#### 4-create-remittance
-
-`POST /api/remittances`  → **HTTP 201**
-
-Request:
-```json
-{
-  "senderId": "e2e-10x-1776544902383-7",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0
-}
-```
-
-Response:
-```json
-{
-  "id": 7,
-  "remittanceId": "65cc4519-b784-4ca2-8488-84d4cadb246f",
-  "senderId": "e2e-10x-1776544902383-7",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "INITIATED",
-  "escrowPda": null,
-  "claimTokenId": "face7b80-45e5-44c4-a200-b7db4fb0065f",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:52.068536146Z",
-  "updatedAt": "2026-04-18T20:41:52.073649015Z",
-  "expiresAt": null
-}
-```
-
-#### 5-poll-escrowed
-
-`GET /api/remittances/65cc4519-b784-4ca2-8488-84d4cadb246f`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 7,
-  "remittanceId": "65cc4519-b784-4ca2-8488-84d4cadb246f",
-  "senderId": "e2e-10x-1776544902383-7",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "escrowPda": null,
-  "claimTokenId": "face7b80-45e5-44c4-a200-b7db4fb0065f",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:52.068536Z",
-  "updatedAt": "2026-04-18T20:42:55.878818Z",
-  "expiresAt": null
-}
-```
-
-#### 6-get-claim
-
-`GET /api/claims/face7b80-45e5-44c4-a200-b7db4fb0065f`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "remittanceId": "65cc4519-b784-4ca2-8488-84d4cadb246f",
-  "senderId": "e2e-10x-1776544902383-7",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": false,
-  "expiresAt": "2026-04-20T20:41:52.072290Z"
-}
-```
-
-#### 7-submit-claim
-
-`POST /api/claims/face7b80-45e5-44c4-a200-b7db4fb0065f`  → **HTTP 200**
-
-Request:
-```json
-{
-  "upiId": "test@upi"
-}
-```
-
-Response:
-```json
-{
-  "remittanceId": "65cc4519-b784-4ca2-8488-84d4cadb246f",
-  "senderId": "e2e-10x-1776544902383-7",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "ESCROWED",
-  "claimed": true,
-  "expiresAt": "2026-04-20T20:41:52.072290Z"
-}
-```
-
-#### 8-poll-delivered
-
-`GET /api/remittances/65cc4519-b784-4ca2-8488-84d4cadb246f`  → **HTTP 200**
-
-Request:
-```json
-(no body)
-```
-
-Response:
-```json
-{
-  "id": 7,
-  "remittanceId": "65cc4519-b784-4ca2-8488-84d4cadb246f",
-  "senderId": "e2e-10x-1776544902383-7",
-  "recipientPhone": "+919876543210",
-  "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
-  "status": "DELIVERED",
-  "escrowPda": null,
-  "claimTokenId": "face7b80-45e5-44c4-a200-b7db4fb0065f",
-  "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:41:52.068536Z",
-  "updatedAt": "2026-04-18T20:43:00.164488Z",
-  "expiresAt": null
-}
-```
-
----
-
-### Customer 8 — `e2e-10x-1776544982690-8`
-
-- walletId: `8`  solanaAddress: `H3m2y6zyjoReYq287YMPt8zY7pzyRQNgWpAVdFW8V6o4`
-- fundingId: `2185ee8c-4040-483a-9fbd-74fae37f2b67`  paymentIntentId: `pi_3TNfhk3nnME1dfOB08abFjKl`
-- remittanceId: `9daf9188-9192-453f-894b-73e3b300f51e`  claimTokenId: `94374633-dc1f-410e-8b29-efe0f81efb92`
-- final status: **DELIVERED**  elapsed: 16.8s  **PASS**
-- On-chain USDC after fund: 1
-- Claim authority USDC after claim: 20
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 201**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544982690-8"
+  "userId": "e2e-10x-1776597783066-1"
 }
 ```
 
@@ -1581,12 +49,12 @@ Response:
 ```json
 {
   "id": 8,
-  "userId": "e2e-10x-1776544982690-8",
-  "solanaAddress": "H3m2y6zyjoReYq287YMPt8zY7pzyRQNgWpAVdFW8V6o4",
+  "userId": "e2e-10x-1776597783066-1",
+  "solanaAddress": "38LhK36pBiBY6PvaG1PUB4tZemCxMFWxPF4HbnGLmJAj",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-18T20:43:02.790865965Z",
-  "updatedAt": "2026-04-18T20:43:02.790865965Z"
+  "createdAt": "2026-04-19T11:23:03.237617654Z",
+  "updatedAt": "2026-04-19T11:23:03.237617654Z"
 }
 ```
 
@@ -1604,19 +72,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "2185ee8c-4040-483a-9fbd-74fae37f2b67",
+  "fundingId": "c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28",
   "walletId": 8,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfhk3nnME1dfOB08abFjKl",
+  "stripePaymentIntentId": "pi_3TNtRM3nnME1dfOB1jvCcDMS",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:43:02.808638862Z"
+  "createdAt": "2026-04-19T11:23:03.262730811Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/2185ee8c-4040-483a-9fbd-74fae37f2b67`  → **HTTP 200**
+`GET /api/funding-orders/c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28`  → **HTTP 200**
 
 Request:
 ```json
@@ -1626,12 +94,12 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "2185ee8c-4040-483a-9fbd-74fae37f2b67",
+  "fundingId": "c9cd5fa8-7c67-403f-8a8b-df8c16cb3b28",
   "walletId": 8,
   "amountUsdc": 1.0,
   "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfhk3nnME1dfOB08abFjKl",
-  "createdAt": "2026-04-18T20:43:02.808639Z"
+  "stripePaymentIntentId": "pi_3TNtRM3nnME1dfOB1jvCcDMS",
+  "createdAt": "2026-04-19T11:23:03.262731Z"
 }
 ```
 
@@ -1642,7 +110,7 @@ Response:
 Request:
 ```json
 {
-  "senderId": "e2e-10x-1776544982690-8",
+  "senderId": "e2e-10x-1776597783066-1",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0
 }
@@ -1651,26 +119,26 @@ Request:
 Response:
 ```json
 {
-  "id": 8,
-  "remittanceId": "9daf9188-9192-453f-894b-73e3b300f51e",
-  "senderId": "e2e-10x-1776544982690-8",
+  "id": 2,
+  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
+  "senderId": "e2e-10x-1776597783066-1",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "94374633-dc1f-410e-8b29-efe0f81efb92",
+  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:12.568963206Z",
-  "updatedAt": "2026-04-18T20:43:12.572987451Z",
+  "createdAt": "2026-04-19T11:23:12.893929266Z",
+  "updatedAt": "2026-04-19T11:23:12.897653796Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/9daf9188-9192-453f-894b-73e3b300f51e`  → **HTTP 200**
+`GET /api/remittances/24eb9ede-3bd3-40c2-9630-951ada545130`  → **HTTP 200**
 
 Request:
 ```json
@@ -1680,26 +148,26 @@ Request:
 Response:
 ```json
 {
-  "id": 8,
-  "remittanceId": "9daf9188-9192-453f-894b-73e3b300f51e",
-  "senderId": "e2e-10x-1776544982690-8",
+  "id": 2,
+  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
+  "senderId": "e2e-10x-1776597783066-1",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "94374633-dc1f-410e-8b29-efe0f81efb92",
+  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:12.568963Z",
-  "updatedAt": "2026-04-18T20:43:13.833559Z",
+  "createdAt": "2026-04-19T11:23:12.893929Z",
+  "updatedAt": "2026-04-19T11:23:13.765042Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/94374633-dc1f-410e-8b29-efe0f81efb92`  → **HTTP 200**
+`GET /api/claims/60e97f79-f86d-4227-aa13-532400e8f7db`  → **HTTP 200**
 
 Request:
 ```json
@@ -1709,20 +177,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "9daf9188-9192-453f-894b-73e3b300f51e",
-  "senderId": "e2e-10x-1776544982690-8",
+  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
+  "senderId": "e2e-10x-1776597783066-1",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-20T20:43:12.571695Z"
+  "expiresAt": "2026-04-21T11:23:12.896743Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/94374633-dc1f-410e-8b29-efe0f81efb92`  → **HTTP 200**
+`POST /api/claims/60e97f79-f86d-4227-aa13-532400e8f7db`  → **HTTP 200**
 
 Request:
 ```json
@@ -1734,20 +202,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "9daf9188-9192-453f-894b-73e3b300f51e",
-  "senderId": "e2e-10x-1776544982690-8",
+  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
+  "senderId": "e2e-10x-1776597783066-1",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-20T20:43:12.571695Z"
+  "expiresAt": "2026-04-21T11:23:12.896743Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/9daf9188-9192-453f-894b-73e3b300f51e`  → **HTTP 200**
+`GET /api/remittances/24eb9ede-3bd3-40c2-9630-951ada545130`  → **HTTP 200**
 
 Request:
 ```json
@@ -1757,65 +225,34 @@ Request:
 Response:
 ```json
 {
-  "id": 8,
-  "remittanceId": "9daf9188-9192-453f-894b-73e3b300f51e",
-  "senderId": "e2e-10x-1776544982690-8",
+  "id": 2,
+  "remittanceId": "24eb9ede-3bd3-40c2-9630-951ada545130",
+  "senderId": "e2e-10x-1776597783066-1",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "94374633-dc1f-410e-8b29-efe0f81efb92",
+  "claimTokenId": "60e97f79-f86d-4227-aa13-532400e8f7db",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:12.568963Z",
-  "updatedAt": "2026-04-18T20:43:17.015649Z",
+  "createdAt": "2026-04-19T11:23:12.893929Z",
+  "updatedAt": "2026-04-19T11:23:17.783516Z",
   "expiresAt": null
 }
 ```
 
 ---
 
-### Customer 9 — `e2e-10x-1776544999530-9`
+### Customer 2 — `e2e-10x-1776597799939-2`
 
-- walletId: `None`  solanaAddress: `None`
-- fundingId: `None`  paymentIntentId: `None`
-- remittanceId: `None`  claimTokenId: `None`
-- final status: **None**  elapsed: 30.1s  **FAIL: create wallet failed — expected 201, see detail log**
-- On-chain USDC after fund: None
-- Claim authority USDC after claim: None
-
-#### 1-create-wallet
-
-`POST /api/wallets`  → **HTTP 500**
-
-Request:
-```json
-{
-  "userId": "e2e-10x-1776544999530-9"
-}
-```
-
-Response:
-```json
-{
-  "timestamp": "2026-04-18T20:43:49.641Z",
-  "status": 500,
-  "error": "Internal Server Error",
-  "path": "/api/wallets"
-}
-```
-
----
-
-### Customer 10 — `e2e-10x-1776545029653-10`
-
-- walletId: `9`  solanaAddress: `DD8Ac8hTuwkjFauRJ9NkLgDazTSC3LRXPJgKsAyzgvNy`
-- fundingId: `25591127-3111-4ee8-a877-c00bc0f331f0`  paymentIntentId: `pi_3TNfiV3nnME1dfOB0mkk4Ehk`
-- remittanceId: `8749a570-a49d-435b-ae49-c1ae8e6b64b1`  claimTokenId: `6944bf13-810b-48d7-852c-85e31f5d9cf7`
-- final status: **DELIVERED**  elapsed: 16.8s  **PASS**
+- walletId: `9`  solanaAddress: `HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht`
+- fundingId: `51d94938-615d-4587-ba12-851cea5710af`  paymentIntentId: `pi_3TNtS93nnME1dfOB0r2lPGyp`
+- remittanceId: `c7f52cb1-9965-40d8-9e1a-927008dd9da6`  claimTokenId: `44d16798-e4fa-4530-aa6d-1e0a6d81c767`
+- final status: **DELIVERED**  elapsed: 49.1s  **PASS**
 - On-chain USDC after fund: 1
-- Claim authority USDC after claim: 21
+- Claim authority USDC after claim: 28
+- Payout: id=`pout_wm_4fgovobnrnkj` status=`processing`
 
 #### 1-create-wallet
 
@@ -1824,7 +261,7 @@ Response:
 Request:
 ```json
 {
-  "userId": "e2e-10x-1776545029653-10"
+  "userId": "e2e-10x-1776597799939-2"
 }
 ```
 
@@ -1832,12 +269,12 @@ Response:
 ```json
 {
   "id": 9,
-  "userId": "e2e-10x-1776545029653-10",
-  "solanaAddress": "DD8Ac8hTuwkjFauRJ9NkLgDazTSC3LRXPJgKsAyzgvNy",
+  "userId": "e2e-10x-1776597799939-2",
+  "solanaAddress": "HjHG4A5H8cLsac9WPpAB3B6aqJpbWfGrqkDvpX4Zfsht",
   "availableBalance": 0,
   "totalBalance": 0,
-  "createdAt": "2026-04-18T20:43:49.779329695Z",
-  "updatedAt": "2026-04-18T20:43:49.779329695Z"
+  "createdAt": "2026-04-19T11:23:52.149506393Z",
+  "updatedAt": "2026-04-19T11:23:52.149506393Z"
 }
 ```
 
@@ -1855,19 +292,19 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "25591127-3111-4ee8-a877-c00bc0f331f0",
+  "fundingId": "51d94938-615d-4587-ba12-851cea5710af",
   "walletId": 9,
   "amountUsdc": 1.0,
   "status": "PAYMENT_CONFIRMED",
-  "stripePaymentIntentId": "pi_3TNfiV3nnME1dfOB0mkk4Ehk",
+  "stripePaymentIntentId": "pi_3TNtS93nnME1dfOB0r2lPGyp",
   "stripeClientSecret": "***REDACTED***",
-  "createdAt": "2026-04-18T20:43:49.804239709Z"
+  "createdAt": "2026-04-19T11:23:52.226785757Z"
 }
 ```
 
 #### 3-poll-funded
 
-`GET /api/funding-orders/25591127-3111-4ee8-a877-c00bc0f331f0`  → **HTTP 200**
+`GET /api/funding-orders/51d94938-615d-4587-ba12-851cea5710af`  → **HTTP 200**
 
 Request:
 ```json
@@ -1877,12 +314,12 @@ Request:
 Response:
 ```json
 {
-  "fundingId": "25591127-3111-4ee8-a877-c00bc0f331f0",
+  "fundingId": "51d94938-615d-4587-ba12-851cea5710af",
   "walletId": 9,
   "amountUsdc": 1.0,
   "status": "FUNDED",
-  "stripePaymentIntentId": "pi_3TNfiV3nnME1dfOB0mkk4Ehk",
-  "createdAt": "2026-04-18T20:43:49.804240Z"
+  "stripePaymentIntentId": "pi_3TNtS93nnME1dfOB0r2lPGyp",
+  "createdAt": "2026-04-19T11:23:52.226786Z"
 }
 ```
 
@@ -1893,7 +330,7 @@ Response:
 Request:
 ```json
 {
-  "senderId": "e2e-10x-1776545029653-10",
+  "senderId": "e2e-10x-1776597799939-2",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0
 }
@@ -1902,26 +339,26 @@ Request:
 Response:
 ```json
 {
-  "id": 9,
-  "remittanceId": "8749a570-a49d-435b-ae49-c1ae8e6b64b1",
-  "senderId": "e2e-10x-1776545029653-10",
+  "id": 3,
+  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
+  "senderId": "e2e-10x-1776597799939-2",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "INITIATED",
   "escrowPda": null,
-  "claimTokenId": "6944bf13-810b-48d7-852c-85e31f5d9cf7",
+  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:59.477564024Z",
-  "updatedAt": "2026-04-18T20:43:59.486155431Z",
+  "createdAt": "2026-04-19T11:24:01.942099622Z",
+  "updatedAt": "2026-04-19T11:24:01.946288239Z",
   "expiresAt": null
 }
 ```
 
 #### 5-poll-escrowed
 
-`GET /api/remittances/8749a570-a49d-435b-ae49-c1ae8e6b64b1`  → **HTTP 200**
+`GET /api/remittances/c7f52cb1-9965-40d8-9e1a-927008dd9da6`  → **HTTP 200**
 
 Request:
 ```json
@@ -1931,26 +368,26 @@ Request:
 Response:
 ```json
 {
-  "id": 9,
-  "remittanceId": "8749a570-a49d-435b-ae49-c1ae8e6b64b1",
-  "senderId": "e2e-10x-1776545029653-10",
+  "id": 3,
+  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
+  "senderId": "e2e-10x-1776597799939-2",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "escrowPda": null,
-  "claimTokenId": "6944bf13-810b-48d7-852c-85e31f5d9cf7",
+  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:59.477564Z",
-  "updatedAt": "2026-04-18T20:44:00.757699Z",
+  "createdAt": "2026-04-19T11:24:01.942100Z",
+  "updatedAt": "2026-04-19T11:24:03.070156Z",
   "expiresAt": null
 }
 ```
 
 #### 6-get-claim
 
-`GET /api/claims/6944bf13-810b-48d7-852c-85e31f5d9cf7`  → **HTTP 200**
+`GET /api/claims/44d16798-e4fa-4530-aa6d-1e0a6d81c767`  → **HTTP 200**
 
 Request:
 ```json
@@ -1960,20 +397,20 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "8749a570-a49d-435b-ae49-c1ae8e6b64b1",
-  "senderId": "e2e-10x-1776545029653-10",
+  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
+  "senderId": "e2e-10x-1776597799939-2",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": false,
-  "expiresAt": "2026-04-20T20:43:59.483835Z"
+  "expiresAt": "2026-04-21T11:24:01.945198Z"
 }
 ```
 
 #### 7-submit-claim
 
-`POST /api/claims/6944bf13-810b-48d7-852c-85e31f5d9cf7`  → **HTTP 200**
+`POST /api/claims/44d16798-e4fa-4530-aa6d-1e0a6d81c767`  → **HTTP 200**
 
 Request:
 ```json
@@ -1985,20 +422,1263 @@ Request:
 Response:
 ```json
 {
-  "remittanceId": "8749a570-a49d-435b-ae49-c1ae8e6b64b1",
-  "senderId": "e2e-10x-1776545029653-10",
+  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
+  "senderId": "e2e-10x-1776597799939-2",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "ESCROWED",
   "claimed": true,
-  "expiresAt": "2026-04-20T20:43:59.483835Z"
+  "expiresAt": "2026-04-21T11:24:01.945198Z"
 }
 ```
 
 #### 8-poll-delivered
 
-`GET /api/remittances/8749a570-a49d-435b-ae49-c1ae8e6b64b1`  → **HTTP 200**
+`GET /api/remittances/c7f52cb1-9965-40d8-9e1a-927008dd9da6`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 3,
+  "remittanceId": "c7f52cb1-9965-40d8-9e1a-927008dd9da6",
+  "senderId": "e2e-10x-1776597799939-2",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "44d16798-e4fa-4530-aa6d-1e0a6d81c767",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:24:01.942100Z",
+  "updatedAt": "2026-04-19T11:24:06.602173Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 3 — `e2e-10x-1776597849019-3`
+
+- walletId: `10`  solanaAddress: `GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ`
+- fundingId: `6f108599-3f3a-4e1c-bf41-d3e5b5c9d488`  paymentIntentId: `pi_3TNtSQ3nnME1dfOB0siozHXF`
+- remittanceId: `53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  claimTokenId: `88d625be-bb00-4fb2-be56-f2d2b452683e`
+- final status: **DELIVERED**  elapsed: 46.4s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 29
+- Payout: id=`pout_wm_gyf0zd8q7idy` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776597849019-3"
+}
+```
+
+Response:
+```json
+{
+  "id": 10,
+  "userId": "e2e-10x-1776597849019-3",
+  "solanaAddress": "GvqrmXdXV6Eak8NRP3F24FAQ2EzP3JkXbzkXarbyeXfZ",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:24:09.110994670Z",
+  "updatedAt": "2026-04-19T11:24:09.110994670Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/10/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "6f108599-3f3a-4e1c-bf41-d3e5b5c9d488",
+  "walletId": 10,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtSQ3nnME1dfOB0siozHXF",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:24:09.128502434Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/6f108599-3f3a-4e1c-bf41-d3e5b5c9d488`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "6f108599-3f3a-4e1c-bf41-d3e5b5c9d488",
+  "walletId": 10,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtSQ3nnME1dfOB0siozHXF",
+  "createdAt": "2026-04-19T11:24:09.128502Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776597849019-3",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 4,
+  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
+  "senderId": "e2e-10x-1776597849019-3",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:24:18.065621408Z",
+  "updatedAt": "2026-04-19T11:24:18.069339354Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 4,
+  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
+  "senderId": "e2e-10x-1776597849019-3",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:24:18.065621Z",
+  "updatedAt": "2026-04-19T11:24:49.479968Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/88d625be-bb00-4fb2-be56-f2d2b452683e`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
+  "senderId": "e2e-10x-1776597849019-3",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:24:18.068118Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/88d625be-bb00-4fb2-be56-f2d2b452683e`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
+  "senderId": "e2e-10x-1776597849019-3",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:24:18.068118Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/53c43ad7-6fda-4b0d-8c6f-310d6218cecc`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 4,
+  "remittanceId": "53c43ad7-6fda-4b0d-8c6f-310d6218cecc",
+  "senderId": "e2e-10x-1776597849019-3",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "88d625be-bb00-4fb2-be56-f2d2b452683e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:24:18.065621Z",
+  "updatedAt": "2026-04-19T11:24:52.866001Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 4 — `e2e-10x-1776597895402-4`
+
+- walletId: `11`  solanaAddress: `UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR`
+- fundingId: `f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f`  paymentIntentId: `pi_3TNtTA3nnME1dfOB06dB2yza`
+- remittanceId: `3b296846-fe40-41a3-ade8-eda73f5e8af2`  claimTokenId: `607e544f-2ec9-4d08-a684-947c25a2c1be`
+- final status: **DELIVERED**  elapsed: 16.7s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 30
+- Payout: id=`pout_wm_kvrbr3peaes8` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776597895402-4"
+}
+```
+
+Response:
+```json
+{
+  "id": 11,
+  "userId": "e2e-10x-1776597895402-4",
+  "solanaAddress": "UqtBgvFcJkagupTZn14Wwe1NkhNj6iD8rgQZ2omyTUR",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:24:55.485703917Z",
+  "updatedAt": "2026-04-19T11:24:55.485703917Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/11/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f",
+  "walletId": 11,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtTA3nnME1dfOB06dB2yza",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:24:55.503511475Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "f0b2e2f6-b26e-4ac1-93d8-d7b50d85fa5f",
+  "walletId": 11,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtTA3nnME1dfOB06dB2yza",
+  "createdAt": "2026-04-19T11:24:55.503511Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776597895402-4",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 5,
+  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
+  "senderId": "e2e-10x-1776597895402-4",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:05.082749926Z",
+  "updatedAt": "2026-04-19T11:25:05.090090234Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/3b296846-fe40-41a3-ade8-eda73f5e8af2`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 5,
+  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
+  "senderId": "e2e-10x-1776597895402-4",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:05.082750Z",
+  "updatedAt": "2026-04-19T11:25:06.166160Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/607e544f-2ec9-4d08-a684-947c25a2c1be`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
+  "senderId": "e2e-10x-1776597895402-4",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:25:05.087736Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/607e544f-2ec9-4d08-a684-947c25a2c1be`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
+  "senderId": "e2e-10x-1776597895402-4",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:25:05.087736Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/3b296846-fe40-41a3-ade8-eda73f5e8af2`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 5,
+  "remittanceId": "3b296846-fe40-41a3-ade8-eda73f5e8af2",
+  "senderId": "e2e-10x-1776597895402-4",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "607e544f-2ec9-4d08-a684-947c25a2c1be",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:05.082750Z",
+  "updatedAt": "2026-04-19T11:25:09.402940Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 5 — `e2e-10x-1776597912110-5`
+
+- walletId: `12`  solanaAddress: `9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g`
+- fundingId: `4d43b24a-0f9b-4f01-8b98-3c8342e80f53`  paymentIntentId: `pi_3TNtTy3nnME1dfOB1uBLkSQH`
+- remittanceId: `721ffdb1-9f30-426b-97ee-565f197549d2`  claimTokenId: `fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`
+- final status: **DELIVERED**  elapsed: 113.0s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 31
+- Payout: id=`pout_wm_tg980vmggklj` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776597912110-5"
+}
+```
+
+Response:
+```json
+{
+  "id": 12,
+  "userId": "e2e-10x-1776597912110-5",
+  "solanaAddress": "9RsH8fyUypCxnz4xD1KF6MhxaU6cfU4jGSkbGcRKwS5g",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:25:44.274575379Z",
+  "updatedAt": "2026-04-19T11:25:44.274575379Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/12/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "4d43b24a-0f9b-4f01-8b98-3c8342e80f53",
+  "walletId": 12,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtTy3nnME1dfOB1uBLkSQH",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:25:44.340020702Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/4d43b24a-0f9b-4f01-8b98-3c8342e80f53`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "4d43b24a-0f9b-4f01-8b98-3c8342e80f53",
+  "walletId": 12,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtTy3nnME1dfOB1uBLkSQH",
+  "createdAt": "2026-04-19T11:25:44.340021Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776597912110-5",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 6,
+  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
+  "senderId": "e2e-10x-1776597912110-5",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:54.292973907Z",
+  "updatedAt": "2026-04-19T11:25:54.302824570Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/721ffdb1-9f30-426b-97ee-565f197549d2`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 6,
+  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
+  "senderId": "e2e-10x-1776597912110-5",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:54.292974Z",
+  "updatedAt": "2026-04-19T11:26:58.460790Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
+  "senderId": "e2e-10x-1776597912110-5",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:25:54.297624Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
+  "senderId": "e2e-10x-1776597912110-5",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:25:54.297624Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/721ffdb1-9f30-426b-97ee-565f197549d2`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 6,
+  "remittanceId": "721ffdb1-9f30-426b-97ee-565f197549d2",
+  "senderId": "e2e-10x-1776597912110-5",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "fdc7ec65-d273-4d6a-83d9-df68e3fbe5cc",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:25:54.292974Z",
+  "updatedAt": "2026-04-19T11:27:02.456120Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 6 — `e2e-10x-1776598025160-6`
+
+- walletId: `13`  solanaAddress: `51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV`
+- fundingId: `108dfcb4-9e95-47ee-a7c1-7b5c60c0e437`  paymentIntentId: `pi_3TNtVG3nnME1dfOB1t6dXwZU`
+- remittanceId: `b9d7812a-aae2-448e-8b40-368810451de6`  claimTokenId: `9aea7175-5647-4f1d-90f4-80126fdc28a7`
+- final status: **DELIVERED**  elapsed: 50.8s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 32
+- Payout: id=`pout_wm_pqbbwa8babew` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776598025160-6"
+}
+```
+
+Response:
+```json
+{
+  "id": 13,
+  "userId": "e2e-10x-1776598025160-6",
+  "solanaAddress": "51GMAD8xXDEN9jr8virrMkMBXVrG2RAV49etrsMbs6gV",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:27:05.320014949Z",
+  "updatedAt": "2026-04-19T11:27:05.320014949Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/13/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "108dfcb4-9e95-47ee-a7c1-7b5c60c0e437",
+  "walletId": 13,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtVG3nnME1dfOB1t6dXwZU",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:27:05.352018460Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/108dfcb4-9e95-47ee-a7c1-7b5c60c0e437`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "108dfcb4-9e95-47ee-a7c1-7b5c60c0e437",
+  "walletId": 13,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtVG3nnME1dfOB1t6dXwZU",
+  "createdAt": "2026-04-19T11:27:05.352018Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776598025160-6",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 7,
+  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
+  "senderId": "e2e-10x-1776598025160-6",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:27:15.108897695Z",
+  "updatedAt": "2026-04-19T11:27:15.118965735Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/b9d7812a-aae2-448e-8b40-368810451de6`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 7,
+  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
+  "senderId": "e2e-10x-1776598025160-6",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:27:15.108898Z",
+  "updatedAt": "2026-04-19T11:27:48.830549Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/9aea7175-5647-4f1d-90f4-80126fdc28a7`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
+  "senderId": "e2e-10x-1776598025160-6",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:27:15.116943Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/9aea7175-5647-4f1d-90f4-80126fdc28a7`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
+  "senderId": "e2e-10x-1776598025160-6",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:27:15.116943Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/b9d7812a-aae2-448e-8b40-368810451de6`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 7,
+  "remittanceId": "b9d7812a-aae2-448e-8b40-368810451de6",
+  "senderId": "e2e-10x-1776598025160-6",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "9aea7175-5647-4f1d-90f4-80126fdc28a7",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:27:15.108898Z",
+  "updatedAt": "2026-04-19T11:27:53.242882Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 7 — `e2e-10x-1776598075964-7`
+
+- walletId: `14`  solanaAddress: `Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY`
+- fundingId: `8ee040a8-a3a6-459d-a90f-71138b3d65bd`  paymentIntentId: `pi_3TNtW53nnME1dfOB1KfgIqZa`
+- remittanceId: `1dee3072-adc6-4872-8fbb-593675866249`  claimTokenId: `ac5d8a94-830f-4cf2-802a-24f064e08681`
+- final status: **DELIVERED**  elapsed: 22.9s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 33
+- Payout: id=`pout_wm_6jarhbmk9wio` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776598075964-7"
+}
+```
+
+Response:
+```json
+{
+  "id": 14,
+  "userId": "e2e-10x-1776598075964-7",
+  "solanaAddress": "Fwex4a76GAFvsYEA8XDWYfFu4xBPTNdgmgBa8tzNCdCY",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:27:56.061156720Z",
+  "updatedAt": "2026-04-19T11:27:56.061156720Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/14/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "8ee040a8-a3a6-459d-a90f-71138b3d65bd",
+  "walletId": 14,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtW53nnME1dfOB1KfgIqZa",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:27:56.084879579Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/8ee040a8-a3a6-459d-a90f-71138b3d65bd`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "8ee040a8-a3a6-459d-a90f-71138b3d65bd",
+  "walletId": 14,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtW53nnME1dfOB1KfgIqZa",
+  "createdAt": "2026-04-19T11:27:56.084880Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776598075964-7",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 8,
+  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
+  "senderId": "e2e-10x-1776598075964-7",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:11.801409970Z",
+  "updatedAt": "2026-04-19T11:28:11.808384151Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/1dee3072-adc6-4872-8fbb-593675866249`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 8,
+  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
+  "senderId": "e2e-10x-1776598075964-7",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:11.801410Z",
+  "updatedAt": "2026-04-19T11:28:12.958556Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/ac5d8a94-830f-4cf2-802a-24f064e08681`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
+  "senderId": "e2e-10x-1776598075964-7",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:28:11.805796Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/ac5d8a94-830f-4cf2-802a-24f064e08681`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
+  "senderId": "e2e-10x-1776598075964-7",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:28:11.805796Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/1dee3072-adc6-4872-8fbb-593675866249`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 8,
+  "remittanceId": "1dee3072-adc6-4872-8fbb-593675866249",
+  "senderId": "e2e-10x-1776598075964-7",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "ac5d8a94-830f-4cf2-802a-24f064e08681",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:11.801410Z",
+  "updatedAt": "2026-04-19T11:28:16.173532Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 8 — `e2e-10x-1776598098872-8`
+
+- walletId: `15`  solanaAddress: `CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3`
+- fundingId: `99f047f0-ab7f-415c-9960-66de2917cb54`  paymentIntentId: `pi_3TNtWS3nnME1dfOB1oC0Ax7k`
+- remittanceId: `9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  claimTokenId: `73835f3a-0c6e-4d91-9fc4-0f76391e46ac`
+- final status: **DELIVERED**  elapsed: 16.3s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 34
+- Payout: id=`pout_wm_u5hmkb1zwkd0` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776598098872-8"
+}
+```
+
+Response:
+```json
+{
+  "id": 15,
+  "userId": "e2e-10x-1776598098872-8",
+  "solanaAddress": "CogKwMA8W5oVBhE8fMUKVQKdVBbB6y6uQ5ggCgiytdF3",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:28:18.977911813Z",
+  "updatedAt": "2026-04-19T11:28:18.977911813Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/15/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "99f047f0-ab7f-415c-9960-66de2917cb54",
+  "walletId": 15,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtWS3nnME1dfOB1oC0Ax7k",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:28:18.997408221Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/99f047f0-ab7f-415c-9960-66de2917cb54`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "99f047f0-ab7f-415c-9960-66de2917cb54",
+  "walletId": 15,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtWS3nnME1dfOB1oC0Ax7k",
+  "createdAt": "2026-04-19T11:28:18.997408Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776598098872-8",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 9,
+  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
+  "senderId": "e2e-10x-1776598098872-8",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:27.892978521Z",
+  "updatedAt": "2026-04-19T11:28:27.912344928Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  → **HTTP 200**
 
 Request:
 ```json
@@ -2009,18 +1689,535 @@ Response:
 ```json
 {
   "id": 9,
-  "remittanceId": "8749a570-a49d-435b-ae49-c1ae8e6b64b1",
-  "senderId": "e2e-10x-1776545029653-10",
+  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
+  "senderId": "e2e-10x-1776598098872-8",
   "recipientPhone": "+919876543210",
   "amountUsdc": 1.0,
-  "amountInr": 92.9,
-  "fxRate": 92.896987,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:27.892979Z",
+  "updatedAt": "2026-04-19T11:28:28.804371Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/73835f3a-0c6e-4d91-9fc4-0f76391e46ac`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
+  "senderId": "e2e-10x-1776598098872-8",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:28:27.908348Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/73835f3a-0c6e-4d91-9fc4-0f76391e46ac`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
+  "senderId": "e2e-10x-1776598098872-8",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:28:27.908348Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/9c6d725f-32dc-42df-bc00-3eaff10f8c9d`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 9,
+  "remittanceId": "9c6d725f-32dc-42df-bc00-3eaff10f8c9d",
+  "senderId": "e2e-10x-1776598098872-8",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
   "status": "DELIVERED",
   "escrowPda": null,
-  "claimTokenId": "6944bf13-810b-48d7-852c-85e31f5d9cf7",
+  "claimTokenId": "73835f3a-0c6e-4d91-9fc4-0f76391e46ac",
   "smsNotificationFailed": false,
-  "createdAt": "2026-04-18T20:43:59.477564Z",
-  "updatedAt": "2026-04-18T20:44:03.803Z",
+  "createdAt": "2026-04-19T11:28:27.892979Z",
+  "updatedAt": "2026-04-19T11:28:32.418422Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 9 — `e2e-10x-1776598115130-9`
+
+- walletId: `16`  solanaAddress: `74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4`
+- fundingId: `32466a08-4bcc-4b60-9e98-4919e12ad5a0`  paymentIntentId: `pi_3TNtWi3nnME1dfOB0Yevm0QL`
+- remittanceId: `af3b0178-7931-4d19-9721-bb3e96727a1c`  claimTokenId: `131682fa-885a-4dab-b44b-7b9cf65c791e`
+- final status: **DELIVERED**  elapsed: 46.8s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 35
+- Payout: id=`pout_wm_pfi0ubnabdur` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776598115130-9"
+}
+```
+
+Response:
+```json
+{
+  "id": 16,
+  "userId": "e2e-10x-1776598115130-9",
+  "solanaAddress": "74GboL5qRGncSJJYXCrFgabNNpfweqUuC5gfF8YQmfA4",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:28:35.330552520Z",
+  "updatedAt": "2026-04-19T11:28:35.330552520Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/16/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "32466a08-4bcc-4b60-9e98-4919e12ad5a0",
+  "walletId": 16,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtWi3nnME1dfOB0Yevm0QL",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:28:35.375705052Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/32466a08-4bcc-4b60-9e98-4919e12ad5a0`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "32466a08-4bcc-4b60-9e98-4919e12ad5a0",
+  "walletId": 16,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtWi3nnME1dfOB0Yevm0QL",
+  "createdAt": "2026-04-19T11:28:35.375705Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776598115130-9",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 10,
+  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
+  "senderId": "e2e-10x-1776598115130-9",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:44.550884574Z",
+  "updatedAt": "2026-04-19T11:28:44.556493453Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/af3b0178-7931-4d19-9721-bb3e96727a1c`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 10,
+  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
+  "senderId": "e2e-10x-1776598115130-9",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:44.550885Z",
+  "updatedAt": "2026-04-19T11:29:15.976473Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/131682fa-885a-4dab-b44b-7b9cf65c791e`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
+  "senderId": "e2e-10x-1776598115130-9",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:28:44.555437Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/131682fa-885a-4dab-b44b-7b9cf65c791e`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
+  "senderId": "e2e-10x-1776598115130-9",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:28:44.555437Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/af3b0178-7931-4d19-9721-bb3e96727a1c`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 10,
+  "remittanceId": "af3b0178-7931-4d19-9721-bb3e96727a1c",
+  "senderId": "e2e-10x-1776598115130-9",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "131682fa-885a-4dab-b44b-7b9cf65c791e",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:28:44.550885Z",
+  "updatedAt": "2026-04-19T11:29:19.498799Z",
+  "expiresAt": null
+}
+```
+
+---
+
+### Customer 10 — `e2e-10x-1776598161943-10`
+
+- walletId: `17`  solanaAddress: `G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9`
+- fundingId: `7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca`  paymentIntentId: `pi_3TNtXT3nnME1dfOB0n69tF9W`
+- remittanceId: `5138141b-9a20-461f-b7df-e4dbf27d6d46`  claimTokenId: `765aac14-5e5f-49b1-9943-08806535ed75`
+- final status: **DELIVERED**  elapsed: 47.4s  **PASS**
+- On-chain USDC after fund: 1
+- Claim authority USDC after claim: 36
+- Payout: id=`pout_wm_mmxjbzzuhsnk` status=`processing`
+
+#### 1-create-wallet
+
+`POST /api/wallets`  → **HTTP 201**
+
+Request:
+```json
+{
+  "userId": "e2e-10x-1776598161943-10"
+}
+```
+
+Response:
+```json
+{
+  "id": 17,
+  "userId": "e2e-10x-1776598161943-10",
+  "solanaAddress": "G37Th6CcvAVRtjUw5acdDCdJmn3y7H8JTKB9W2ViKze9",
+  "availableBalance": 0,
+  "totalBalance": 0,
+  "createdAt": "2026-04-19T11:29:22.027111483Z",
+  "updatedAt": "2026-04-19T11:29:22.027111483Z"
+}
+```
+
+#### 2-initiate-fund
+
+`POST /api/wallets/17/fund`  → **HTTP 201**
+
+Request:
+```json
+{
+  "amount": 1.0
+}
+```
+
+Response:
+```json
+{
+  "fundingId": "7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca",
+  "walletId": 17,
+  "amountUsdc": 1.0,
+  "status": "PAYMENT_CONFIRMED",
+  "stripePaymentIntentId": "pi_3TNtXT3nnME1dfOB0n69tF9W",
+  "stripeClientSecret": "***REDACTED***",
+  "createdAt": "2026-04-19T11:29:22.040386216Z"
+}
+```
+
+#### 3-poll-funded
+
+`GET /api/funding-orders/7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "fundingId": "7a7a7dc6-fd38-4e2a-8572-21cf8b0110ca",
+  "walletId": 17,
+  "amountUsdc": 1.0,
+  "status": "FUNDED",
+  "stripePaymentIntentId": "pi_3TNtXT3nnME1dfOB0n69tF9W",
+  "createdAt": "2026-04-19T11:29:22.040386Z"
+}
+```
+
+#### 4-create-remittance
+
+`POST /api/remittances`  → **HTTP 201**
+
+Request:
+```json
+{
+  "senderId": "e2e-10x-1776598161943-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0
+}
+```
+
+Response:
+```json
+{
+  "id": 11,
+  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
+  "senderId": "e2e-10x-1776598161943-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "INITIATED",
+  "escrowPda": null,
+  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:29:31.785075306Z",
+  "updatedAt": "2026-04-19T11:29:31.790060930Z",
+  "expiresAt": null
+}
+```
+
+#### 5-poll-escrowed
+
+`GET /api/remittances/5138141b-9a20-461f-b7df-e4dbf27d6d46`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 11,
+  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
+  "senderId": "e2e-10x-1776598161943-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "escrowPda": null,
+  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:29:31.785075Z",
+  "updatedAt": "2026-04-19T11:30:03.054652Z",
+  "expiresAt": null
+}
+```
+
+#### 6-get-claim
+
+`GET /api/claims/765aac14-5e5f-49b1-9943-08806535ed75`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
+  "senderId": "e2e-10x-1776598161943-10",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": false,
+  "expiresAt": "2026-04-21T11:29:31.788423Z"
+}
+```
+
+#### 7-submit-claim
+
+`POST /api/claims/765aac14-5e5f-49b1-9943-08806535ed75`  → **HTTP 200**
+
+Request:
+```json
+{
+  "upiId": "test@upi"
+}
+```
+
+Response:
+```json
+{
+  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
+  "senderId": "e2e-10x-1776598161943-10",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "ESCROWED",
+  "claimed": true,
+  "expiresAt": "2026-04-21T11:29:31.788423Z"
+}
+```
+
+#### 8-poll-delivered
+
+`GET /api/remittances/5138141b-9a20-461f-b7df-e4dbf27d6d46`  → **HTTP 200**
+
+Request:
+```json
+(no body)
+```
+
+Response:
+```json
+{
+  "id": 11,
+  "remittanceId": "5138141b-9a20-461f-b7df-e4dbf27d6d46",
+  "senderId": "e2e-10x-1776598161943-10",
+  "recipientPhone": "+919876543210",
+  "amountUsdc": 1.0,
+  "amountInr": 92.92,
+  "fxRate": 92.922391,
+  "status": "DELIVERED",
+  "escrowPda": null,
+  "claimTokenId": "765aac14-5e5f-49b1-9943-08806535ed75",
+  "smsNotificationFailed": false,
+  "createdAt": "2026-04-19T11:29:31.785075Z",
+  "updatedAt": "2026-04-19T11:30:06.334869Z",
   "expiresAt": null
 }
 ```

--- a/scripts/e2e_10_customers.py
+++ b/scripts/e2e_10_customers.py
@@ -56,6 +56,28 @@ def spl_balance(owner: str) -> str:
     return r.stdout.strip() if r.returncode == 0 else r.stderr.strip()
 
 
+def fetch_payout_row(remittance_id: str) -> tuple[str | None, str | None, str | None]:
+    """Read payout_id, payout_provider_status, payout_failure_reason from the
+    remittances row. STA-91 wires RemittancePayoutWriter into the disburse
+    activity; the API response deliberately does NOT expose these (STA-92),
+    so the e2e harness goes straight to the DB. Returns (payout_id,
+    provider_status, failure_reason); any of them may be None."""
+    r = subprocess.run(
+        ["docker", "exec", "stablepay-hackathon-postgres-1",
+         "psql", "-U", "stablepay", "-d", "stablepay", "-tAc",
+         "SELECT COALESCE(payout_id,''), COALESCE(payout_provider_status,''), "
+         "COALESCE(payout_failure_reason,'') FROM remittances "
+         f"WHERE remittance_id='{remittance_id}';"],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        return None, None, None
+    parts = r.stdout.strip().split("|")
+    if len(parts) != 3:
+        return None, None, None
+    pid, status, reason = parts
+    return pid or None, status or None, reason or None
+
+
 SENSITIVE_KEYS = {"stripeClientSecret", "clientSecret"}
 
 
@@ -94,6 +116,8 @@ class RunResult:
     final_status: str | None = None
     on_chain_usdc_after_fund: str | None = None
     on_chain_usdc_after_claim: str | None = None
+    payout_id: str | None = None
+    payout_provider_status: str | None = None
     elapsed_secs: float = 0.0
     passed: bool = False
     error: str | None = None
@@ -209,6 +233,21 @@ def run_one(idx: int) -> RunResult:
             )
             return r
 
+        # 11. STA-91 — verify RemittancePayoutWriter persisted payout_id +
+        # provider_status during disburseInr. Logging adapter returns
+        # "log_<uuid>" + "SIMULATED"; Razorpay (real or WireMock-stubbed)
+        # returns "pout_..." + "processing". Either shape proves the writer
+        # path ran; any other combination is a regression.
+        payout_id, provider_status, _ = fetch_payout_row(r.remittance_id)
+        r.payout_id = payout_id
+        r.payout_provider_status = provider_status
+        if not payout_id or not (payout_id.startswith("log_") or payout_id.startswith("pout_")):
+            r.error = f"payout_id not persisted or wrong format: {payout_id!r}"
+            return r
+        if provider_status not in ("SIMULATED", "processing"):
+            r.error = f"payout_provider_status = {provider_status!r}, expected 'SIMULATED' or 'processing'"
+            return r
+
         r.passed = True
     finally:
         r.elapsed_secs = round(time.time() - t0, 1)
@@ -228,14 +267,15 @@ def write_report(results: list[RunResult], out_path: str):
         f"- Failed: {sum(1 for r in results if not r.passed)}",
         f"- Per-customer amount: ${AMOUNT_USDC} USDC",
         "",
-        "| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | elapsed (s) | PASS |",
-        "|---|--------|----------|---------|-----------|--------------|-------|-----------------|-------------|------|",
+        "| # | userId | walletId | address | fundingId | remittanceId | final | USDC after fund | payout_id | elapsed (s) | PASS |",
+        "|---|--------|----------|---------|-----------|--------------|-------|-----------------|-----------|-------------|------|",
     ]
     for r in results:
         lines.append(
             f"| {r.index} | `{r.user_id}` | {r.wallet_id} | `{r.solana_address}` | "
             f"`{r.funding_id}` | `{r.remittance_id}` | {r.final_status or '-'} | "
-            f"{r.on_chain_usdc_after_fund or '-'} | {r.elapsed_secs} | "
+            f"{r.on_chain_usdc_after_fund or '-'} | `{r.payout_id or '-'}` | "
+            f"{r.elapsed_secs} | "
             f"{'✅' if r.passed else '❌ ' + (r.error or '')} |"
         )
     lines += ["", "## Per-customer request / response log", ""]
@@ -250,6 +290,7 @@ def write_report(results: list[RunResult], out_path: str):
             f"{'**PASS**' if r.passed else '**FAIL: ' + (r.error or '') + '**'}",
             f"- On-chain USDC after fund: {r.on_chain_usdc_after_fund}",
             f"- Claim authority USDC after claim: {r.on_chain_usdc_after_claim}",
+            f"- Payout: id=`{r.payout_id or '-'}` status=`{r.payout_provider_status or '-'}`",
             "",
         ]
         for d in r.detail:
@@ -330,6 +371,15 @@ def run_salvage(idx: int, wallet_id: int, user_id: str, amount_usdc: str) -> Run
             r.error = f"final status = {r.final_status}"
             return r
         r.on_chain_usdc_after_claim = spl_balance(CLAIM_AUTHORITY)
+        payout_id, provider_status, _ = fetch_payout_row(r.remittance_id)
+        r.payout_id = payout_id
+        r.payout_provider_status = provider_status
+        if not payout_id or not (payout_id.startswith("log_") or payout_id.startswith("pout_")):
+            r.error = f"payout_id not persisted or wrong format: {payout_id!r}"
+            return r
+        if provider_status not in ("SIMULATED", "processing"):
+            r.error = f"payout_provider_status = {provider_status!r}, expected 'SIMULATED' or 'processing'"
+            return r
         r.passed = True
     finally:
         r.elapsed_secs = round(time.time() - t0, 1)

--- a/wiremock/mappings/contacts.json
+++ b/wiremock/mappings/contacts.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/contacts"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "{\"id\":\"cont_wm_{{randomValue length=12 type='ALPHANUMERIC'}}\",\"entity\":\"contact\",\"type\":\"customer\"}",
+    "transformers": ["response-template"]
+  }
+}

--- a/wiremock/mappings/fund_accounts.json
+++ b/wiremock/mappings/fund_accounts.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/fund_accounts"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "{\"id\":\"fa_wm_{{randomValue length=12 type='ALPHANUMERIC'}}\",\"entity\":\"fund_account\",\"account_type\":\"vpa\",\"active\":true}",
+    "transformers": ["response-template"]
+  }
+}

--- a/wiremock/mappings/payouts.json
+++ b/wiremock/mappings/payouts.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/payouts"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": "{\"id\":\"pout_wm_{{randomValue length=12 type='ALPHANUMERIC'}}\",\"entity\":\"payout\",\"mode\":\"UPI\",\"status\":\"processing\",\"amount\":{{jsonPath request.body '$.amount'}},\"currency\":\"INR\",\"reference_id\":\"{{jsonPath request.body '$.reference_id'}}\"}",
+    "transformers": ["response-template"]
+  }
+}


### PR DESCRIPTION
## Summary

- Add WireMock stubs for Razorpay contacts, fund_accounts, and payouts endpoints for contract-level E2E testing
- Update `docker-compose.yml` with WireMock service and `.env.example` with required config
- Refresh E2E 10-customer run report — 10/10 pass with WireMock Razorpay
- Update `e2e_10_customers.py` script for WireMock compatibility

## Test plan

- [x] 10/10 customer E2E scenarios pass with WireMock Razorpay stubs
- [x] WireMock mappings return valid Razorpay-shaped responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)