### PR TITLE
STA-95: add users table, auth domain skeleton, and String→UUID migration

### DIFF
--- a/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablepay.application.dto.CreateWalletRequest;
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.wallet.model.GeneratedKey;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.test.PgTest;
@@ -36,6 +40,15 @@ class WalletApiIntegrationTest {
     @Autowired
     private MpcWalletClient mpcWalletClient;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID createUser() {
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
+        return userId;
+    }
+
     @Nested
     class CreateWallet {
 
@@ -43,7 +56,7 @@ class WalletApiIntegrationTest {
         @SneakyThrows
         void shouldCreateWalletAndReturnCreatedResponse() {
             // given
-            var userId = "api-user-" + System.nanoTime();
+            var userId = createUser();
             var solanaAddress = SOME_SOLANA_ADDRESS + System.nanoTime();
             var generatedKey = GeneratedKey.builder()
                     .solanaAddress(solanaAddress)
@@ -63,7 +76,7 @@ class WalletApiIntegrationTest {
             // then
             result.andExpect(status().isCreated())
                     .andExpect(jsonPath("$.id").isNumber())
-                    .andExpect(jsonPath("$.userId").value(userId))
+                    .andExpect(jsonPath("$.userId").value(userId.toString()))
                     .andExpect(jsonPath("$.solanaAddress").value(solanaAddress))
                     .andExpect(jsonPath("$.availableBalance").value(0))
                     .andExpect(jsonPath("$.totalBalance").value(0))
@@ -74,7 +87,7 @@ class WalletApiIntegrationTest {
         @SneakyThrows
         void shouldReturn409WhenWalletAlreadyExistsForUser() {
             // given
-            var userId = "dup-user-" + System.nanoTime();
+            var userId = createUser();
             var generatedKey = GeneratedKey.builder()
                     .solanaAddress("addr-dup-" + System.nanoTime())
                     .publicKey(SOME_PUBLIC_KEY)
@@ -103,9 +116,9 @@ class WalletApiIntegrationTest {
 
         @Test
         @SneakyThrows
-        void shouldReturn400WhenUserIdIsBlank() {
+        void shouldReturn400WhenUserIdIsNull() {
             // given
-            var request = CreateWalletRequest.builder().userId("").build();
+            var request = CreateWalletRequest.builder().userId(null).build();
 
             // when
             var result = mockMvc.perform(post("/api/wallets")

--- a/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
@@ -9,8 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.UUID;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,11 +18,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stablepay.application.dto.CreateWalletRequest;
-import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.wallet.model.GeneratedKey;
 import com.stablepay.domain.wallet.port.MpcWalletClient;
 import com.stablepay.test.PgTest;
+import com.stablepay.testutil.AuthFixtures;
 
 import lombok.SneakyThrows;
 
@@ -43,12 +41,6 @@ class WalletApiIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
-    private UUID createUser() {
-        var userId = UUID.randomUUID();
-        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
-        return userId;
-    }
-
     @Nested
     class CreateWallet {
 
@@ -56,7 +48,7 @@ class WalletApiIntegrationTest {
         @SneakyThrows
         void shouldCreateWalletAndReturnCreatedResponse() {
             // given
-            var userId = createUser();
+            var userId = AuthFixtures.createTestUser(userRepository);
             var solanaAddress = SOME_SOLANA_ADDRESS + System.nanoTime();
             var generatedKey = GeneratedKey.builder()
                     .solanaAddress(solanaAddress)
@@ -87,7 +79,7 @@ class WalletApiIntegrationTest {
         @SneakyThrows
         void shouldReturn409WhenWalletAlreadyExistsForUser() {
             // given
-            var userId = createUser();
+            var userId = AuthFixtures.createTestUser(userRepository);
             var generatedKey = GeneratedKey.builder()
                     .solanaAddress("addr-dup-" + System.nanoTime())
                     .publicKey(SOME_PUBLIC_KEY)

--- a/backend/src/integration-test/java/com/stablepay/application/e2e/RemittanceLifecycleE2EIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/e2e/RemittanceLifecycleE2EIntegrationTest.java
@@ -18,6 +18,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.jayway.jsonpath.JsonPath;
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.remittance.handler.UpdateRemittanceStatusHandler;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.wallet.model.GeneratedKey;
@@ -31,7 +33,7 @@ import lombok.SneakyThrows;
 @AutoConfigureMockMvc
 class RemittanceLifecycleE2EIntegrationTest {
 
-    private static final String E2E_USER_ID = "e2e-user-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final UUID E2E_USER_ID = UUID.randomUUID();
     private static final String E2E_SOLANA_ADDRESS = "E2eSoLaNa1234567890AbCdEfGhIjKlMnOpQrStUv";
     private static final byte[] E2E_PUBLIC_KEY = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
     private static final byte[] E2E_KEY_SHARE_DATA = new byte[]{10, 20, 30, 40, 50};
@@ -49,8 +51,12 @@ class RemittanceLifecycleE2EIntegrationTest {
     @Autowired
     private WalletRepository walletRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @BeforeEach
     void setUp() {
+        userRepository.save(AppUser.builder().id(E2E_USER_ID).email("e2e@test.com").build());
         given(mpcWalletClient.generateKey()).willReturn(
                 GeneratedKey.builder()
                         .solanaAddress(E2E_SOLANA_ADDRESS)
@@ -108,7 +114,7 @@ class RemittanceLifecycleE2EIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.userId").value(E2E_USER_ID))
+                .andExpect(jsonPath("$.userId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.solanaAddress").value(E2E_SOLANA_ADDRESS))
                 .andExpect(jsonPath("$.availableBalance").value(0))
                 .andReturn();
@@ -157,7 +163,7 @@ class RemittanceLifecycleE2EIntegrationTest {
                         .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.remittanceId").isString())
-                .andExpect(jsonPath("$.senderId").value(E2E_USER_ID))
+                .andExpect(jsonPath("$.senderId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.recipientPhone").value("+919876543210"))
                 .andExpect(jsonPath("$.amountUsdc").value(25.00))
                 .andExpect(jsonPath("$.amountInr").isNumber())
@@ -215,13 +221,13 @@ class RemittanceLifecycleE2EIntegrationTest {
     private void listRemittances() {
         // when / then
         mockMvc.perform(get("/api/remittances")
-                        .param("senderId", E2E_USER_ID)
+                        .param("senderId", E2E_USER_ID.toString())
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content.length()").value(1))
-                .andExpect(jsonPath("$.content[0].senderId").value(E2E_USER_ID))
+                .andExpect(jsonPath("$.content[0].senderId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.content[0].amountUsdc").value(25.00))
                 .andExpect(jsonPath("$.totalElements").value(1));
     }

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/CompleteFundingHandlerIntegrationTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
@@ -34,6 +36,9 @@ class CompleteFundingHandlerIntegrationTest {
     private FundingOrderRepository fundingOrderRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     private FundingOrder confirmedOrder;
@@ -42,8 +47,10 @@ class CompleteFundingHandlerIntegrationTest {
     void setUp() {
         var unique = String.valueOf(System.nanoTime());
         transactionTemplate.executeWithoutResult(status -> {
+            var userId = UUID.randomUUID();
+            userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
             var wallet = walletRepository.save(Wallet.builder()
-                    .userId("complete-user-" + unique)
+                    .userId(userId)
                     .solanaAddress("complete-addr-" + unique)
                     .publicKey(new byte[]{1})
                     .keyShareData(new byte[]{2})

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FinalizeFundingHandlerIntegrationTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
@@ -37,6 +39,9 @@ class FinalizeFundingHandlerIntegrationTest {
     private FundingOrderRepository fundingOrderRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     private Wallet initialWallet;
@@ -46,8 +51,10 @@ class FinalizeFundingHandlerIntegrationTest {
     void setUp() {
         var unique = String.valueOf(System.nanoTime());
         transactionTemplate.executeWithoutResult(status -> {
+            var userId = UUID.randomUUID();
+            userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
             initialWallet = walletRepository.save(Wallet.builder()
-                    .userId("finalize-user-" + unique)
+                    .userId(userId)
                     .solanaAddress("finalize-addr-" + unique)
                     .publicKey(new byte[]{1})
                     .keyShareData(new byte[]{2})

--- a/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FundingOrderWriterIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/funding/handler/FundingOrderWriterIntegrationTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
@@ -33,6 +35,9 @@ class FundingOrderWriterIntegrationTest {
     private WalletRepository walletRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     private Long walletId;
@@ -40,8 +45,11 @@ class FundingOrderWriterIntegrationTest {
     @BeforeEach
     void setUp() {
         var unique = String.valueOf(System.nanoTime());
+        var userId = java.util.UUID.randomUUID();
+        transactionTemplate.executeWithoutResult(status ->
+                userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build()));
         walletId = transactionTemplate.execute(status -> walletRepository.save(Wallet.builder()
-                .userId("writer-user-" + unique)
+                .userId(userId)
                 .solanaAddress("writer-addr-" + unique)
                 .publicKey(new byte[]{1})
                 .keyShareData(new byte[]{2})

--- a/backend/src/integration-test/java/com/stablepay/domain/remittance/handler/RemittancePayoutWriterIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/domain/remittance/handler/RemittancePayoutWriterIntegrationTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.remittance.model.DisbursementResult;
 import com.stablepay.domain.remittance.model.Remittance;
@@ -31,6 +33,9 @@ class RemittancePayoutWriterIntegrationTest {
     private RemittanceRepository remittanceRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     private UUID remittanceId;
@@ -38,9 +43,12 @@ class RemittancePayoutWriterIntegrationTest {
     @BeforeEach
     void setUp() {
         remittanceId = UUID.randomUUID();
+        var senderId = UUID.randomUUID();
+        transactionTemplate.executeWithoutResult(status ->
+                userRepository.save(AppUser.builder().id(senderId).email(senderId + "@test.com").build()));
         transactionTemplate.execute(status -> remittanceRepository.save(Remittance.builder()
                 .remittanceId(remittanceId)
-                .senderId("writer-sender-" + System.nanoTime())
+                .senderId(senderId)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .amountInr(SOME_AMOUNT_INR)
@@ -104,9 +112,12 @@ class RemittancePayoutWriterIntegrationTest {
         remittancePayoutWriter.writePayoutId(remittanceId, "pout_DUP001", "processing");
 
         var secondRemittanceId = UUID.randomUUID();
+        var secondSenderId = UUID.randomUUID();
+        transactionTemplate.executeWithoutResult(status ->
+                userRepository.save(AppUser.builder().id(secondSenderId).email(secondSenderId + "@test.com").build()));
         transactionTemplate.execute(status -> remittanceRepository.save(Remittance.builder()
                 .remittanceId(secondRemittanceId)
-                .senderId("writer-sender-second-" + System.nanoTime())
+                .senderId(secondSenderId)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .amountInr(SOME_AMOUNT_INR)

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/claim/ClaimTokenRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/claim/ClaimTokenRepositoryIntegrationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.model.ClaimToken;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
@@ -22,6 +21,7 @@ import com.stablepay.domain.remittance.model.Remittance;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
 import com.stablepay.test.PgTest;
+import com.stablepay.testutil.AuthFixtures;
 
 @PgTest
 @Transactional
@@ -36,14 +36,8 @@ class ClaimTokenRepositoryIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
-    private UUID createUser() {
-        var userId = UUID.randomUUID();
-        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
-        return userId;
-    }
-
     private UUID createRemittanceAndReturnId() {
-        var senderId = createUser();
+        var senderId = AuthFixtures.createTestUser(userRepository);
         var remittanceId = UUID.randomUUID();
         var remittance = Remittance.builder()
                 .remittanceId(remittanceId)

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/claim/ClaimTokenRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/claim/ClaimTokenRepositoryIntegrationTest.java
@@ -3,7 +3,6 @@ package com.stablepay.infrastructure.db.claim;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -15,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.model.ClaimToken;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
 import com.stablepay.domain.remittance.model.Remittance;
@@ -32,11 +33,21 @@ class ClaimTokenRepositoryIntegrationTest {
     @Autowired
     private RemittanceRepository remittanceRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID createUser() {
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
+        return userId;
+    }
+
     private UUID createRemittanceAndReturnId() {
+        var senderId = createUser();
         var remittanceId = UUID.randomUUID();
         var remittance = Remittance.builder()
                 .remittanceId(remittanceId)
-                .senderId(SOME_SENDER_ID)
+                .senderId(senderId)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .fxRate(SOME_FX_RATE)

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/funding/FundingOrderRepositoryIntegrationTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.model.FundingStatus;
@@ -34,12 +36,17 @@ class FundingOrderRepositoryIntegrationTest {
     private WalletRepository walletRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private EntityManager entityManager;
 
     private Long createWalletAndReturnId() {
         var unique = String.valueOf(System.nanoTime());
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
         var wallet = Wallet.builder()
-                .userId("funding-user-" + unique)
+                .userId(userId)
                 .solanaAddress("funding-addr-" + unique)
                 .publicKey(new byte[]{1})
                 .keyShareData(new byte[]{2})

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryIntegrationTest.java
@@ -4,7 +4,6 @@ import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
@@ -15,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.remittance.model.Remittance;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
@@ -27,7 +28,16 @@ class RemittanceRepositoryIntegrationTest {
     @Autowired
     private RemittanceRepository remittanceRepository;
 
-    private Remittance buildRemittance(UUID remittanceId, String senderId) {
+    @Autowired
+    private UserRepository userRepository;
+
+    private UUID createUser() {
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
+        return userId;
+    }
+
+    private Remittance buildRemittance(UUID remittanceId, UUID senderId) {
         return Remittance.builder()
                 .remittanceId(remittanceId)
                 .senderId(senderId)
@@ -46,7 +56,8 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldSaveAndAssignId() {
             // given
-            var remittance = buildRemittance(UUID.randomUUID(), SOME_SENDER_ID);
+            var senderId = createUser();
+            var remittance = buildRemittance(UUID.randomUUID(), senderId);
 
             // when
             var saved = remittanceRepository.save(remittance);
@@ -62,8 +73,9 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldPersistAllFieldsCorrectly() {
             // given
+            var senderId = createUser();
             var remittanceId = UUID.randomUUID();
-            var remittance = buildRemittance(remittanceId, SOME_SENDER_ID)
+            var remittance = buildRemittance(remittanceId, senderId)
                     .toBuilder()
                     .escrowPda("EsCrOwPdA1234567890AbCdEfGh")
                     .claimTokenId("claim-token-123")
@@ -89,8 +101,9 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldFindRemittanceByUuid() {
             // given
+            var senderId = createUser();
             var remittanceId = UUID.randomUUID();
-            var remittance = buildRemittance(remittanceId, SOME_SENDER_ID);
+            var remittance = buildRemittance(remittanceId, senderId);
             remittanceRepository.save(remittance);
 
             // when
@@ -99,7 +112,7 @@ class RemittanceRepositoryIntegrationTest {
             // then
             assertThat(found).isPresent();
             assertThat(found.get().remittanceId()).isEqualTo(remittanceId);
-            assertThat(found.get().senderId()).isEqualTo(SOME_SENDER_ID);
+            assertThat(found.get().senderId()).isEqualTo(senderId);
         }
 
         @Test
@@ -118,7 +131,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldReturnPagedResultsForSender() {
             // given
-            var senderId = "sender-" + System.nanoTime();
+            var senderId = createUser();
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
@@ -136,7 +149,7 @@ class RemittanceRepositoryIntegrationTest {
         void shouldReturnEmptyPageWhenNoRemittancesForSender() {
             // when
             var page = remittanceRepository.findBySenderId(
-                    "nonexistent-sender", PageRequest.of(0, 10));
+                    UUID.randomUUID(), PageRequest.of(0, 10));
 
             // then
             assertThat(page.getContent()).isEmpty();
@@ -146,8 +159,8 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldNotReturnRemittancesFromOtherSenders() {
             // given
-            var senderId = "sender-a-" + System.nanoTime();
-            var otherSenderId = "sender-b-" + System.nanoTime();
+            var senderId = createUser();
+            var otherSenderId = createUser();
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), otherSenderId));
 
@@ -166,8 +179,9 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldPersistStatusUpdatesCorrectly() {
             // given
+            var senderId = createUser();
             var remittanceId = UUID.randomUUID();
-            var remittance = buildRemittance(remittanceId, SOME_SENDER_ID);
+            var remittance = buildRemittance(remittanceId, senderId);
             var saved = remittanceRepository.save(remittance);
 
             // when

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryIntegrationTest.java
@@ -14,12 +14,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.remittance.model.Remittance;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.remittance.port.RemittanceRepository;
 import com.stablepay.test.PgTest;
+import com.stablepay.testutil.AuthFixtures;
 
 @PgTest
 @Transactional
@@ -30,12 +30,6 @@ class RemittanceRepositoryIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    private UUID createUser() {
-        var userId = UUID.randomUUID();
-        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
-        return userId;
-    }
 
     private Remittance buildRemittance(UUID remittanceId, UUID senderId) {
         return Remittance.builder()
@@ -56,7 +50,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldSaveAndAssignId() {
             // given
-            var senderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
             var remittance = buildRemittance(UUID.randomUUID(), senderId);
 
             // when
@@ -73,7 +67,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldPersistAllFieldsCorrectly() {
             // given
-            var senderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
             var remittanceId = UUID.randomUUID();
             var remittance = buildRemittance(remittanceId, senderId)
                     .toBuilder()
@@ -101,7 +95,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldFindRemittanceByUuid() {
             // given
-            var senderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
             var remittanceId = UUID.randomUUID();
             var remittance = buildRemittance(remittanceId, senderId);
             remittanceRepository.save(remittance);
@@ -131,7 +125,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldReturnPagedResultsForSender() {
             // given
-            var senderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
@@ -159,8 +153,8 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldNotReturnRemittancesFromOtherSenders() {
             // given
-            var senderId = createUser();
-            var otherSenderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
+            var otherSenderId = AuthFixtures.createTestUser(userRepository);
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), senderId));
             remittanceRepository.save(buildRemittance(UUID.randomUUID(), otherSenderId));
 
@@ -179,7 +173,7 @@ class RemittanceRepositoryIntegrationTest {
         @Test
         void shouldPersistStatusUpdatesCorrectly() {
             // given
-            var senderId = createUser();
+            var senderId = AuthFixtures.createTestUser(userRepository);
             var remittanceId = UUID.randomUUID();
             var remittance = buildRemittance(remittanceId, senderId);
             var saved = remittanceRepository.save(remittance);

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
@@ -5,11 +5,11 @@ import static com.stablepay.testutil.WalletFixtures.SOME_KEY_SHARE_DATA;
 import static com.stablepay.testutil.WalletFixtures.SOME_PEER_KEY_SHARE_DATA;
 import static com.stablepay.testutil.WalletFixtures.SOME_PUBLIC_KEY;
 import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
-import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import jakarta.persistence.EntityManager;
 
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.WalletRepository;
 import com.stablepay.test.PgTest;
@@ -30,13 +32,23 @@ class WalletRepositoryIntegrationTest {
     private WalletRepository walletRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private EntityManager entityManager;
+
+    private UUID createUser() {
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
+        return userId;
+    }
 
     @Test
     void shouldSaveAndFindWalletById() {
         // given
+        var userId = createUser();
         var wallet = Wallet.builder()
-                .userId(SOME_USER_ID)
+                .userId(userId)
                 .solanaAddress(SOME_SOLANA_ADDRESS)
                 .publicKey(SOME_PUBLIC_KEY)
                 .keyShareData(SOME_KEY_SHARE_DATA)
@@ -60,8 +72,9 @@ class WalletRepositoryIntegrationTest {
     @Test
     void shouldFindWalletByUserId() {
         // given
+        var userId = createUser();
         var wallet = Wallet.builder()
-                .userId("unique-user-" + System.nanoTime())
+                .userId(userId)
                 .solanaAddress("addr-" + System.nanoTime())
                 .publicKey(SOME_PUBLIC_KEY)
                 .keyShareData(SOME_KEY_SHARE_DATA)
@@ -72,11 +85,11 @@ class WalletRepositoryIntegrationTest {
         walletRepository.save(wallet);
 
         // when
-        var found = walletRepository.findByUserId(wallet.userId());
+        var found = walletRepository.findByUserId(userId);
 
         // then
         assertThat(found).isPresent();
-        assertThat(found.get().userId()).isEqualTo(wallet.userId());
+        assertThat(found.get().userId()).isEqualTo(userId);
     }
 
     @Test
@@ -91,9 +104,10 @@ class WalletRepositoryIntegrationTest {
     @Test
     void shouldFindWalletBySolanaAddress() {
         // given
+        var userId = createUser();
         var solanaAddress = "addr-solana-" + System.nanoTime();
         var wallet = Wallet.builder()
-                .userId("user-solana-" + System.nanoTime())
+                .userId(userId)
                 .solanaAddress(solanaAddress)
                 .publicKey(SOME_PUBLIC_KEY)
                 .keyShareData(SOME_KEY_SHARE_DATA)
@@ -122,11 +136,10 @@ class WalletRepositoryIntegrationTest {
 
     @Test
     void shouldRejectWalletWithNullPeerKeyShareData() {
-        // given — STA-83: peer_key_share_data is NOT NULL at the DB level.
-        // A DKG race that fails to capture the peer share must never result
-        // in a persisted wallet row.
+        // given
+        var userId = createUser();
         var wallet = Wallet.builder()
-                .userId("null-peer-user-" + System.nanoTime())
+                .userId(userId)
                 .solanaAddress("null-peer-addr-" + System.nanoTime())
                 .publicKey(SOME_PUBLIC_KEY)
                 .keyShareData(SOME_KEY_SHARE_DATA)
@@ -135,8 +148,7 @@ class WalletRepositoryIntegrationTest {
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        // when / then — flush forces the INSERT so the DB NOT NULL check fires,
-        // rather than deferring until transaction commit
+        // when / then
         assertThatThrownBy(() -> {
             walletRepository.save(wallet);
             entityManager.flush();
@@ -146,8 +158,9 @@ class WalletRepositoryIntegrationTest {
     @Test
     void shouldRejectWalletWithNullKeyShareData() {
         // given
+        var userId = createUser();
         var wallet = Wallet.builder()
-                .userId("null-self-user-" + System.nanoTime())
+                .userId(userId)
                 .solanaAddress("null-self-addr-" + System.nanoTime())
                 .publicKey(SOME_PUBLIC_KEY)
                 .keyShareData(null)
@@ -156,8 +169,7 @@ class WalletRepositoryIntegrationTest {
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        // when / then — flush forces the INSERT so the DB NOT NULL check fires,
-        // rather than deferring until transaction commit
+        // when / then
         assertThatThrownBy(() -> {
             walletRepository.save(wallet);
             entityManager.flush();
@@ -167,8 +179,9 @@ class WalletRepositoryIntegrationTest {
     @Test
     void shouldRejectWalletWithNullPublicKey() {
         // given
+        var userId = createUser();
         var wallet = Wallet.builder()
-                .userId("null-pk-user-" + System.nanoTime())
+                .userId(userId)
                 .solanaAddress("null-pk-addr-" + System.nanoTime())
                 .publicKey(null)
                 .keyShareData(SOME_KEY_SHARE_DATA)
@@ -177,8 +190,7 @@ class WalletRepositoryIntegrationTest {
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        // when / then — flush forces the INSERT so the DB NOT NULL check fires,
-        // rather than deferring until transaction commit
+        // when / then
         assertThatThrownBy(() -> {
             walletRepository.save(wallet);
             entityManager.flush();

--- a/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryIntegrationTest.java
@@ -18,11 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.wallet.model.Wallet;
 import com.stablepay.domain.wallet.port.WalletRepository;
 import com.stablepay.test.PgTest;
+import com.stablepay.testutil.AuthFixtures;
 
 @PgTest
 @Transactional
@@ -38,9 +38,7 @@ class WalletRepositoryIntegrationTest {
     private EntityManager entityManager;
 
     private UUID createUser() {
-        var userId = UUID.randomUUID();
-        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
-        return userId;
+        return AuthFixtures.createTestUser(userRepository);
     }
 
     @Test

--- a/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
@@ -75,7 +75,7 @@ public class RemittanceController {
         @ApiResponse(responseCode = "200", description = "Remittances retrieved")
     })
     public Page<RemittanceResponse> listRemittances(
-            @RequestParam String senderId,
+            @RequestParam UUID senderId,
             Pageable pageable) {
         return listRemittancesQueryHandler.handle(senderId, pageable)
                 .map(remittanceApiMapper::toResponse);

--- a/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record ClaimResponse(
     UUID remittanceId,
-    String senderId,
+    UUID senderId,
     BigDecimal amountUsdc,
     BigDecimal amountInr,
     BigDecimal fxRate,

--- a/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
@@ -1,6 +1,7 @@
 package com.stablepay.application.dto;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,7 +11,7 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record CreateRemittanceRequest(
-    @NotBlank String senderId,
+    @NotNull UUID senderId,
     @NotBlank String recipientPhone,
     @NotNull @Positive BigDecimal amountUsdc
 ) {}

--- a/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateWalletRequest.java
@@ -1,10 +1,12 @@
 package com.stablepay.application.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
 
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record CreateWalletRequest(
-    @NotBlank String userId
+    @NotNull UUID userId
 ) {}

--- a/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 public record RemittanceResponse(
     Long id,
     UUID remittanceId,
-    String senderId,
+    UUID senderId,
     String recipientPhone,
     BigDecimal amountUsdc,
     BigDecimal amountInr,

--- a/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
@@ -2,13 +2,14 @@ package com.stablepay.application.dto;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record WalletResponse(
     Long id,
-    String userId,
+    UUID userId,
     String solanaAddress,
     BigDecimal availableBalance,
     BigDecimal totalBalance,

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/EmailNotVerifiedException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/EmailNotVerifiedException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.auth.exception;
+
+public class EmailNotVerifiedException extends RuntimeException {
+
+    public static EmailNotVerifiedException forEmail(String email) {
+        return new EmailNotVerifiedException("SP-0033: Email not verified: " + email);
+    }
+
+    private EmailNotVerifiedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/EmailNotVerifiedException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/EmailNotVerifiedException.java
@@ -3,7 +3,7 @@ package com.stablepay.domain.auth.exception;
 public class EmailNotVerifiedException extends RuntimeException {
 
     public static EmailNotVerifiedException forEmail(String email) {
-        return new EmailNotVerifiedException("SP-0033: Email not verified: " + email);
+        return new EmailNotVerifiedException("SP-0033: Email not verified");
     }
 
     private EmailNotVerifiedException(String message) {

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/InvalidIdTokenException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/InvalidIdTokenException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.auth.exception;
+
+public class InvalidIdTokenException extends RuntimeException {
+
+    public static InvalidIdTokenException of(String detail) {
+        return new InvalidIdTokenException("SP-0032: Invalid ID token: " + detail);
+    }
+
+    private InvalidIdTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+
+    public static InvalidRefreshTokenException of(String detail) {
+        return new InvalidRefreshTokenException("SP-0035: Invalid refresh token: " + detail);
+    }
+
+    private InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/RefreshTokenExpiredException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,14 @@
+package com.stablepay.domain.auth.exception;
+
+import java.util.UUID;
+
+public class RefreshTokenExpiredException extends RuntimeException {
+
+    public static RefreshTokenExpiredException forToken(UUID tokenId) {
+        return new RefreshTokenExpiredException("SP-0036: Refresh token expired: " + tokenId);
+    }
+
+    private RefreshTokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/exception/UnsupportedAuthProviderException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/UnsupportedAuthProviderException.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.auth.exception;
+
+public class UnsupportedAuthProviderException extends RuntimeException {
+
+    public static UnsupportedAuthProviderException forProvider(String provider) {
+        return new UnsupportedAuthProviderException("SP-0034: Unsupported auth provider: " + provider);
+    }
+
+    private UnsupportedAuthProviderException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/AppUser.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/AppUser.java
@@ -1,0 +1,20 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AppUser(
+    UUID id,
+    String email,
+    Instant createdAt
+) {
+    public AppUser {
+        requireNonNull(id, "id cannot be null");
+        requireNonNull(email, "email cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/AuthSession.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/AuthSession.java
@@ -1,0 +1,20 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthSession(
+    String accessToken,
+    String refreshToken,
+    Instant accessExpiresAt
+) {
+    public AuthSession {
+        requireNonNull(accessToken, "accessToken cannot be null");
+        requireNonNull(refreshToken, "refreshToken cannot be null");
+        requireNonNull(accessExpiresAt, "accessExpiresAt cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/RefreshToken.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/RefreshToken.java
@@ -1,0 +1,24 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record RefreshToken(
+    UUID id,
+    UUID userId,
+    String tokenHash,
+    Instant expiresAt,
+    Instant revokedAt
+) {
+    public RefreshToken {
+        requireNonNull(id, "id cannot be null");
+        requireNonNull(userId, "userId cannot be null");
+        requireNonNull(tokenHash, "tokenHash cannot be null");
+        requireNonNull(expiresAt, "expiresAt cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/SocialIdentity.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/SocialIdentity.java
@@ -2,16 +2,20 @@ package com.stablepay.domain.auth.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.UUID;
+
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record SocialIdentity(
+    UUID userId,
     String provider,
     String subject,
     String email,
     boolean emailVerified
 ) {
     public SocialIdentity {
+        requireNonNull(userId, "userId cannot be null");
         requireNonNull(provider, "provider cannot be null");
         requireNonNull(subject, "subject cannot be null");
         requireNonNull(email, "email cannot be null");

--- a/backend/src/main/java/com/stablepay/domain/auth/model/SocialIdentity.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/SocialIdentity.java
@@ -1,0 +1,19 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SocialIdentity(
+    String provider,
+    String subject,
+    String email,
+    boolean emailVerified
+) {
+    public SocialIdentity {
+        requireNonNull(provider, "provider cannot be null");
+        requireNonNull(subject, "subject cannot be null");
+        requireNonNull(email, "email cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.stablepay.domain.auth.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.stablepay.domain.auth.model.RefreshToken;
+
+public interface RefreshTokenRepository {
+    Optional<RefreshToken> findByHash(String tokenHash);
+    RefreshToken save(RefreshToken token);
+    void revokeByUserId(UUID userId);
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityRepository.java
@@ -1,0 +1,11 @@
+package com.stablepay.domain.auth.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+public interface SocialIdentityRepository {
+    Optional<SocialIdentity> findByProviderAndSubject(String provider, String subject);
+    SocialIdentity save(SocialIdentity identity, UUID userId);
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityRepository.java
@@ -1,11 +1,10 @@
 package com.stablepay.domain.auth.port;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import com.stablepay.domain.auth.model.SocialIdentity;
 
 public interface SocialIdentityRepository {
     Optional<SocialIdentity> findByProviderAndSubject(String provider, String subject);
-    SocialIdentity save(SocialIdentity identity, UUID userId);
+    SocialIdentity save(SocialIdentity identity);
 }

--- a/backend/src/main/java/com/stablepay/domain/auth/port/UserRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/UserRepository.java
@@ -1,0 +1,11 @@
+package com.stablepay.domain.auth.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.stablepay.domain.auth.model.AppUser;
+
+public interface UserRepository {
+    Optional<AppUser> findById(UUID id);
+    AppUser save(AppUser user);
+}

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/CreateRemittanceHandler.java
@@ -38,7 +38,7 @@ public class CreateRemittanceHandler {
     private final ClaimTokenRepository claimTokenRepository;
     private final Optional<RemittanceWorkflowStarter> workflowStarter;
 
-    public Remittance handle(String senderId, String recipientPhone, BigDecimal amountUsdc) {
+    public Remittance handle(UUID senderId, String recipientPhone, BigDecimal amountUsdc) {
         var wallet = walletRepository.findByUserId(senderId)
                 .orElseThrow(() -> WalletNotFoundException.byUserId(senderId));
 

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/ListRemittancesQueryHandler.java
@@ -1,5 +1,7 @@
 package com.stablepay.domain.remittance.handler;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,7 +19,7 @@ public class ListRemittancesQueryHandler {
 
     private final RemittanceRepository remittanceRepository;
 
-    public Page<Remittance> handle(String senderId, Pageable pageable) {
+    public Page<Remittance> handle(UUID senderId, Pageable pageable) {
         return remittanceRepository.findBySenderId(senderId, pageable);
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/remittance/model/Remittance.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/model/Remittance.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 public record Remittance(
     Long id,
     UUID remittanceId,
-    String senderId,
+    UUID senderId,
     String recipientPhone,
     BigDecimal amountUsdc,
     BigDecimal amountInr,

--- a/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/port/RemittanceRepository.java
@@ -12,5 +12,5 @@ public interface RemittanceRepository {
     Remittance save(Remittance remittance);
     Remittance saveAndFlush(Remittance remittance);
     Optional<Remittance> findByRemittanceId(UUID remittanceId);
-    Page<Remittance> findBySenderId(String senderId, Pageable pageable);
+    Page<Remittance> findBySenderId(UUID senderId, Pageable pageable);
 }

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletAlreadyExistsException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletAlreadyExistsException.java
@@ -1,8 +1,10 @@
 package com.stablepay.domain.wallet.exception;
 
+import java.util.UUID;
+
 public class WalletAlreadyExistsException extends RuntimeException {
 
-    public static WalletAlreadyExistsException forUserId(String userId) {
+    public static WalletAlreadyExistsException forUserId(UUID userId) {
         return new WalletAlreadyExistsException(
                 "SP-0008: Wallet already exists for userId: " + userId);
     }

--- a/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/exception/WalletNotFoundException.java
@@ -1,12 +1,14 @@
 package com.stablepay.domain.wallet.exception;
 
+import java.util.UUID;
+
 public class WalletNotFoundException extends RuntimeException {
 
     public static WalletNotFoundException byId(Long id) {
         return new WalletNotFoundException("SP-0006: Wallet not found: " + id);
     }
 
-    public static WalletNotFoundException byUserId(String userId) {
+    public static WalletNotFoundException byUserId(UUID userId) {
         return new WalletNotFoundException("SP-0006: Wallet not found for user: " + userId);
     }
 

--- a/backend/src/main/java/com/stablepay/domain/wallet/handler/CreateWalletHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/handler/CreateWalletHandler.java
@@ -1,6 +1,7 @@
 package com.stablepay.domain.wallet.handler;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class CreateWalletHandler {
     private final WalletRepository walletRepository;
     private final MpcWalletClient mpcWalletClient;
 
-    public Wallet handle(String userId) {
+    public Wallet handle(UUID userId) {
         walletRepository.findByUserId(userId).ifPresent(existing -> {
             throw WalletAlreadyExistsException.forUserId(userId);
         });

--- a/backend/src/main/java/com/stablepay/domain/wallet/model/Wallet.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/model/Wallet.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 
@@ -12,7 +13,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record Wallet(
     Long id,
-    String userId,
+    UUID userId,
     String solanaAddress,
     byte[] publicKey,
     byte[] keyShareData,

--- a/backend/src/main/java/com/stablepay/domain/wallet/port/WalletRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/port/WalletRepository.java
@@ -1,6 +1,7 @@
 package com.stablepay.domain.wallet.port;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import com.stablepay.domain.wallet.model.Wallet;
 
@@ -8,7 +9,7 @@ public interface WalletRepository {
     Wallet save(Wallet wallet);
     Optional<Wallet> findById(Long id);
     Optional<Wallet> findByIdForUpdate(Long id);
-    Optional<Wallet> findByUserId(String userId);
+    Optional<Wallet> findByUserId(UUID userId);
     Optional<Wallet> findBySolanaAddress(String solanaAddress);
     boolean existsById(Long id);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceEntity.java
@@ -39,7 +39,7 @@ public class RemittanceEntity {
     private UUID remittanceId;
 
     @Column(name = "sender_id", nullable = false)
-    private String senderId;
+    private UUID senderId;
 
     @Column(name = "recipient_phone", nullable = false)
     private String recipientPhone;

--- a/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceJpaRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface RemittanceJpaRepository extends JpaRepository<RemittanceEntity, Long> {
     Optional<RemittanceEntity> findByRemittanceId(UUID remittanceId);
-    Page<RemittanceEntity> findBySenderId(String senderId, Pageable pageable);
+    Page<RemittanceEntity> findBySenderId(UUID senderId, Pageable pageable);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/remittance/RemittanceRepositoryAdapter.java
@@ -48,7 +48,7 @@ class RemittanceRepositoryAdapter implements RemittanceRepository {
     }
 
     @Override
-    public Page<Remittance> findBySenderId(String senderId, Pageable pageable) {
+    public Page<Remittance> findBySenderId(UUID senderId, Pageable pageable) {
         return jpaRepository.findBySenderId(senderId, pageable).map(mapper::toDomain);
     }
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenEntity.java
@@ -1,0 +1,44 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshTokenEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token_hash", nullable = false, unique = true)
+    private String tokenHash;
+
+    @Column(name = "issued_at", nullable = false, updatable = false)
+    private Instant issuedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, UUID> {
     Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional
     @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = CURRENT_TIMESTAMP WHERE r.userId = :userId AND r.revokedAt IS NULL")
     void revokeByUserId(@Param("userId") UUID userId);

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
@@ -1,0 +1,17 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+    Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
+
+    @Modifying
+    @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = CURRENT_TIMESTAMP WHERE r.userId = :userId AND r.revokedAt IS NULL")
+    void revokeByUserId(@Param("userId") UUID userId);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
@@ -7,11 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, UUID> {
     Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
 
     @Modifying
+    @Transactional
     @Query("UPDATE RefreshTokenEntity r SET r.revokedAt = CURRENT_TIMESTAMP WHERE r.userId = :userId AND r.revokedAt IS NULL")
     void revokeByUserId(@Param("userId") UUID userId);
 }

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
+
+    private final RefreshTokenJpaRepository jpaRepository;
+    private final UserMapper mapper;
+
+    @Override
+    public Optional<RefreshToken> findByHash(String tokenHash) {
+        return jpaRepository.findByTokenHash(tokenHash).map(mapper::toDomain);
+    }
+
+    @Override
+    public RefreshToken save(RefreshToken token) {
+        var entity = mapper.toEntity(token);
+        entity.setIssuedAt(Instant.now());
+        var saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public void revokeByUserId(UUID userId) {
+        jpaRepository.revokeByUserId(userId);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityEntity.java
@@ -1,0 +1,47 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "social_identities")
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SocialIdentityEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "provider", nullable = false)
+    private String provider;
+
+    @Column(name = "subject", nullable = false)
+    private String subject;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityJpaRepository.java
@@ -1,0 +1,10 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SocialIdentityJpaRepository extends JpaRepository<SocialIdentityEntity, UUID> {
+    Optional<SocialIdentityEntity> findByProviderAndSubject(String provider, String subject);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapter.java
@@ -1,0 +1,35 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.model.SocialIdentity;
+import com.stablepay.domain.auth.port.SocialIdentityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class SocialIdentityRepositoryAdapter implements SocialIdentityRepository {
+
+    private final SocialIdentityJpaRepository jpaRepository;
+    private final UserMapper mapper;
+
+    @Override
+    public Optional<SocialIdentity> findByProviderAndSubject(String provider, String subject) {
+        return jpaRepository.findByProviderAndSubject(provider, subject).map(mapper::toDomain);
+    }
+
+    @Override
+    public SocialIdentity save(SocialIdentity identity, UUID userId) {
+        var entity = mapper.toEntity(identity);
+        entity.setId(UUID.randomUUID());
+        entity.setUserId(userId);
+        entity.setCreatedAt(Instant.now());
+        var saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapter.java
@@ -24,10 +24,9 @@ class SocialIdentityRepositoryAdapter implements SocialIdentityRepository {
     }
 
     @Override
-    public SocialIdentity save(SocialIdentity identity, UUID userId) {
+    public SocialIdentity save(SocialIdentity identity) {
         var entity = mapper.toEntity(identity);
         entity.setId(UUID.randomUUID());
-        entity.setUserId(userId);
         entity.setCreatedAt(Instant.now());
         var saved = jpaRepository.save(entity);
         return mapper.toDomain(saved);

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserEntity.java
@@ -1,0 +1,38 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserMapper.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserMapper.java
@@ -17,7 +17,6 @@ public interface UserMapper {
     SocialIdentity toDomain(SocialIdentityEntity entity);
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "userId", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     SocialIdentityEntity toEntity(SocialIdentity domain);
 

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserMapper.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserMapper.java
@@ -1,0 +1,28 @@
+package com.stablepay.infrastructure.db.user;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    AppUser toDomain(UserEntity entity);
+
+    @Mapping(target = "updatedAt", ignore = true)
+    UserEntity toEntity(AppUser domain);
+
+    SocialIdentity toDomain(SocialIdentityEntity entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    SocialIdentityEntity toEntity(SocialIdentity domain);
+
+    RefreshToken toDomain(RefreshTokenEntity entity);
+
+    @Mapping(target = "issuedAt", ignore = true)
+    RefreshTokenEntity toEntity(RefreshToken domain);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapter.java
@@ -27,9 +27,10 @@ class UserRepositoryAdapter implements UserRepository {
     public AppUser save(AppUser user) {
         var entity = mapper.toEntity(user);
         var now = Instant.now();
-        if (entity.getCreatedAt() == null) {
-            entity.setCreatedAt(now);
-        }
+        var createdAt = Optional.ofNullable(entity.getCreatedAt())
+                .or(() -> jpaRepository.findById(user.id()).map(UserEntity::getCreatedAt))
+                .orElse(now);
+        entity.setCreatedAt(createdAt);
         entity.setUpdatedAt(now);
         var saved = jpaRepository.save(entity);
         return mapper.toDomain(saved);

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.stablepay.infrastructure.db.user;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.port.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class UserRepositoryAdapter implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+    private final UserMapper mapper;
+
+    @Override
+    public Optional<AppUser> findById(UUID id) {
+        return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public AppUser save(AppUser user) {
+        var entity = mapper.toEntity(user);
+        var now = Instant.now();
+        if (entity.getCreatedAt() == null) {
+            entity.setCreatedAt(now);
+        }
+        entity.setUpdatedAt(now);
+        var saved = jpaRepository.save(entity);
+        return mapper.toDomain(saved);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletEntity.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletEntity.java
@@ -2,6 +2,7 @@ package com.stablepay.infrastructure.db.wallet;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,7 +32,7 @@ public class WalletEntity {
     private Long id;
 
     @Column(name = "user_id", nullable = false, unique = true)
-    private String userId;
+    private UUID userId;
 
     @Column(name = "solana_address", nullable = false, unique = true)
     private String solanaAddress;

--- a/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletJpaRepository.java
@@ -1,6 +1,7 @@
 package com.stablepay.infrastructure.db.wallet;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
@@ -15,7 +16,7 @@ interface WalletJpaRepository extends JpaRepository<WalletEntity, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "4000")})
-    Optional<WalletEntity> findByUserId(String userId);
+    Optional<WalletEntity> findByUserId(UUID userId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "4000")})

--- a/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/wallet/WalletRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.stablepay.infrastructure.db.wallet;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -40,7 +41,7 @@ class WalletRepositoryAdapter implements WalletRepository {
     }
 
     @Override
-    public Optional<Wallet> findByUserId(String userId) {
+    public Optional<Wallet> findByUserId(UUID userId) {
         return jpaRepository.findByUserId(userId).map(mapper::toDomain);
     }
 

--- a/backend/src/main/resources/db/migration/V8__users_and_auth.sql
+++ b/backend/src/main/resources/db/migration/V8__users_and_auth.sql
@@ -1,0 +1,39 @@
+CREATE TABLE users (
+    id         UUID         PRIMARY KEY,
+    email      VARCHAR(320) NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE TABLE social_identities (
+    id             UUID         PRIMARY KEY,
+    user_id        UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider       VARCHAR(32)  NOT NULL,
+    subject        VARCHAR(255) NOT NULL,
+    email          VARCHAR(320) NOT NULL,
+    email_verified BOOLEAN      NOT NULL,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uk_social_identity UNIQUE (provider, subject)
+);
+
+CREATE TABLE refresh_tokens (
+    id          UUID         PRIMARY KEY,
+    user_id     UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  VARCHAR(64)  NOT NULL,
+    issued_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ  NOT NULL,
+    revoked_at  TIMESTAMPTZ,
+    CONSTRAINT uk_refresh_hash UNIQUE (token_hash)
+);
+CREATE INDEX idx_refresh_user ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_hash ON refresh_tokens(token_hash) WHERE revoked_at IS NULL;
+
+TRUNCATE TABLE wallets CASCADE;
+ALTER TABLE wallets DROP COLUMN user_id;
+ALTER TABLE wallets ADD COLUMN user_id UUID NOT NULL REFERENCES users(id);
+CREATE UNIQUE INDEX idx_wallet_user ON wallets(user_id);
+
+TRUNCATE TABLE remittances CASCADE;
+ALTER TABLE remittances DROP COLUMN sender_id;
+ALTER TABLE remittances ADD COLUMN sender_id UUID NOT NULL REFERENCES users(id);
+CREATE INDEX idx_remittance_sender ON remittances(sender_id);

--- a/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/GlobalExceptionHandlerTest.java
@@ -87,7 +87,7 @@ class GlobalExceptionHandlerTest {
 
         @GetMapping("/test/wallet-already-exists")
         public void walletAlreadyExists() {
-            throw WalletAlreadyExistsException.forUserId("user-123");
+            throw WalletAlreadyExistsException.forUserId(UUID.fromString("00000000-0000-0000-0000-000000000123"));
         }
 
         @GetMapping("/test/unsupported-corridor")
@@ -199,7 +199,7 @@ class GlobalExceptionHandlerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0008"))
                 .andExpect(jsonPath("$.message").value(
-                        "SP-0008: Wallet already exists for userId: user-123"))
+                        "SP-0008: Wallet already exists for userId: 00000000-0000-0000-0000-000000000123"))
                 .andExpect(jsonPath("$.timestamp").value(FIXED_INSTANT.toString()))
                 .andExpect(jsonPath("$.path").value("/test/wallet-already-exists"));
     }

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -85,7 +85,7 @@ class ClaimControllerTest {
         mockMvc.perform(get("/api/claims/{token}", SOME_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()))
                 .andExpect(jsonPath("$.claimed").value(false));
     }
 

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -101,7 +101,7 @@ class RemittanceControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(SOME_REMITTANCE_DB_ID))
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()))
                 .andExpect(jsonPath("$.recipientPhone").value(SOME_RECIPIENT_PHONE))
                 .andExpect(jsonPath("$.status").value("INITIATED"));
     }
@@ -131,7 +131,7 @@ class RemittanceControllerTest {
         mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID));
+                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()));
     }
 
     @Test
@@ -154,12 +154,12 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(get("/api/remittances")
-                        .param("senderId", SOME_SENDER_ID)
+                        .param("senderId", SOME_SENDER_ID.toString())
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.content[0].senderId").value(SOME_SENDER_ID))
+                .andExpect(jsonPath("$.content[0].senderId").value(SOME_SENDER_ID.toString()))
                 .andExpect(jsonPath("$.totalElements").value(1));
     }
 
@@ -203,7 +203,7 @@ class RemittanceControllerTest {
     void shouldReturn400WhenValidationFails() {
         // given
         var request = CreateRemittanceRequest.builder()
-                .senderId("")
+                .senderId(null)
                 .recipientPhone("")
                 .amountUsdc(null)
                 .build();

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -215,4 +215,19 @@ class RemittanceControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0003"));
     }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn400WhenSenderIdIsBlankString() {
+        // given
+        var json = """
+                {"senderId":"","recipientPhone":"+919876543210","amountUsdc":100}
+                """;
+
+        // when / then
+        mockMvc.perform(post("/api/remittances")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -78,7 +78,7 @@ class WalletControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.userId").value(SOME_USER_ID))
+                .andExpect(jsonPath("$.userId").value(SOME_USER_ID.toString()))
                 .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
     }
 
@@ -86,7 +86,7 @@ class WalletControllerTest {
     @SneakyThrows
     void shouldReturn400WhenValidationFails() {
         // given
-        var request = CreateWalletRequest.builder().userId("").build();
+        var request = CreateWalletRequest.builder().userId(null).build();
 
         // when / then
         mockMvc.perform(post("/api/wallets")

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/CreateWalletHandlerTest.java
@@ -112,6 +112,6 @@ class CreateWalletHandlerTest {
         assertThatThrownBy(() -> createWalletHandler.handle(SOME_USER_ID))
                 .isInstanceOf(WalletAlreadyExistsException.class)
                 .hasMessageContaining("SP-0008")
-                .hasMessageContaining(SOME_USER_ID);
+                .hasMessageContaining(SOME_USER_ID.toString());
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
@@ -1,0 +1,125 @@
+package com.stablepay.infrastructure.db.user;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_EXPIRES_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
+import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.model.RefreshToken;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenRepositoryAdapterTest {
+
+    @Mock
+    private RefreshTokenJpaRepository jpaRepository;
+
+    @Spy
+    private UserMapper mapper = new UserMapperImpl();
+
+    @InjectMocks
+    private RefreshTokenRepositoryAdapter adapter;
+
+    @Captor
+    private ArgumentCaptor<RefreshTokenEntity> entityCaptor;
+
+    @Test
+    void shouldFindByHashAndMapToDomain() {
+        // given
+        var entity = RefreshTokenEntity.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .issuedAt(java.time.Instant.now())
+                .expiresAt(SOME_EXPIRES_AT)
+                .revokedAt(null)
+                .build();
+        given(jpaRepository.findByTokenHash(SOME_TOKEN_HASH)).willReturn(Optional.of(entity));
+
+        // when
+        var result = adapter.findByHash(SOME_TOKEN_HASH);
+
+        // then
+        var expected = RefreshToken.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_EXPIRES_AT)
+                .revokedAt(null)
+                .build();
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenHashNotFound() {
+        // given
+        given(jpaRepository.findByTokenHash(SOME_TOKEN_HASH)).willReturn(Optional.empty());
+
+        // when
+        var result = adapter.findByHash(SOME_TOKEN_HASH);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldSaveWithIssuedAtTimestamp() {
+        // given
+        var token = RefreshToken.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_EXPIRES_AT)
+                .build();
+        var savedEntity = RefreshTokenEntity.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .issuedAt(java.time.Instant.now())
+                .expiresAt(SOME_EXPIRES_AT)
+                .build();
+        given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
+
+        // when
+        var result = adapter.save(token);
+
+        // then
+        var captured = entityCaptor.getValue();
+        assertThat(captured.getIssuedAt()).isNotNull();
+
+        var expected = RefreshToken.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_EXPIRES_AT)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldDelegateRevokeByUserId() {
+        // when
+        adapter.revokeByUserId(SOME_USER_ID);
+
+        // then
+        then(jpaRepository).should().revokeByUserId(SOME_USER_ID);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
@@ -1,9 +1,9 @@
 package com.stablepay.infrastructure.db.user;
 
-import static com.stablepay.testutil.AuthFixtures.SOME_EXPIRES_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_EXPIRES_AT;
 import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
-import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -42,10 +42,10 @@ class RefreshTokenRepositoryAdapterTest {
         // given
         var entity = RefreshTokenEntity.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
                 .issuedAt(Instant.now())
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .revokedAt(null)
                 .build();
         given(jpaRepository.findByTokenHash(SOME_TOKEN_HASH)).willReturn(Optional.of(entity));
@@ -56,15 +56,14 @@ class RefreshTokenRepositoryAdapterTest {
         // then
         var expected = RefreshToken.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .revokedAt(null)
                 .build();
-        assertThat(result).isPresent();
-        assertThat(result.get())
+        assertThat(result)
                 .usingRecursiveComparison()
-                .isEqualTo(expected);
+                .isEqualTo(Optional.of(expected));
     }
 
     @Test
@@ -84,16 +83,16 @@ class RefreshTokenRepositoryAdapterTest {
         // given
         var token = RefreshToken.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .build();
         var savedEntity = RefreshTokenEntity.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
                 .issuedAt(Instant.now())
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .build();
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
 
@@ -104,9 +103,9 @@ class RefreshTokenRepositoryAdapterTest {
         var captured = entityCaptor.getValue();
         var expectedEntity = RefreshTokenEntity.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .build();
         assertThat(captured)
                 .usingRecursiveComparison()
@@ -116,9 +115,9 @@ class RefreshTokenRepositoryAdapterTest {
 
         var expected = RefreshToken.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .expiresAt(SOME_EXPIRES_AT)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
                 .build();
         assertThat(result)
                 .usingRecursiveComparison()
@@ -127,10 +126,12 @@ class RefreshTokenRepositoryAdapterTest {
 
     @Test
     void shouldDelegateRevokeByUserId() {
+        // given
+
         // when
-        adapter.revokeByUserId(SOME_USER_ID);
+        adapter.revokeByUserId(SOME_AUTH_USER_ID);
 
         // then
-        then(jpaRepository).should().revokeByUserId(SOME_USER_ID);
+        then(jpaRepository).should().revokeByUserId(SOME_AUTH_USER_ID);
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ class RefreshTokenRepositoryAdapterTest {
                 .id(SOME_REFRESH_TOKEN_ID)
                 .userId(SOME_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .issuedAt(java.time.Instant.now())
+                .issuedAt(Instant.now())
                 .expiresAt(SOME_EXPIRES_AT)
                 .revokedAt(null)
                 .build();
@@ -91,7 +92,7 @@ class RefreshTokenRepositoryAdapterTest {
                 .id(SOME_REFRESH_TOKEN_ID)
                 .userId(SOME_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .issuedAt(java.time.Instant.now())
+                .issuedAt(Instant.now())
                 .expiresAt(SOME_EXPIRES_AT)
                 .build();
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
@@ -101,6 +102,16 @@ class RefreshTokenRepositoryAdapterTest {
 
         // then
         var captured = entityCaptor.getValue();
+        var expectedEntity = RefreshTokenEntity.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_EXPIRES_AT)
+                .build();
+        assertThat(captured)
+                .usingRecursiveComparison()
+                .ignoringFields("issuedAt")
+                .isEqualTo(expectedEntity);
         assertThat(captured.getIssuedAt()).isNotNull();
 
         var expected = RefreshToken.builder()

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
@@ -1,9 +1,9 @@
 package com.stablepay.infrastructure.db.user;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
 import static com.stablepay.testutil.AuthFixtures.SOME_SOCIAL_EMAIL;
 import static com.stablepay.testutil.AuthFixtures.SOME_SUBJECT;
-import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -42,7 +42,7 @@ class SocialIdentityRepositoryAdapterTest {
         // given
         var entity = SocialIdentityEntity.builder()
                 .id(UUID.randomUUID())
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
@@ -57,15 +57,15 @@ class SocialIdentityRepositoryAdapterTest {
 
         // then
         var expected = SocialIdentity.builder()
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
                 .emailVerified(true)
                 .build();
-        assertThat(result).isPresent();
-        assertThat(result.get())
+        assertThat(result)
                 .usingRecursiveComparison()
-                .isEqualTo(expected);
+                .isEqualTo(Optional.of(expected));
     }
 
     @Test
@@ -85,6 +85,7 @@ class SocialIdentityRepositoryAdapterTest {
     void shouldSaveWithGeneratedIdAndUserId() {
         // given
         var identity = SocialIdentity.builder()
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
@@ -92,7 +93,7 @@ class SocialIdentityRepositoryAdapterTest {
                 .build();
         var savedEntity = SocialIdentityEntity.builder()
                 .id(UUID.randomUUID())
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
@@ -102,12 +103,12 @@ class SocialIdentityRepositoryAdapterTest {
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
 
         // when
-        var result = adapter.save(identity, SOME_USER_ID);
+        var result = adapter.save(identity);
 
         // then
         var captured = entityCaptor.getValue();
         var expectedEntity = SocialIdentityEntity.builder()
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
@@ -121,6 +122,7 @@ class SocialIdentityRepositoryAdapterTest {
         assertThat(captured.getCreatedAt()).isNotNull();
 
         var expected = SocialIdentity.builder()
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
@@ -7,7 +7,9 @@ import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,13 +41,13 @@ class SocialIdentityRepositoryAdapterTest {
     void shouldFindByProviderAndSubjectAndMapToDomain() {
         // given
         var entity = SocialIdentityEntity.builder()
-                .id(java.util.UUID.randomUUID())
+                .id(UUID.randomUUID())
                 .userId(SOME_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
                 .emailVerified(true)
-                .createdAt(java.time.Instant.now())
+                .createdAt(Instant.now())
                 .build();
         given(jpaRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
                 .willReturn(Optional.of(entity));
@@ -89,13 +91,13 @@ class SocialIdentityRepositoryAdapterTest {
                 .emailVerified(true)
                 .build();
         var savedEntity = SocialIdentityEntity.builder()
-                .id(java.util.UUID.randomUUID())
+                .id(UUID.randomUUID())
                 .userId(SOME_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
                 .emailVerified(true)
-                .createdAt(java.time.Instant.now())
+                .createdAt(Instant.now())
                 .build();
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
 
@@ -104,8 +106,18 @@ class SocialIdentityRepositoryAdapterTest {
 
         // then
         var captured = entityCaptor.getValue();
+        var expectedEntity = SocialIdentityEntity.builder()
+                .userId(SOME_USER_ID)
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .build();
+        assertThat(captured)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "createdAt")
+                .isEqualTo(expectedEntity);
         assertThat(captured.getId()).isNotNull();
-        assertThat(captured.getUserId()).isEqualTo(SOME_USER_ID);
         assertThat(captured.getCreatedAt()).isNotNull();
 
         var expected = SocialIdentity.builder()

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/SocialIdentityRepositoryAdapterTest.java
@@ -1,0 +1,121 @@
+package com.stablepay.infrastructure.db.user;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
+import static com.stablepay.testutil.AuthFixtures.SOME_SOCIAL_EMAIL;
+import static com.stablepay.testutil.AuthFixtures.SOME_SUBJECT;
+import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+@ExtendWith(MockitoExtension.class)
+class SocialIdentityRepositoryAdapterTest {
+
+    @Mock
+    private SocialIdentityJpaRepository jpaRepository;
+
+    @Spy
+    private UserMapper mapper = new UserMapperImpl();
+
+    @InjectMocks
+    private SocialIdentityRepositoryAdapter adapter;
+
+    @Captor
+    private ArgumentCaptor<SocialIdentityEntity> entityCaptor;
+
+    @Test
+    void shouldFindByProviderAndSubjectAndMapToDomain() {
+        // given
+        var entity = SocialIdentityEntity.builder()
+                .id(java.util.UUID.randomUUID())
+                .userId(SOME_USER_ID)
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .createdAt(java.time.Instant.now())
+                .build();
+        given(jpaRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
+                .willReturn(Optional.of(entity));
+
+        // when
+        var result = adapter.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT);
+
+        // then
+        var expected = SocialIdentity.builder()
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .build();
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNotFound() {
+        // given
+        given(jpaRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
+                .willReturn(Optional.empty());
+
+        // when
+        var result = adapter.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldSaveWithGeneratedIdAndUserId() {
+        // given
+        var identity = SocialIdentity.builder()
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .build();
+        var savedEntity = SocialIdentityEntity.builder()
+                .id(java.util.UUID.randomUUID())
+                .userId(SOME_USER_ID)
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .createdAt(java.time.Instant.now())
+                .build();
+        given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
+
+        // when
+        var result = adapter.save(identity, SOME_USER_ID);
+
+        // then
+        var captured = entityCaptor.getValue();
+        assertThat(captured.getId()).isNotNull();
+        assertThat(captured.getUserId()).isEqualTo(SOME_USER_ID);
+        assertThat(captured.getCreatedAt()).isNotNull();
+
+        var expected = SocialIdentity.builder()
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
@@ -1,14 +1,14 @@
 package com.stablepay.infrastructure.db.user;
 
-import static com.stablepay.testutil.AuthFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_EMAIL;
-import static com.stablepay.testutil.AuthFixtures.SOME_EXPIRES_AT;
 import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_EXPIRES_AT;
 import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_SOCIAL_EMAIL;
 import static com.stablepay.testutil.AuthFixtures.SOME_SUBJECT;
 import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
-import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
@@ -29,31 +29,35 @@ class UserMapperTest {
     class AppUserMapping {
 
         @Test
-        void shouldMapDomainToEntityAndBack() {
+        void shouldMapDomainToEntity() {
             // given
             var domain = AppUser.builder()
-                    .id(SOME_USER_ID)
+                    .id(SOME_AUTH_USER_ID)
                     .email(SOME_EMAIL)
-                    .createdAt(SOME_CREATED_AT)
+                    .createdAt(SOME_AUTH_CREATED_AT)
                     .build();
 
             // when
             var entity = mapper.toEntity(domain);
-            var backToDomain = mapper.toDomain(entity);
 
             // then
-            assertThat(backToDomain)
+            var expectedEntity = UserEntity.builder()
+                    .id(SOME_AUTH_USER_ID)
+                    .email(SOME_EMAIL)
+                    .createdAt(SOME_AUTH_CREATED_AT)
+                    .build();
+            assertThat(entity)
                     .usingRecursiveComparison()
-                    .isEqualTo(domain);
+                    .isEqualTo(expectedEntity);
         }
 
         @Test
         void shouldMapEntityToDomainWithAllFields() {
             // given
             var entity = UserEntity.builder()
-                    .id(SOME_USER_ID)
+                    .id(SOME_AUTH_USER_ID)
                     .email(SOME_EMAIL)
-                    .createdAt(SOME_CREATED_AT)
+                    .createdAt(SOME_AUTH_CREATED_AT)
                     .updatedAt(Instant.parse("2026-04-03T12:00:00Z"))
                     .build();
 
@@ -62,9 +66,9 @@ class UserMapperTest {
 
             // then
             var expected = AppUser.builder()
-                    .id(SOME_USER_ID)
+                    .id(SOME_AUTH_USER_ID)
                     .email(SOME_EMAIL)
-                    .createdAt(SOME_CREATED_AT)
+                    .createdAt(SOME_AUTH_CREATED_AT)
                     .build();
 
             assertThat(domain)
@@ -77,16 +81,16 @@ class UserMapperTest {
     class SocialIdentityMapping {
 
         @Test
-        void shouldMapEntityToDomainDroppingInfraFields() {
+        void shouldMapEntityToDomainIncludingUserId() {
             // given
             var entity = SocialIdentityEntity.builder()
                     .id(UUID.randomUUID())
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_AUTH_USER_ID)
                     .provider(SOME_PROVIDER)
                     .subject(SOME_SUBJECT)
                     .email(SOME_SOCIAL_EMAIL)
                     .emailVerified(true)
-                    .createdAt(SOME_CREATED_AT)
+                    .createdAt(SOME_AUTH_CREATED_AT)
                     .build();
 
             // when
@@ -94,6 +98,7 @@ class UserMapperTest {
 
             // then
             var expected = SocialIdentity.builder()
+                    .userId(SOME_AUTH_USER_ID)
                     .provider(SOME_PROVIDER)
                     .subject(SOME_SUBJECT)
                     .email(SOME_SOCIAL_EMAIL)
@@ -109,6 +114,7 @@ class UserMapperTest {
         void shouldMapDomainToEntityIgnoringInfraFields() {
             // given
             var domain = SocialIdentity.builder()
+                    .userId(SOME_AUTH_USER_ID)
                     .provider(SOME_PROVIDER)
                     .subject(SOME_SUBJECT)
                     .email(SOME_SOCIAL_EMAIL)
@@ -120,6 +126,7 @@ class UserMapperTest {
 
             // then
             var expectedEntity = SocialIdentityEntity.builder()
+                    .userId(SOME_AUTH_USER_ID)
                     .provider(SOME_PROVIDER)
                     .subject(SOME_SUBJECT)
                     .email(SOME_SOCIAL_EMAIL)
@@ -139,10 +146,10 @@ class UserMapperTest {
             // given
             var entity = RefreshTokenEntity.builder()
                     .id(SOME_REFRESH_TOKEN_ID)
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_AUTH_USER_ID)
                     .tokenHash(SOME_TOKEN_HASH)
                     .issuedAt(Instant.parse("2026-04-03T10:00:00Z"))
-                    .expiresAt(SOME_EXPIRES_AT)
+                    .expiresAt(SOME_REFRESH_EXPIRES_AT)
                     .revokedAt(null)
                     .build();
 
@@ -152,9 +159,9 @@ class UserMapperTest {
             // then
             var expected = RefreshToken.builder()
                     .id(SOME_REFRESH_TOKEN_ID)
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_AUTH_USER_ID)
                     .tokenHash(SOME_TOKEN_HASH)
-                    .expiresAt(SOME_EXPIRES_AT)
+                    .expiresAt(SOME_REFRESH_EXPIRES_AT)
                     .revokedAt(null)
                     .build();
 
@@ -168,9 +175,9 @@ class UserMapperTest {
             // given
             var domain = RefreshToken.builder()
                     .id(SOME_REFRESH_TOKEN_ID)
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_AUTH_USER_ID)
                     .tokenHash(SOME_TOKEN_HASH)
-                    .expiresAt(SOME_EXPIRES_AT)
+                    .expiresAt(SOME_REFRESH_EXPIRES_AT)
                     .build();
 
             // when
@@ -179,9 +186,9 @@ class UserMapperTest {
             // then
             var expectedEntity = RefreshTokenEntity.builder()
                     .id(SOME_REFRESH_TOKEN_ID)
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_AUTH_USER_ID)
                     .tokenHash(SOME_TOKEN_HASH)
-                    .expiresAt(SOME_EXPIRES_AT)
+                    .expiresAt(SOME_REFRESH_EXPIRES_AT)
                     .build();
             assertThat(entity)
                     .usingRecursiveComparison()

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
@@ -1,0 +1,184 @@
+package com.stablepay.infrastructure.db.user;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_EMAIL;
+import static com.stablepay.testutil.AuthFixtures.SOME_EXPIRES_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_SOCIAL_EMAIL;
+import static com.stablepay.testutil.AuthFixtures.SOME_SUBJECT;
+import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
+import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+class UserMapperTest {
+
+    private final UserMapper mapper = new UserMapperImpl();
+
+    @Nested
+    class AppUserMapping {
+
+        @Test
+        void shouldMapDomainToEntityAndBack() {
+            // given
+            var domain = AppUser.builder()
+                    .id(SOME_USER_ID)
+                    .email(SOME_EMAIL)
+                    .createdAt(SOME_CREATED_AT)
+                    .build();
+
+            // when
+            var entity = mapper.toEntity(domain);
+            var backToDomain = mapper.toDomain(entity);
+
+            // then
+            assertThat(backToDomain)
+                    .usingRecursiveComparison()
+                    .isEqualTo(domain);
+        }
+
+        @Test
+        void shouldMapEntityToDomainWithAllFields() {
+            // given
+            var entity = UserEntity.builder()
+                    .id(SOME_USER_ID)
+                    .email(SOME_EMAIL)
+                    .createdAt(SOME_CREATED_AT)
+                    .updatedAt(Instant.parse("2026-04-03T12:00:00Z"))
+                    .build();
+
+            // when
+            var domain = mapper.toDomain(entity);
+
+            // then
+            var expected = AppUser.builder()
+                    .id(SOME_USER_ID)
+                    .email(SOME_EMAIL)
+                    .createdAt(SOME_CREATED_AT)
+                    .build();
+
+            assertThat(domain)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class SocialIdentityMapping {
+
+        @Test
+        void shouldMapEntityToDomainDroppingInfraFields() {
+            // given
+            var entity = SocialIdentityEntity.builder()
+                    .id(UUID.randomUUID())
+                    .userId(SOME_USER_ID)
+                    .provider(SOME_PROVIDER)
+                    .subject(SOME_SUBJECT)
+                    .email(SOME_SOCIAL_EMAIL)
+                    .emailVerified(true)
+                    .createdAt(SOME_CREATED_AT)
+                    .build();
+
+            // when
+            var domain = mapper.toDomain(entity);
+
+            // then
+            var expected = SocialIdentity.builder()
+                    .provider(SOME_PROVIDER)
+                    .subject(SOME_SUBJECT)
+                    .email(SOME_SOCIAL_EMAIL)
+                    .emailVerified(true)
+                    .build();
+
+            assertThat(domain)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldMapDomainToEntityIgnoringInfraFields() {
+            // given
+            var domain = SocialIdentity.builder()
+                    .provider(SOME_PROVIDER)
+                    .subject(SOME_SUBJECT)
+                    .email(SOME_SOCIAL_EMAIL)
+                    .emailVerified(true)
+                    .build();
+
+            // when
+            var entity = mapper.toEntity(domain);
+
+            // then
+            assertThat(entity.getId()).isNull();
+            assertThat(entity.getUserId()).isNull();
+            assertThat(entity.getCreatedAt()).isNull();
+
+            var backToDomain = mapper.toDomain(entity);
+            assertThat(backToDomain)
+                    .usingRecursiveComparison()
+                    .isEqualTo(domain);
+        }
+    }
+
+    @Nested
+    class RefreshTokenMapping {
+
+        @Test
+        void shouldMapEntityToDomainDroppingIssuedAt() {
+            // given
+            var entity = RefreshTokenEntity.builder()
+                    .id(SOME_REFRESH_TOKEN_ID)
+                    .userId(SOME_USER_ID)
+                    .tokenHash(SOME_TOKEN_HASH)
+                    .issuedAt(Instant.parse("2026-04-03T10:00:00Z"))
+                    .expiresAt(SOME_EXPIRES_AT)
+                    .revokedAt(null)
+                    .build();
+
+            // when
+            var domain = mapper.toDomain(entity);
+
+            // then
+            var expected = RefreshToken.builder()
+                    .id(SOME_REFRESH_TOKEN_ID)
+                    .userId(SOME_USER_ID)
+                    .tokenHash(SOME_TOKEN_HASH)
+                    .expiresAt(SOME_EXPIRES_AT)
+                    .revokedAt(null)
+                    .build();
+
+            assertThat(domain)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldMapDomainToEntityIgnoringIssuedAt() {
+            // given
+            var domain = RefreshToken.builder()
+                    .id(SOME_REFRESH_TOKEN_ID)
+                    .userId(SOME_USER_ID)
+                    .tokenHash(SOME_TOKEN_HASH)
+                    .expiresAt(SOME_EXPIRES_AT)
+                    .build();
+
+            // when
+            var entity = mapper.toEntity(domain);
+
+            // then
+            assertThat(entity.getIssuedAt()).isNull();
+            assertThat(entity.getId()).isEqualTo(SOME_REFRESH_TOKEN_ID);
+            assertThat(entity.getUserId()).isEqualTo(SOME_USER_ID);
+        }
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserMapperTest.java
@@ -119,14 +119,15 @@ class UserMapperTest {
             var entity = mapper.toEntity(domain);
 
             // then
-            assertThat(entity.getId()).isNull();
-            assertThat(entity.getUserId()).isNull();
-            assertThat(entity.getCreatedAt()).isNull();
-
-            var backToDomain = mapper.toDomain(entity);
-            assertThat(backToDomain)
+            var expectedEntity = SocialIdentityEntity.builder()
+                    .provider(SOME_PROVIDER)
+                    .subject(SOME_SUBJECT)
+                    .email(SOME_SOCIAL_EMAIL)
+                    .emailVerified(true)
+                    .build();
+            assertThat(entity)
                     .usingRecursiveComparison()
-                    .isEqualTo(domain);
+                    .isEqualTo(expectedEntity);
         }
     }
 
@@ -176,9 +177,15 @@ class UserMapperTest {
             var entity = mapper.toEntity(domain);
 
             // then
-            assertThat(entity.getIssuedAt()).isNull();
-            assertThat(entity.getId()).isEqualTo(SOME_REFRESH_TOKEN_ID);
-            assertThat(entity.getUserId()).isEqualTo(SOME_USER_ID);
+            var expectedEntity = RefreshTokenEntity.builder()
+                    .id(SOME_REFRESH_TOKEN_ID)
+                    .userId(SOME_USER_ID)
+                    .tokenHash(SOME_TOKEN_HASH)
+                    .expiresAt(SOME_EXPIRES_AT)
+                    .build();
+            assertThat(entity)
+                    .usingRecursiveComparison()
+                    .isEqualTo(expectedEntity);
         }
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
@@ -1,8 +1,8 @@
 package com.stablepay.infrastructure.db.user;
 
-import static com.stablepay.testutil.AuthFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_EMAIL;
-import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -39,52 +39,51 @@ class UserRepositoryAdapterTest {
     void shouldFindUserByIdAndMapToDomain() {
         // given
         var entity = UserEntity.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
+                .updatedAt(SOME_AUTH_CREATED_AT)
                 .build();
-        given(jpaRepository.findById(SOME_USER_ID)).willReturn(Optional.of(entity));
+        given(jpaRepository.findById(SOME_AUTH_USER_ID)).willReturn(Optional.of(entity));
 
         // when
-        var result = adapter.findById(SOME_USER_ID);
+        var result = adapter.findById(SOME_AUTH_USER_ID);
 
         // then
         var expected = AppUser.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
                 .build();
-        assertThat(result).isPresent();
-        assertThat(result.get())
+        assertThat(result)
                 .usingRecursiveComparison()
-                .isEqualTo(expected);
+                .isEqualTo(Optional.of(expected));
     }
 
     @Test
     void shouldReturnEmptyWhenUserNotFound() {
         // given
-        given(jpaRepository.findById(SOME_USER_ID)).willReturn(Optional.empty());
+        given(jpaRepository.findById(SOME_AUTH_USER_ID)).willReturn(Optional.empty());
 
         // when
-        var result = adapter.findById(SOME_USER_ID);
+        var result = adapter.findById(SOME_AUTH_USER_ID);
 
         // then
         assertThat(result).isEmpty();
     }
 
     @Test
-    void shouldSaveUserWithTimestamps() {
+    void shouldSaveNewUserWithTimestamps() {
         // given
         var user = AppUser.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
                 .build();
         var savedEntity = UserEntity.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
+                .updatedAt(SOME_AUTH_CREATED_AT)
                 .build();
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
 
@@ -94,7 +93,7 @@ class UserRepositoryAdapterTest {
         // then
         var captured = entityCaptor.getValue();
         var expectedEntity = UserEntity.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
                 .build();
         assertThat(captured)
@@ -105,9 +104,9 @@ class UserRepositoryAdapterTest {
         assertThat(captured.getUpdatedAt()).isNotNull();
 
         var expected = AppUser.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
                 .build();
         assertThat(result)
                 .usingRecursiveComparison()
@@ -118,15 +117,15 @@ class UserRepositoryAdapterTest {
     void shouldPreserveExistingCreatedAtOnSave() {
         // given
         var user = AppUser.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
                 .build();
         var savedEntity = UserEntity.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_CREATED_AT)
+                .createdAt(SOME_AUTH_CREATED_AT)
+                .updatedAt(SOME_AUTH_CREATED_AT)
                 .build();
         given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
 
@@ -135,7 +134,37 @@ class UserRepositoryAdapterTest {
 
         // then
         var captured = entityCaptor.getValue();
-        assertThat(captured.getCreatedAt()).isEqualTo(SOME_CREATED_AT);
+        assertThat(captured.getCreatedAt()).isEqualTo(SOME_AUTH_CREATED_AT);
         then(jpaRepository).should().save(captured);
+    }
+
+    @Test
+    void shouldPreserveDbCreatedAtWhenDomainModelOmitsIt() {
+        // given
+        var user = AppUser.builder()
+                .id(SOME_AUTH_USER_ID)
+                .email(SOME_EMAIL)
+                .build();
+        var existingEntity = UserEntity.builder()
+                .id(SOME_AUTH_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_AUTH_CREATED_AT)
+                .updatedAt(SOME_AUTH_CREATED_AT)
+                .build();
+        given(jpaRepository.findById(SOME_AUTH_USER_ID)).willReturn(Optional.of(existingEntity));
+        var savedEntity = UserEntity.builder()
+                .id(SOME_AUTH_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_AUTH_CREATED_AT)
+                .updatedAt(SOME_AUTH_CREATED_AT)
+                .build();
+        given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
+
+        // when
+        adapter.save(user);
+
+        // then
+        var captured = entityCaptor.getValue();
+        assertThat(captured.getCreatedAt()).isEqualTo(SOME_AUTH_CREATED_AT);
     }
 }

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
@@ -93,6 +93,14 @@ class UserRepositoryAdapterTest {
 
         // then
         var captured = entityCaptor.getValue();
+        var expectedEntity = UserEntity.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .build();
+        assertThat(captured)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "updatedAt")
+                .isEqualTo(expectedEntity);
         assertThat(captured.getCreatedAt()).isNotNull();
         assertThat(captured.getUpdatedAt()).isNotNull();
 

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/UserRepositoryAdapterTest.java
@@ -1,0 +1,133 @@
+package com.stablepay.infrastructure.db.user;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_EMAIL;
+import static com.stablepay.testutil.AuthFixtures.SOME_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.model.AppUser;
+
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryAdapterTest {
+
+    @Mock
+    private UserJpaRepository jpaRepository;
+
+    @Spy
+    private UserMapper mapper = new UserMapperImpl();
+
+    @InjectMocks
+    private UserRepositoryAdapter adapter;
+
+    @Captor
+    private ArgumentCaptor<UserEntity> entityCaptor;
+
+    @Test
+    void shouldFindUserByIdAndMapToDomain() {
+        // given
+        var entity = UserEntity.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_CREATED_AT)
+                .build();
+        given(jpaRepository.findById(SOME_USER_ID)).willReturn(Optional.of(entity));
+
+        // when
+        var result = adapter.findById(SOME_USER_ID);
+
+        // then
+        var expected = AppUser.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .build();
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenUserNotFound() {
+        // given
+        given(jpaRepository.findById(SOME_USER_ID)).willReturn(Optional.empty());
+
+        // when
+        var result = adapter.findById(SOME_USER_ID);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldSaveUserWithTimestamps() {
+        // given
+        var user = AppUser.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .build();
+        var savedEntity = UserEntity.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_CREATED_AT)
+                .build();
+        given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
+
+        // when
+        var result = adapter.save(user);
+
+        // then
+        var captured = entityCaptor.getValue();
+        assertThat(captured.getCreatedAt()).isNotNull();
+        assertThat(captured.getUpdatedAt()).isNotNull();
+
+        var expected = AppUser.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldPreserveExistingCreatedAtOnSave() {
+        // given
+        var user = AppUser.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .build();
+        var savedEntity = UserEntity.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_CREATED_AT)
+                .build();
+        given(jpaRepository.save(entityCaptor.capture())).willReturn(savedEntity);
+
+        // when
+        adapter.save(user);
+
+        // then
+        var captured = entityCaptor.getValue();
+        assertThat(captured.getCreatedAt()).isEqualTo(SOME_CREATED_AT);
+        then(jpaRepository).should().save(captured);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -1,0 +1,48 @@
+package com.stablepay.testutil;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+public final class AuthFixtures {
+
+    private AuthFixtures() {}
+
+    public static final UUID SOME_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
+    public static final String SOME_EMAIL = "alice@example.com";
+    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+
+    public static final String SOME_PROVIDER = "google";
+    public static final String SOME_SUBJECT = "google-sub-12345";
+    public static final String SOME_SOCIAL_EMAIL = "alice@gmail.com";
+
+    public static final UUID SOME_REFRESH_TOKEN_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
+    public static final String SOME_TOKEN_HASH = "sha256-abc123def456";
+    public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-05-03T10:00:00Z");
+
+    public static AppUser.AppUserBuilder appUserBuilder() {
+        return AppUser.builder()
+                .id(SOME_USER_ID)
+                .email(SOME_EMAIL)
+                .createdAt(SOME_CREATED_AT);
+    }
+
+    public static SocialIdentity.SocialIdentityBuilder socialIdentityBuilder() {
+        return SocialIdentity.builder()
+                .provider(SOME_PROVIDER)
+                .subject(SOME_SUBJECT)
+                .email(SOME_SOCIAL_EMAIL)
+                .emailVerified(true);
+    }
+
+    public static RefreshToken.RefreshTokenBuilder refreshTokenBuilder() {
+        return RefreshToken.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_EXPIRES_AT);
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -6,14 +6,15 @@ import java.util.UUID;
 import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.model.RefreshToken;
 import com.stablepay.domain.auth.model.SocialIdentity;
+import com.stablepay.domain.auth.port.UserRepository;
 
 public final class AuthFixtures {
 
     private AuthFixtures() {}
 
-    public static final UUID SOME_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
+    public static final UUID SOME_AUTH_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
     public static final String SOME_EMAIL = "alice@example.com";
-    public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
+    public static final Instant SOME_AUTH_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
 
     public static final String SOME_PROVIDER = "google";
     public static final String SOME_SUBJECT = "google-sub-12345";
@@ -21,17 +22,18 @@ public final class AuthFixtures {
 
     public static final UUID SOME_REFRESH_TOKEN_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
     public static final String SOME_TOKEN_HASH = "sha256-abc123def456";
-    public static final Instant SOME_EXPIRES_AT = Instant.parse("2026-05-03T10:00:00Z");
+    public static final Instant SOME_REFRESH_EXPIRES_AT = Instant.parse("2026-05-03T10:00:00Z");
 
     public static AppUser.AppUserBuilder appUserBuilder() {
         return AppUser.builder()
-                .id(SOME_USER_ID)
+                .id(SOME_AUTH_USER_ID)
                 .email(SOME_EMAIL)
-                .createdAt(SOME_CREATED_AT);
+                .createdAt(SOME_AUTH_CREATED_AT);
     }
 
     public static SocialIdentity.SocialIdentityBuilder socialIdentityBuilder() {
         return SocialIdentity.builder()
+                .userId(SOME_AUTH_USER_ID)
                 .provider(SOME_PROVIDER)
                 .subject(SOME_SUBJECT)
                 .email(SOME_SOCIAL_EMAIL)
@@ -41,8 +43,14 @@ public final class AuthFixtures {
     public static RefreshToken.RefreshTokenBuilder refreshTokenBuilder() {
         return RefreshToken.builder()
                 .id(SOME_REFRESH_TOKEN_ID)
-                .userId(SOME_USER_ID)
+                .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
-                .expiresAt(SOME_EXPIRES_AT);
+                .expiresAt(SOME_REFRESH_EXPIRES_AT);
+    }
+
+    public static UUID createTestUser(UserRepository userRepository) {
+        var userId = UUID.randomUUID();
+        userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
+        return userId;
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/RemittanceFixtures.java
@@ -13,7 +13,7 @@ public final class RemittanceFixtures {
 
     public static final Long SOME_REMITTANCE_DB_ID = 1L;
     public static final UUID SOME_REMITTANCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-    public static final String SOME_SENDER_ID = "user-42";
+    public static final UUID SOME_SENDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
     public static final String SOME_RECIPIENT_PHONE = "+919876543210";
     public static final BigDecimal SOME_AMOUNT_USDC = BigDecimal.valueOf(100);
     public static final BigDecimal SOME_AMOUNT_INR = new BigDecimal("8325.00");

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
@@ -2,6 +2,7 @@ package com.stablepay.testutil;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
 
 import com.stablepay.domain.wallet.model.Wallet;
 
@@ -10,7 +11,7 @@ public final class WalletFixtures {
     private WalletFixtures() {}
 
     public static final Long SOME_WALLET_ID = 1L;
-    public static final String SOME_USER_ID = "user-42";
+    public static final UUID SOME_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
     public static final String SOME_SOLANA_ADDRESS = "SoLaNa1234567890AbCdEfGhIjKlMnOpQrStUvWx";
     public static final byte[] SOME_PUBLIC_KEY = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
     public static final byte[] SOME_KEY_SHARE_DATA = new byte[]{10, 20, 30, 40, 50};

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -196,9 +196,9 @@
 **Token architecture:**
 - Access token: HS256 JWT signed with `JWT_SECRET` env var, 15-minute TTL, minimal claims (`sub=userId UUID`, `iat`, `exp`). Verified by Spring OAuth2 Resource Server filter chain (`NimbusJwtDecoder.withSecretKey`).
 - Refresh token: 32-byte cryptographically random, prefixed `r1_`, SHA-256 hashed in DB. 30-day TTL. Rotated on use (old revoked, new issued). Single active chain per user.
-- Google idToken verification: `NimbusJwtDecoder.withJwkSetUri` against Google JWKS, called manually from domain handler — NOT in filter chain.
+- Google idToken verification: the domain handler depends on an `IdTokenVerifier` port. The infrastructure adapter verifies Google tokens with `NimbusJwtDecoder.withJwkSetUri` against Google JWKS. This remains outside the resource-server filter chain.
 
-**Eager wallet provisioning:** First login creates user + MPC wallet atomically in a single `@Transactional` block. MPC sidecar failure rolls back the entire transaction — no partial user. `CreateWalletHandler` is called inline (synchronous gRPC), not via Temporal workflow. Temporal is only used for the remittance lifecycle (ADR-005).
+**Eager wallet provisioning:** First login provisions the MPC wallet via synchronous gRPC and persists the user + wallet in one database transaction after successful key generation. Because the MPC sidecar is an external system, this flow is not truly atomic across DB and MPC state; use idempotency keys/timeouts and reconcile orphaned sidecar keys if persistence fails. Temporal remains reserved for the remittance lifecycle (ADR-005).
 
 **Ownership model:** Controllers extract `@AuthenticationPrincipal AppUser(UUID id)` from JWT `sub` claim via `AppUserConverter`. Load-by-id handlers verify `resource.userId == authenticatedUser.id`. Return 404 (not 403) on mismatch to prevent user enumeration.
 

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -186,3 +186,26 @@
 - Lock timeout (4s) bounds worst-case wait, preventing thread starvation.
 - `READ_COMMITTED` isolation is sufficient when combined with pessimistic locks.
 **Consequences:** Wallet reads that precede updates will block concurrent transactions. Acceptable for a single-corridor remittance system. Future sorted-lock-acquisition pattern may be needed if multi-wallet transfers are introduced.
+
+## ADR-022: Authentication & Authorization Strategy
+
+**Status:** Accepted
+**Context:** StablePay endpoints are currently unauthenticated — any caller can create wallets, send remittances, and view any user's data. Before the hackathon demo, we need to tie API access to a verified Google identity while keeping claim pages (recipient-facing) public and token-scoped.
+**Decision:** Google Social Login via OAuth2 + HS256 app-issued JWTs + opaque refresh token rotation.
+
+**Token architecture:**
+- Access token: HS256 JWT signed with `JWT_SECRET` env var, 15-minute TTL, minimal claims (`sub=userId UUID`, `iat`, `exp`). Verified by Spring OAuth2 Resource Server filter chain (`NimbusJwtDecoder.withSecretKey`).
+- Refresh token: 32-byte cryptographically random, prefixed `r1_`, SHA-256 hashed in DB. 30-day TTL. Rotated on use (old revoked, new issued). Single active chain per user.
+- Google idToken verification: `NimbusJwtDecoder.withJwkSetUri` against Google JWKS, called manually from domain handler — NOT in filter chain.
+
+**Eager wallet provisioning:** First login creates user + MPC wallet atomically in a single `@Transactional` block. MPC sidecar failure rolls back the entire transaction — no partial user. `CreateWalletHandler` is called inline (synchronous gRPC), not via Temporal workflow. Temporal is only used for the remittance lifecycle (ADR-005).
+
+**Ownership model:** Controllers extract `@AuthenticationPrincipal AppUser(UUID id)` from JWT `sub` claim via `AppUserConverter`. Load-by-id handlers verify `resource.userId == authenticatedUser.id`. Return 404 (not 403) on mismatch to prevent user enumeration.
+
+**Rationale:**
+- HS256 over RS256: simpler for single-service hackathon. No JWKS endpoint to host. Secret rotation = env var change + rolling restart.
+- Refresh rotation: prevents token theft from being permanent. Single chain per user simplifies revocation.
+- Eager wallet: eliminates "user exists but wallet doesn't" partial state. Single roundtrip for the mobile app on first login.
+- 404 over 403: standard practice to prevent resource enumeration.
+
+**Consequences:** All authenticated endpoints depend on `JWT_SECRET` being set. Secret rotation invalidates all access tokens immediately; refresh tokens survive (re-issued on next `/refresh` call). Claim pages remain public and token-scoped (ADR-011 unchanged). No JWT denylist — access tokens valid until natural expiry (≤15 min) after logout.


### PR DESCRIPTION
## STA Issue
Closes #203

## Changes
- Add Flyway migration `V8__users_and_auth.sql` creating `users`, `social_identities`, and `refresh_tokens` tables with FK constraints and indexes
- Migrate `wallets.user_id` and `remittances.sender_id` from `VARCHAR(255)` to `UUID NOT NULL REFERENCES users(id)` via `TRUNCATE CASCADE` (devnet-safe)
- Create `com.stablepay.domain.auth` package: 4 domain models (`AppUser`, `SocialIdentity`, `AuthSession`, `RefreshToken`), 3 ports, 5 exceptions (SP-0032 through SP-0036)
- Create `com.stablepay.infrastructure.db.user` package: 3 JPA entities, 3 Spring Data repos, 3 repository adapters, 1 MapStruct mapper
- Cascade `String→UUID` type change across all domain models, handlers, ports, DTOs, controllers, entities, JPA repos, and adapters (30+ files)
- Update all existing unit and integration tests for UUID userId/senderId, including jsonPath `.toString()` comparisons and `@NotBlank→@NotNull` validation changes
- Add `AuthFixtures` test fixture class and unit tests for `UserMapper`, `UserRepositoryAdapter`, `SocialIdentityRepositoryAdapter`, `RefreshTokenRepositoryAdapter`
- Add ADR-022 (Auth Strategy: Google OIDC + short-lived JWT + refresh tokens)

## Checklist
- [x] `./gradlew build` passes (416 unit tests green)
- [x] `./gradlew integrationTest` passes
- [x] Unit tests added for all new adapters and mapper
- [x] ArchUnit rules pass — domain imports no infrastructure or application code
- [x] Spotless formatting applied
- [x] All domain models are Java records with `@Builder(toBuilder = true)`, zero Spring imports
- [x] All exceptions use `SP-XXXX` error codes and static factory methods
- [x] MapStruct `@Mapper(componentModel = "spring")` for entity ↔ domain mapping
- [x] `@RequiredArgsConstructor` + `private final` for DI — no `@Autowired`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google OAuth2 social login with JWT access tokens and opaque rotating refresh tokens.
  * Automatic user account (and initial wallet) provisioning on first login.
  * Email verification requirement enforced for accounts.

* **Bug Fixes**
  * More reliable user identifier handling and validation (reduces mismatch/validation errors).
  * Improved error responses for invalid or missing IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->