### PR TITLE
STA-96: add JWT machinery and Spring Security dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ docker compose down                # stop infrastructure
 | Component | Version / Library |
 |---|---|
 | Java | 25 (LTS, Eclipse Temurin) |
-| Spring Boot | 4.0.3 |
+| Spring Boot | 4.0.5 |
 | HTTP Server | Tomcat (Spring MVC) |
 | HTTP Layer | Spring MVC — controllers return standard types |
 | Database | JPA + Hibernate + PostgreSQL 16 |

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.apache.commons:commons-pool2")
 
     // Lombok

--- a/backend/src/main/java/com/stablepay/application/config/AppUserConverter.java
+++ b/backend/src/main/java/com/stablepay/application/config/AppUserConverter.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -11,10 +12,10 @@ import org.springframework.stereotype.Component;
 import com.stablepay.domain.auth.model.AuthPrincipal;
 
 @Component
-public class AppUserConverter implements Converter<Jwt, JwtAuthenticationToken> {
+public class AppUserConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
     @Override
-    public JwtAuthenticationToken convert(Jwt jwt) {
+    public AbstractAuthenticationToken convert(Jwt jwt) {
         var userId = UUID.fromString(jwt.getSubject());
         var principal = AuthPrincipal.builder().id(userId).build();
         return new JwtAuthenticationToken(jwt, Collections.emptyList(), principal.id().toString()) {

--- a/backend/src/main/java/com/stablepay/application/config/AppUserConverter.java
+++ b/backend/src/main/java/com/stablepay/application/config/AppUserConverter.java
@@ -1,0 +1,27 @@
+package com.stablepay.application.config;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.model.AuthPrincipal;
+
+@Component
+public class AppUserConverter implements Converter<Jwt, JwtAuthenticationToken> {
+
+    @Override
+    public JwtAuthenticationToken convert(Jwt jwt) {
+        var userId = UUID.fromString(jwt.getSubject());
+        var principal = AuthPrincipal.builder().id(userId).build();
+        return new JwtAuthenticationToken(jwt, Collections.emptyList(), principal.id().toString()) {
+            @Override
+            public Object getPrincipal() {
+                return principal;
+            }
+        };
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/GoogleAuthProps.java
+++ b/backend/src/main/java/com/stablepay/application/config/GoogleAuthProps.java
@@ -1,0 +1,24 @@
+package com.stablepay.application.config;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Builder;
+
+@ConfigurationProperties(prefix = "stablepay.auth.google")
+@Validated
+@Builder(toBuilder = true)
+public record GoogleAuthProps(
+    @NotEmpty List<String> clientIds
+) {
+    public GoogleAuthProps {
+        requireNonNull(clientIds, "clientIds cannot be null");
+        clientIds = List.copyOf(clientIds);
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/JwtConfig.java
+++ b/backend/src/main/java/com/stablepay/application/config/JwtConfig.java
@@ -1,0 +1,86 @@
+package com.stablepay.application.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtClaimValidator;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties({JwtProperties.class, GoogleAuthProps.class})
+public class JwtConfig {
+
+    private final JwtProperties jwtProperties;
+    private final GoogleAuthProps googleAuthProps;
+
+    @Bean
+    public AuthTokenConfig authTokenConfig() {
+        return AuthTokenConfig.builder()
+                .accessTtl(jwtProperties.accessTtl())
+                .refreshTtl(jwtProperties.refreshTtl())
+                .build();
+    }
+
+    @Bean
+    public JwtEncoder appJwtEncoder() {
+        var secretKey = hmacKey();
+        var jwk = new OctetSequenceKey.Builder(secretKey).build();
+        JWKSource<SecurityContext> jwkSource = new ImmutableJWKSet<>(new com.nimbusds.jose.jwk.JWKSet(jwk));
+        return new NimbusJwtEncoder(jwkSource);
+    }
+
+    @Bean("appJwtDecoder")
+    public JwtDecoder appJwtDecoder() {
+        return NimbusJwtDecoder.withSecretKey(hmacKey()).build();
+    }
+
+    @Bean("googleJwtDecoder")
+    public JwtDecoder googleJwtDecoder() {
+        var decoder = NimbusJwtDecoder
+                .withJwkSetUri("https://www.googleapis.com/oauth2/v3/certs")
+                .build();
+
+        OAuth2TokenValidator<Jwt> issuerValidator =
+                JwtValidators.createDefaultWithIssuer("https://accounts.google.com");
+
+        OAuth2TokenValidator<Jwt> audienceValidator =
+                new JwtClaimValidator<Collection<String>>(JwtClaimNames.AUD,
+                        aud -> {
+                            var audiences = aud != null ? List.copyOf(aud) : Collections.<String>emptyList();
+                            return googleAuthProps.clientIds().stream().anyMatch(audiences::contains);
+                        });
+
+        var compositeValidator = new DelegatingOAuth2TokenValidator<>(issuerValidator, audienceValidator);
+        decoder.setJwtValidator(compositeValidator);
+
+        return decoder;
+    }
+
+    private SecretKeySpec hmacKey() {
+        return new SecretKeySpec(
+                jwtProperties.secret().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/JwtProperties.java
+++ b/backend/src/main/java/com/stablepay/application/config/JwtProperties.java
@@ -1,0 +1,28 @@
+package com.stablepay.application.config;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Builder;
+
+@ConfigurationProperties(prefix = "stablepay.jwt")
+@Validated
+@Builder(toBuilder = true)
+public record JwtProperties(
+    @NotBlank String secret,
+    @NotNull Duration accessTtl,
+    @NotNull Duration refreshTtl
+) {
+    public JwtProperties {
+        requireNonNull(secret, "secret cannot be null");
+        requireNonNull(accessTtl, "accessTtl cannot be null");
+        requireNonNull(refreshTtl, "refreshTtl cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/application/config/JwtProperties.java
+++ b/backend/src/main/java/com/stablepay/application/config/JwtProperties.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -16,7 +17,7 @@ import lombok.Builder;
 @Validated
 @Builder(toBuilder = true)
 public record JwtProperties(
-    @NotBlank String secret,
+    @NotBlank @Size(min = 32) String secret,
     @NotNull Duration accessTtl,
     @NotNull Duration refreshTtl
 ) {

--- a/backend/src/main/java/com/stablepay/application/config/SecurityConfig.java
+++ b/backend/src/main/java/com/stablepay/application/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.stablepay.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/AuthPrincipal.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/AuthPrincipal.java
@@ -1,0 +1,14 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthPrincipal(UUID id) {
+    public AuthPrincipal {
+        requireNonNull(id, "id cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/model/AuthTokenConfig.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/AuthTokenConfig.java
@@ -14,5 +14,11 @@ public record AuthTokenConfig(
     public AuthTokenConfig {
         requireNonNull(accessTtl, "accessTtl cannot be null");
         requireNonNull(refreshTtl, "refreshTtl cannot be null");
+        if (accessTtl.isNegative() || accessTtl.isZero()) {
+            throw new IllegalArgumentException("accessTtl must be positive");
+        }
+        if (refreshTtl.isNegative() || refreshTtl.isZero()) {
+            throw new IllegalArgumentException("refreshTtl must be positive");
+        }
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/auth/model/AuthTokenConfig.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/AuthTokenConfig.java
@@ -1,0 +1,18 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthTokenConfig(
+    Duration accessTtl,
+    Duration refreshTtl
+) {
+    public AuthTokenConfig {
+        requireNonNull(accessTtl, "accessTtl cannot be null");
+        requireNonNull(refreshTtl, "refreshTtl cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/AuthTokenIssuer.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/AuthTokenIssuer.java
@@ -1,0 +1,9 @@
+package com.stablepay.domain.auth.port;
+
+import java.util.UUID;
+
+import com.stablepay.domain.auth.model.AuthSession;
+
+public interface AuthTokenIssuer {
+    AuthSession issue(UUID userId);
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityVerifier.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/SocialIdentityVerifier.java
@@ -1,0 +1,7 @@
+package com.stablepay.domain.auth.port;
+
+import com.stablepay.domain.auth.model.SocialIdentity;
+
+public interface SocialIdentityVerifier {
+    SocialIdentity verify(String provider, String idToken);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapter.java
@@ -1,0 +1,52 @@
+package com.stablepay.infrastructure.auth.jwt;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.model.AuthSession;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+import com.stablepay.domain.auth.port.AuthTokenIssuer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenIssuerAdapter implements AuthTokenIssuer {
+
+    private final JwtEncoder jwtEncoder;
+    private final AuthTokenConfig authTokenConfig;
+    private final Clock clock;
+    private final RefreshTokenGenerator refreshTokenGenerator;
+
+    @Override
+    public AuthSession issue(UUID userId) {
+        var now = Instant.now(clock);
+        var expiresAt = now.plus(authTokenConfig.accessTtl());
+
+        var claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .build();
+
+        var header = JwsHeader.with(() -> JwsAlgorithms.HS256).build();
+        var jwt = jwtEncoder.encode(JwtEncoderParameters.from(header, claims));
+        var refreshToken = refreshTokenGenerator.generate();
+
+        return AuthSession.builder()
+                .accessToken(jwt.getTokenValue())
+                .refreshToken(refreshToken)
+                .accessExpiresAt(expiresAt)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapter.java
@@ -1,5 +1,7 @@
 package com.stablepay.infrastructure.auth.jwt;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
@@ -16,9 +18,7 @@ import com.stablepay.domain.auth.model.AuthTokenConfig;
 import com.stablepay.domain.auth.port.AuthTokenIssuer;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenIssuerAdapter implements AuthTokenIssuer {
@@ -30,6 +30,7 @@ public class JwtTokenIssuerAdapter implements AuthTokenIssuer {
 
     @Override
     public AuthSession issue(UUID userId) {
+        requireNonNull(userId, "userId cannot be null");
         var now = Instant.now(clock);
         var expiresAt = now.plus(authTokenConfig.accessTtl());
 

--- a/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/RefreshTokenGenerator.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/RefreshTokenGenerator.java
@@ -1,0 +1,37 @@
+package com.stablepay.infrastructure.auth.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenGenerator {
+
+    private static final String TOKEN_PREFIX = "r1_";
+    private static final int TOKEN_BYTES = 32;
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generate() {
+        var bytes = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(bytes);
+        var encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        return TOKEN_PREFIX + encoded;
+    }
+
+    public String hash(String rawToken) {
+        try {
+            var digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            var hashBytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -38,6 +38,14 @@ server:
   port: 8080
 
 stablepay:
+  jwt:
+    secret: ${JWT_SECRET:dev-secret-at-least-32-characters-long!!}
+    access-ttl: PT15M
+    refresh-ttl: P30D
+  auth:
+    google:
+      client-ids:
+        - ${GOOGLE_ANDROID_CLIENT_ID:placeholder-client-id}
   disbursement:
     provider: ${STABLEPAY_DISBURSEMENT_PROVIDER:logging}
   razorpay:

--- a/backend/src/test/java/com/stablepay/application/config/AppUserConverterTest.java
+++ b/backend/src/test/java/com/stablepay/application/config/AppUserConverterTest.java
@@ -1,0 +1,39 @@
+package com.stablepay.application.config;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.stablepay.domain.auth.model.AuthPrincipal;
+
+@ExtendWith(MockitoExtension.class)
+class AppUserConverterTest {
+
+    @Mock
+    private Jwt jwt;
+
+    @InjectMocks
+    private AppUserConverter converter;
+
+    @Test
+    void shouldConvertJwtToAuthenticationTokenWithAuthPrincipal() {
+        // given
+        given(jwt.getSubject()).willReturn(SOME_AUTH_USER_ID.toString());
+
+        // when
+        var result = converter.convert(jwt);
+
+        // then
+        var expected = AuthPrincipal.builder().id(SOME_AUTH_USER_ID).build();
+        assertThat(result.getPrincipal())
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/auth/jwt/JwtTokenIssuerAdapterTest.java
@@ -1,0 +1,94 @@
+package com.stablepay.infrastructure.auth.jwt;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_ACCESS_TTL;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_JWT_SECRET;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TTL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+
+class JwtTokenIssuerAdapterTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-20T12:00:00Z");
+
+    private JwtTokenIssuerAdapter adapter;
+    private NimbusJwtDecoder decoder;
+
+    @BeforeEach
+    void setUp() {
+        var secretKey = new SecretKeySpec(
+                SOME_JWT_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        var jwk = new OctetSequenceKey.Builder(secretKey).build();
+        var jwkSource = new ImmutableJWKSet<>(new com.nimbusds.jose.jwk.JWKSet(jwk));
+        var encoder = new NimbusJwtEncoder(jwkSource);
+
+        var tokenConfig = AuthTokenConfig.builder()
+                .accessTtl(SOME_ACCESS_TTL)
+                .refreshTtl(SOME_REFRESH_TTL)
+                .build();
+        var fixedClock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+        var refreshTokenGenerator = new RefreshTokenGenerator();
+        adapter = new JwtTokenIssuerAdapter(encoder, tokenConfig, fixedClock, refreshTokenGenerator);
+
+        decoder = NimbusJwtDecoder.withSecretKey(secretKey).build();
+        var timestampValidator = new JwtTimestampValidator();
+        timestampValidator.setClock(fixedClock);
+        decoder.setJwtValidator(timestampValidator);
+    }
+
+    @Test
+    void shouldIssueValidAccessTokenWithCorrectClaims() {
+        // given
+        var expectedClaims = Map.of(
+                "sub", (Object) SOME_AUTH_USER_ID.toString(),
+                "iat", FIXED_NOW,
+                "exp", FIXED_NOW.plus(SOME_ACCESS_TTL));
+
+        // when
+        var result = adapter.issue(SOME_AUTH_USER_ID);
+
+        // then
+        var decoded = decoder.decode(result.accessToken());
+        assertThat(decoded.getClaims())
+                .containsExactlyInAnyOrderEntriesOf(expectedClaims);
+    }
+
+    @Test
+    void shouldGenerateRefreshTokenWithR1Prefix() {
+        // given
+
+        // when
+        var result = adapter.issue(SOME_AUTH_USER_ID);
+
+        // then
+        assertThat(result.refreshToken()).startsWith("r1_");
+    }
+
+    @Test
+    void shouldSetAccessExpiresAtToNowPlusTtl() {
+        // given
+        var expectedExpiresAt = FIXED_NOW.plus(SOME_ACCESS_TTL);
+
+        // when
+        var result = adapter.issue(SOME_AUTH_USER_ID);
+
+        // then
+        assertThat(result.accessExpiresAt()).isEqualTo(expectedExpiresAt);
+    }
+}

--- a/backend/src/test/java/com/stablepay/infrastructure/auth/jwt/RefreshTokenGeneratorTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/auth/jwt/RefreshTokenGeneratorTest.java
@@ -1,0 +1,77 @@
+package com.stablepay.infrastructure.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenGeneratorTest {
+
+    private RefreshTokenGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new RefreshTokenGenerator();
+    }
+
+    @Test
+    void shouldGenerateTokenWithR1Prefix() {
+        // given
+
+        // when
+        var result = generator.generate();
+
+        // then
+        assertThat(result).startsWith("r1_");
+    }
+
+    @Test
+    void shouldGenerateUrlSafeBase64Token() {
+        // given
+
+        // when
+        var result = generator.generate();
+
+        // then
+        var tokenBody = result.substring(3);
+        assertThat(tokenBody).doesNotContain("+", "=", "/");
+    }
+
+    @Test
+    void shouldGenerateUniqueTokensOnEachCall() {
+        // given
+
+        // when
+        var first = generator.generate();
+        var second = generator.generate();
+
+        // then
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void shouldProduceConsistentHashForSameToken() {
+        // given
+        var token = generator.generate();
+
+        // when
+        var hash1 = generator.hash(token);
+        var hash2 = generator.hash(token);
+
+        // then
+        assertThat(hash1).isEqualTo(hash2);
+    }
+
+    @Test
+    void shouldProduceHexHashOf64Characters() {
+        // given
+        var token = generator.generate();
+
+        // when
+        var result = generator.hash(token);
+
+        // then
+        assertThat(result).hasSize(64);
+        assertThat(result).matches("[0-9a-f]{64}");
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -1,5 +1,6 @@
 package com.stablepay.testutil;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -11,6 +12,10 @@ import com.stablepay.domain.auth.port.UserRepository;
 public final class AuthFixtures {
 
     private AuthFixtures() {}
+
+    public static final String SOME_JWT_SECRET = "test-jwt-secret-must-be-at-least-32-bytes-long!!";
+    public static final Duration SOME_ACCESS_TTL = Duration.ofMinutes(15);
+    public static final Duration SOME_REFRESH_TTL = Duration.ofDays(30);
 
     public static final UUID SOME_AUTH_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
     public static final String SOME_EMAIL = "alice@example.com";


### PR DESCRIPTION
## STA Issue
Closes #204

## Changes
- Add `spring-boot-starter-oauth2-resource-server` dependency (transitively pulls Spring Security + nimbus-jose-jwt)
- Add domain ports: `AuthTokenIssuer` (issue JWT + refresh token) and `SocialIdentityVerifier` (interface only, impl in #205)
- Add `AuthPrincipal(UUID id)` lightweight principal record and `AuthTokenConfig` domain value object for access/refresh TTLs
- Add `JwtConfig` with two `JwtDecoder` beans: `appJwtDecoder` (HS256/HMAC) and `googleJwtDecoder` (Google JWKS with issuer + audience validators), plus `JwtEncoder` bean
- Add `AppUserConverter` — converts JWT `sub` claim to `AuthPrincipal` for `@AuthenticationPrincipal` extraction
- Add `JwtTokenIssuerAdapter` — signs HS256 JWT with `sub=userId`, `iat`, `exp` (15 min TTL) via `NimbusJwtEncoder`
- Add `RefreshTokenGenerator` — 32-byte random, URL-safe base64 with `r1_` prefix, SHA-256 hash for storage
- Add `SecurityConfig` with temporary `permitAll()` to prevent Spring Security from breaking existing endpoints (filter chain wiring in #208)
- Add `@ConfigurationProperties` for `stablepay.jwt.*` and `stablepay.auth.google.*` in `application.yml`
- Add unit tests: `JwtTokenIssuerAdapterTest` (round-trip sign→decode, claims-only verification), `RefreshTokenGeneratorTest` (5 tests), `AppUserConverterTest`

## Architecture notes
- `JwtTokenIssuerAdapter` depends only on domain (`AuthTokenConfig`, `AuthTokenIssuer` port) and Spring `JwtEncoder` bean — no `application` layer imports from infrastructure
- HMAC key construction centralized in `JwtConfig` with explicit `StandardCharsets.UTF_8`
- All records follow project conventions: `@Builder(toBuilder = true)`, `requireNonNull` compact constructors

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (9 test methods across 3 test classes)
- [ ] Integration tests added/updated (not applicable — no DB/Spring context needed)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

## Test plan
- [x] Verify `JwtTokenIssuerAdapter` round-trip: issue HS256 JWT → decode with `NimbusJwtDecoder` → assert `sub`/`iat`/`exp` are exactly correct and no extra claims
- [x] Verify `RefreshTokenGenerator` produces `r1_`-prefixed URL-safe tokens with consistent 64-char hex SHA-256 hashes
- [x] Verify `AppUserConverter` extracts `AuthPrincipal(UUID)` from JWT `sub` claim
- [x] Verify existing tests still pass with Spring Security on classpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)