### PR TITLE
STA-98: add social login, refresh token rotation, and logout handlers

### DIFF
--- a/backend/src/main/java/com/stablepay/domain/auth/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.stablepay.domain.auth.exception;
+
+import java.util.UUID;
+
+public class UserNotFoundException extends RuntimeException {
+
+    public static UserNotFoundException byId(UUID userId) {
+        return new UserNotFoundException("SP-0037: User not found: " + userId);
+    }
+
+    private UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/LogoutHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/LogoutHandler.java
@@ -1,0 +1,25 @@
+package com.stablepay.domain.auth.handler;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LogoutHandler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void handle(UUID userId) {
+        refreshTokenRepository.revokeByUserId(userId);
+        log.info("All refresh tokens revoked for userId={}", userId);
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/RefreshTokenHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/RefreshTokenHandler.java
@@ -1,0 +1,66 @@
+package com.stablepay.domain.auth.handler;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.auth.exception.InvalidRefreshTokenException;
+import com.stablepay.domain.auth.exception.RefreshTokenExpiredException;
+import com.stablepay.domain.auth.model.AuthSession;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.port.AuthTokenIssuer;
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+import com.stablepay.domain.auth.port.TokenHasher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenHandler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenHasher tokenHasher;
+    private final AuthTokenIssuer authTokenIssuer;
+    private final AuthTokenConfig authTokenConfig;
+    private final Clock clock;
+
+    public AuthSession handle(String rawRefreshToken) {
+        var now = Instant.now(clock);
+        var tokenHash = tokenHasher.hash(rawRefreshToken);
+
+        var token = refreshTokenRepository.findByHash(tokenHash)
+                .orElseThrow(() -> InvalidRefreshTokenException.of("not found"));
+
+        if (token.revokedAt() != null) {
+            throw InvalidRefreshTokenException.of("revoked");
+        }
+
+        if (now.isAfter(token.expiresAt())) {
+            throw RefreshTokenExpiredException.forToken(token.id());
+        }
+
+        refreshTokenRepository.save(token.toBuilder().revokedAt(now).build());
+
+        var newSession = authTokenIssuer.issue(token.userId());
+        var newHash = tokenHasher.hash(newSession.refreshToken());
+
+        var newRefreshToken = RefreshToken.builder()
+                .id(UUID.randomUUID())
+                .userId(token.userId())
+                .tokenHash(newHash)
+                .expiresAt(now.plus(authTokenConfig.refreshTtl()))
+                .build();
+        refreshTokenRepository.save(newRefreshToken);
+
+        log.info("Refresh token rotated for userId={}", token.userId());
+
+        return newSession;
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/RefreshTokenHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/RefreshTokenHandler.java
@@ -35,14 +35,14 @@ public class RefreshTokenHandler {
         var now = Instant.now(clock);
         var tokenHash = tokenHasher.hash(rawRefreshToken);
 
-        var token = refreshTokenRepository.findByHash(tokenHash)
+        var token = refreshTokenRepository.findByHashForUpdate(tokenHash)
                 .orElseThrow(() -> InvalidRefreshTokenException.of("not found"));
 
         if (token.revokedAt() != null) {
             throw InvalidRefreshTokenException.of("revoked");
         }
 
-        if (now.isAfter(token.expiresAt())) {
+        if (!now.isBefore(token.expiresAt())) {
             throw RefreshTokenExpiredException.forToken(token.id());
         }
 

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
@@ -73,6 +73,8 @@ public class SocialLoginHandler {
         var session = authTokenIssuer.issue(appUser.id());
         var tokenHash = tokenHasher.hash(session.refreshToken());
 
+        refreshTokenRepository.revokeByUserId(appUser.id());
+
         var refreshToken = RefreshToken.builder()
                 .id(UUID.randomUUID())
                 .userId(appUser.id())

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
@@ -1,0 +1,88 @@
+package com.stablepay.domain.auth.handler;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+import com.stablepay.domain.auth.model.LoginResult;
+import com.stablepay.domain.auth.model.RefreshToken;
+import com.stablepay.domain.auth.port.AuthTokenIssuer;
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+import com.stablepay.domain.auth.port.SocialIdentityRepository;
+import com.stablepay.domain.auth.port.SocialIdentityVerifier;
+import com.stablepay.domain.auth.port.TokenHasher;
+import com.stablepay.domain.auth.port.UserRepository;
+import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SocialLoginHandler {
+
+    private final SocialIdentityVerifier socialIdentityVerifier;
+    private final SocialIdentityRepository socialIdentityRepository;
+    private final UserRepository userRepository;
+    private final CreateWalletHandler createWalletHandler;
+    private final WalletRepository walletRepository;
+    private final AuthTokenIssuer authTokenIssuer;
+    private final TokenHasher tokenHasher;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthTokenConfig authTokenConfig;
+    private final Clock clock;
+
+    public LoginResult handle(String provider, String idToken) {
+        var identity = socialIdentityVerifier.verify(provider, idToken);
+
+        var existingIdentity = socialIdentityRepository.findByProviderAndSubject(
+                identity.provider(), identity.subject());
+
+        var newUser = existingIdentity.isEmpty();
+        var appUser = existingIdentity
+                .map(existing -> userRepository.findById(existing.userId()).orElseThrow())
+                .orElseGet(() -> {
+                    var user = AppUser.builder()
+                            .id(UUID.randomUUID())
+                            .email(identity.email())
+                            .createdAt(Instant.now(clock))
+                            .build();
+                    var savedUser = userRepository.save(user);
+                    socialIdentityRepository.save(
+                            identity.toBuilder().userId(savedUser.id()).build());
+                    return savedUser;
+                });
+
+        var wallet = existingIdentity.isPresent()
+                ? walletRepository.findByUserId(appUser.id()).orElseThrow()
+                : createWalletHandler.handle(appUser.id());
+
+        var session = authTokenIssuer.issue(appUser.id());
+        var tokenHash = tokenHasher.hash(session.refreshToken());
+
+        var refreshToken = RefreshToken.builder()
+                .id(UUID.randomUUID())
+                .userId(appUser.id())
+                .tokenHash(tokenHash)
+                .expiresAt(Instant.now(clock).plus(authTokenConfig.refreshTtl()))
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        log.info("Social login completed for userId={}, newUser={}", appUser.id(), newUser);
+
+        return LoginResult.builder()
+                .session(session)
+                .user(appUser)
+                .wallet(wallet)
+                .newUser(newUser)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/handler/SocialLoginHandler.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.exception.UserNotFoundException;
 import com.stablepay.domain.auth.model.AppUser;
 import com.stablepay.domain.auth.model.AuthTokenConfig;
 import com.stablepay.domain.auth.model.LoginResult;
@@ -17,6 +18,7 @@ import com.stablepay.domain.auth.port.SocialIdentityRepository;
 import com.stablepay.domain.auth.port.SocialIdentityVerifier;
 import com.stablepay.domain.auth.port.TokenHasher;
 import com.stablepay.domain.auth.port.UserRepository;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
 import com.stablepay.domain.wallet.port.WalletRepository;
 
@@ -41,6 +43,7 @@ public class SocialLoginHandler {
     private final Clock clock;
 
     public LoginResult handle(String provider, String idToken) {
+        var now = Instant.now(clock);
         var identity = socialIdentityVerifier.verify(provider, idToken);
 
         var existingIdentity = socialIdentityRepository.findByProviderAndSubject(
@@ -48,12 +51,13 @@ public class SocialLoginHandler {
 
         var newUser = existingIdentity.isEmpty();
         var appUser = existingIdentity
-                .map(existing -> userRepository.findById(existing.userId()).orElseThrow())
+                .map(existing -> userRepository.findById(existing.userId())
+                        .orElseThrow(() -> UserNotFoundException.byId(existing.userId())))
                 .orElseGet(() -> {
                     var user = AppUser.builder()
                             .id(UUID.randomUUID())
                             .email(identity.email())
-                            .createdAt(Instant.now(clock))
+                            .createdAt(now)
                             .build();
                     var savedUser = userRepository.save(user);
                     socialIdentityRepository.save(
@@ -62,7 +66,8 @@ public class SocialLoginHandler {
                 });
 
         var wallet = existingIdentity.isPresent()
-                ? walletRepository.findByUserId(appUser.id()).orElseThrow()
+                ? walletRepository.findByUserId(appUser.id())
+                        .orElseThrow(() -> WalletNotFoundException.byUserId(appUser.id()))
                 : createWalletHandler.handle(appUser.id());
 
         var session = authTokenIssuer.issue(appUser.id());
@@ -72,7 +77,7 @@ public class SocialLoginHandler {
                 .id(UUID.randomUUID())
                 .userId(appUser.id())
                 .tokenHash(tokenHash)
-                .expiresAt(Instant.now(clock).plus(authTokenConfig.refreshTtl()))
+                .expiresAt(now.plus(authTokenConfig.refreshTtl()))
                 .build();
         refreshTokenRepository.save(refreshToken);
 

--- a/backend/src/main/java/com/stablepay/domain/auth/model/LoginResult.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/model/LoginResult.java
@@ -1,0 +1,21 @@
+package com.stablepay.domain.auth.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.stablepay.domain.wallet.model.Wallet;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record LoginResult(
+    AuthSession session,
+    AppUser user,
+    Wallet wallet,
+    boolean newUser
+) {
+    public LoginResult {
+        requireNonNull(session, "session cannot be null");
+        requireNonNull(user, "user cannot be null");
+        requireNonNull(wallet, "wallet cannot be null");
+    }
+}

--- a/backend/src/main/java/com/stablepay/domain/auth/port/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/RefreshTokenRepository.java
@@ -7,6 +7,7 @@ import com.stablepay.domain.auth.model.RefreshToken;
 
 public interface RefreshTokenRepository {
     Optional<RefreshToken> findByHash(String tokenHash);
+    Optional<RefreshToken> findByHashForUpdate(String tokenHash);
     RefreshToken save(RefreshToken token);
     void revokeByUserId(UUID userId);
 }

--- a/backend/src/main/java/com/stablepay/domain/auth/port/TokenHasher.java
+++ b/backend/src/main/java/com/stablepay/domain/auth/port/TokenHasher.java
@@ -1,0 +1,5 @@
+package com.stablepay.domain.auth.port;
+
+public interface TokenHasher {
+    String hash(String rawToken);
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/TokenHasherAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/auth/jwt/TokenHasherAdapter.java
@@ -1,0 +1,19 @@
+package com.stablepay.infrastructure.auth.jwt;
+
+import org.springframework.stereotype.Component;
+
+import com.stablepay.domain.auth.port.TokenHasher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class TokenHasherAdapter implements TokenHasher {
+
+    private final RefreshTokenGenerator refreshTokenGenerator;
+
+    @Override
+    public String hash(String rawToken) {
+        return refreshTokenGenerator.hash(rawToken);
+    }
+}

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenJpaRepository.java
@@ -3,14 +3,24 @@ package com.stablepay.infrastructure.db.user;
 import java.util.Optional;
 import java.util.UUID;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, UUID> {
     Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "4000")})
+    @Query("SELECT r FROM RefreshTokenEntity r WHERE r.tokenHash = :tokenHash")
+    Optional<RefreshTokenEntity> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional

--- a/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapter.java
+++ b/backend/src/main/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapter.java
@@ -24,6 +24,11 @@ class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
     }
 
     @Override
+    public Optional<RefreshToken> findByHashForUpdate(String tokenHash) {
+        return jpaRepository.findByTokenHashForUpdate(tokenHash).map(mapper::toDomain);
+    }
+
+    @Override
     public RefreshToken save(RefreshToken token) {
         var entity = mapper.toEntity(token);
         entity.setIssuedAt(Instant.now());

--- a/backend/src/test/java/com/stablepay/domain/auth/handler/LogoutHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/auth/handler/LogoutHandlerTest.java
@@ -1,0 +1,33 @@
+package com.stablepay.domain.auth.handler;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutHandlerTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private LogoutHandler logoutHandler;
+
+    @Test
+    void shouldRevokeAllRefreshTokensForUser() {
+        // given
+
+        // when
+        logoutHandler.handle(SOME_AUTH_USER_ID);
+
+        // then
+        then(refreshTokenRepository).should().revokeByUserId(SOME_AUTH_USER_ID);
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/auth/handler/RefreshTokenHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/auth/handler/RefreshTokenHandlerTest.java
@@ -1,0 +1,141 @@
+package com.stablepay.domain.auth.handler;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_RAW_REFRESH_TOKEN;
+import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
+import static com.stablepay.testutil.AuthFixtures.refreshTokenBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.exception.InvalidRefreshTokenException;
+import com.stablepay.domain.auth.exception.RefreshTokenExpiredException;
+import com.stablepay.domain.auth.model.AuthSession;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+import com.stablepay.domain.auth.port.AuthTokenIssuer;
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+import com.stablepay.domain.auth.port.TokenHasher;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenHandlerTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-03T10:00:00Z");
+    private static final String SOME_NEW_RAW_REFRESH_TOKEN = "r1_bmV3LXJlZnJlc2gtdG9rZW4";
+    private static final String SOME_NEW_TOKEN_HASH = "sha256-new-token-hash";
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private TokenHasher tokenHasher;
+
+    @Mock
+    private AuthTokenIssuer authTokenIssuer;
+
+    private final AuthTokenConfig authTokenConfig = AuthTokenConfig.builder()
+            .accessTtl(Duration.ofMinutes(15))
+            .refreshTtl(Duration.ofDays(30))
+            .build();
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private RefreshTokenHandler refreshTokenHandler;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenHandler = new RefreshTokenHandler(
+                refreshTokenRepository,
+                tokenHasher,
+                authTokenIssuer,
+                authTokenConfig,
+                clock);
+    }
+
+    @Test
+    void shouldRotateRefreshToken() {
+        // given
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+
+        var existingToken = refreshTokenBuilder().build();
+        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+                .willReturn(Optional.of(existingToken));
+
+        var revokedToken = existingToken.toBuilder().revokedAt(NOW).build();
+        given(refreshTokenRepository.save(revokedToken)).willReturn(revokedToken);
+
+        var newSession = AuthSession.builder()
+                .accessToken("new-access-token")
+                .refreshToken(SOME_NEW_RAW_REFRESH_TOKEN)
+                .accessExpiresAt(NOW.plus(Duration.ofMinutes(15)))
+                .build();
+        given(authTokenIssuer.issue(SOME_AUTH_USER_ID)).willReturn(newSession);
+        given(tokenHasher.hash(SOME_NEW_RAW_REFRESH_TOKEN)).willReturn(SOME_NEW_TOKEN_HASH);
+
+        // when
+        var result = refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN);
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(newSession);
+    }
+
+    @Test
+    void shouldThrowWhenTokenNotFound() {
+        // given
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void shouldThrowWhenTokenRevoked() {
+        // given
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+
+        var revokedToken = refreshTokenBuilder()
+                .revokedAt(NOW.minus(Duration.ofHours(1)))
+                .build();
+        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+                .willReturn(Optional.of(revokedToken));
+
+        // when / then
+        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessageContaining("revoked");
+    }
+
+    @Test
+    void shouldThrowWhenTokenExpired() {
+        // given
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+
+        var expiredToken = refreshTokenBuilder()
+                .expiresAt(NOW.minus(Duration.ofHours(1)))
+                .build();
+        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+                .willReturn(Optional.of(expiredToken));
+
+        // when / then
+        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+                .isInstanceOf(RefreshTokenExpiredException.class)
+                .hasMessageContaining(SOME_REFRESH_TOKEN_ID.toString());
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/auth/handler/RefreshTokenHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/auth/handler/RefreshTokenHandlerTest.java
@@ -6,8 +6,10 @@ import static com.stablepay.testutil.AuthFixtures.SOME_REFRESH_TOKEN_ID;
 import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
 import static com.stablepay.testutil.AuthFixtures.refreshTokenBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -70,7 +72,7 @@ class RefreshTokenHandlerTest {
         given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
 
         var existingToken = refreshTokenBuilder().build();
-        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+        given(refreshTokenRepository.findByHashForUpdate(SOME_TOKEN_HASH))
                 .willReturn(Optional.of(existingToken));
 
         var revokedToken = existingToken.toBuilder().revokedAt(NOW).build();
@@ -91,16 +93,23 @@ class RefreshTokenHandlerTest {
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(newSession);
+        then(refreshTokenRepository).should().save(argThat(rt ->
+                rt.tokenHash().equals(SOME_NEW_TOKEN_HASH)
+                        && rt.userId().equals(SOME_AUTH_USER_ID)
+                        && rt.expiresAt().equals(NOW.plus(Duration.ofDays(30)))));
     }
 
     @Test
     void shouldThrowWhenTokenNotFound() {
         // given
         given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
-        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH)).willReturn(Optional.empty());
+        given(refreshTokenRepository.findByHashForUpdate(SOME_TOKEN_HASH)).willReturn(Optional.empty());
 
-        // when / then
-        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+        // when
+        var thrown = catchThrowable(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN));
+
+        // then
+        assertThat(thrown)
                 .isInstanceOf(InvalidRefreshTokenException.class)
                 .hasMessageContaining("not found");
     }
@@ -113,11 +122,14 @@ class RefreshTokenHandlerTest {
         var revokedToken = refreshTokenBuilder()
                 .revokedAt(NOW.minus(Duration.ofHours(1)))
                 .build();
-        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+        given(refreshTokenRepository.findByHashForUpdate(SOME_TOKEN_HASH))
                 .willReturn(Optional.of(revokedToken));
 
-        // when / then
-        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+        // when
+        var thrown = catchThrowable(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN));
+
+        // then
+        assertThat(thrown)
                 .isInstanceOf(InvalidRefreshTokenException.class)
                 .hasMessageContaining("revoked");
     }
@@ -130,11 +142,14 @@ class RefreshTokenHandlerTest {
         var expiredToken = refreshTokenBuilder()
                 .expiresAt(NOW.minus(Duration.ofHours(1)))
                 .build();
-        given(refreshTokenRepository.findByHash(SOME_TOKEN_HASH))
+        given(refreshTokenRepository.findByHashForUpdate(SOME_TOKEN_HASH))
                 .willReturn(Optional.of(expiredToken));
 
-        // when / then
-        assertThatThrownBy(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN))
+        // when
+        var thrown = catchThrowable(() -> refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN));
+
+        // then
+        assertThat(thrown)
                 .isInstanceOf(RefreshTokenExpiredException.class)
                 .hasMessageContaining(SOME_REFRESH_TOKEN_ID.toString());
     }

--- a/backend/src/test/java/com/stablepay/domain/auth/handler/SocialLoginHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/auth/handler/SocialLoginHandlerTest.java
@@ -1,0 +1,206 @@
+package com.stablepay.domain.auth.handler;
+
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_CREATED_AT;
+import static com.stablepay.testutil.AuthFixtures.SOME_AUTH_USER_ID;
+import static com.stablepay.testutil.AuthFixtures.SOME_ID_TOKEN;
+import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
+import static com.stablepay.testutil.AuthFixtures.SOME_RAW_REFRESH_TOKEN;
+import static com.stablepay.testutil.AuthFixtures.SOME_SOCIAL_EMAIL;
+import static com.stablepay.testutil.AuthFixtures.SOME_SUBJECT;
+import static com.stablepay.testutil.AuthFixtures.SOME_TOKEN_HASH;
+import static com.stablepay.testutil.AuthFixtures.appUserBuilder;
+import static com.stablepay.testutil.AuthFixtures.authSessionBuilder;
+import static com.stablepay.testutil.AuthFixtures.socialIdentityBuilder;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.auth.exception.EmailNotVerifiedException;
+import com.stablepay.domain.auth.model.AuthTokenConfig;
+import com.stablepay.domain.auth.model.LoginResult;
+import com.stablepay.domain.auth.port.AuthTokenIssuer;
+import com.stablepay.domain.auth.port.RefreshTokenRepository;
+import com.stablepay.domain.auth.port.SocialIdentityRepository;
+import com.stablepay.domain.auth.port.SocialIdentityVerifier;
+import com.stablepay.domain.auth.port.TokenHasher;
+import com.stablepay.domain.auth.port.UserRepository;
+import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SocialLoginHandlerTest {
+
+    @Mock
+    private SocialIdentityVerifier socialIdentityVerifier;
+
+    @Mock
+    private SocialIdentityRepository socialIdentityRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CreateWalletHandler createWalletHandler;
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @Mock
+    private AuthTokenIssuer authTokenIssuer;
+
+    @Mock
+    private TokenHasher tokenHasher;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private final AuthTokenConfig authTokenConfig = AuthTokenConfig.builder()
+            .accessTtl(Duration.ofMinutes(15))
+            .refreshTtl(Duration.ofDays(30))
+            .build();
+
+    private final Clock clock = Clock.fixed(SOME_AUTH_CREATED_AT, ZoneOffset.UTC);
+
+    private SocialLoginHandler socialLoginHandler;
+
+    @BeforeEach
+    void setUp() {
+        socialLoginHandler = new SocialLoginHandler(
+                socialIdentityVerifier,
+                socialIdentityRepository,
+                userRepository,
+                createWalletHandler,
+                walletRepository,
+                authTokenIssuer,
+                tokenHasher,
+                refreshTokenRepository,
+                authTokenConfig,
+                clock);
+    }
+
+    @Test
+    void shouldCreateNewUserWithWalletOnFirstLogin() {
+        // given
+        var identity = socialIdentityBuilder().userId(null).build();
+        given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN)).willReturn(identity);
+        given(socialIdentityRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
+                .willReturn(Optional.empty());
+
+        var appUser = appUserBuilder().build();
+        given(userRepository.save(argThat(user ->
+                user.email().equals(SOME_SOCIAL_EMAIL)
+                        && user.createdAt().equals(SOME_AUTH_CREATED_AT))))
+                .willReturn(appUser);
+
+        var savedIdentity = identity.toBuilder().userId(SOME_AUTH_USER_ID).build();
+        given(socialIdentityRepository.save(savedIdentity)).willReturn(savedIdentity);
+
+        var wallet = walletBuilder().userId(SOME_AUTH_USER_ID).build();
+        given(createWalletHandler.handle(SOME_AUTH_USER_ID)).willReturn(wallet);
+
+        var session = authSessionBuilder().build();
+        given(authTokenIssuer.issue(SOME_AUTH_USER_ID)).willReturn(session);
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+
+        // when
+        var result = socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN);
+
+        // then
+        var expected = LoginResult.builder()
+                .session(session)
+                .user(appUser)
+                .wallet(wallet)
+                .newUser(true)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnExistingUserOnReturningLogin() {
+        // given
+        var identity = socialIdentityBuilder().build();
+        given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN)).willReturn(identity);
+
+        var existingIdentity = socialIdentityBuilder().build();
+        given(socialIdentityRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
+                .willReturn(Optional.of(existingIdentity));
+
+        var appUser = appUserBuilder().build();
+        given(userRepository.findById(SOME_AUTH_USER_ID)).willReturn(Optional.of(appUser));
+
+        var wallet = walletBuilder().userId(SOME_AUTH_USER_ID).build();
+        given(walletRepository.findByUserId(SOME_AUTH_USER_ID)).willReturn(Optional.of(wallet));
+
+        var session = authSessionBuilder().build();
+        given(authTokenIssuer.issue(SOME_AUTH_USER_ID)).willReturn(session);
+        given(tokenHasher.hash(SOME_RAW_REFRESH_TOKEN)).willReturn(SOME_TOKEN_HASH);
+
+        // when
+        var result = socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN);
+
+        // then
+        var expected = LoginResult.builder()
+                .session(session)
+                .user(appUser)
+                .wallet(wallet)
+                .newUser(false)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldPropagateEmailNotVerifiedException() {
+        // given
+        given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN))
+                .willThrow(EmailNotVerifiedException.forEmail(SOME_SOCIAL_EMAIL));
+
+        // when / then
+        assertThatThrownBy(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN))
+                .isInstanceOf(EmailNotVerifiedException.class);
+    }
+
+    @Test
+    void shouldPropagateExceptionOnMpcFailure() {
+        // given
+        var identity = socialIdentityBuilder().userId(null).build();
+        given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN)).willReturn(identity);
+        given(socialIdentityRepository.findByProviderAndSubject(SOME_PROVIDER, SOME_SUBJECT))
+                .willReturn(Optional.empty());
+
+        var appUser = appUserBuilder().build();
+        given(userRepository.save(argThat(user ->
+                user.email().equals(SOME_SOCIAL_EMAIL)
+                        && user.createdAt().equals(SOME_AUTH_CREATED_AT))))
+                .willReturn(appUser);
+
+        var savedIdentity = identity.toBuilder().userId(SOME_AUTH_USER_ID).build();
+        given(socialIdentityRepository.save(savedIdentity)).willReturn(savedIdentity);
+
+        given(createWalletHandler.handle(SOME_AUTH_USER_ID))
+                .willThrow(new RuntimeException("MPC sidecar unavailable"));
+
+        // when / then
+        assertThatThrownBy(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("MPC sidecar unavailable");
+    }
+}

--- a/backend/src/test/java/com/stablepay/domain/auth/handler/SocialLoginHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/auth/handler/SocialLoginHandlerTest.java
@@ -13,9 +13,10 @@ import static com.stablepay.testutil.AuthFixtures.authSessionBuilder;
 import static com.stablepay.testutil.AuthFixtures.socialIdentityBuilder;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -129,12 +130,17 @@ class SocialLoginHandlerTest {
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+        then(refreshTokenRepository).should().revokeByUserId(SOME_AUTH_USER_ID);
+        then(refreshTokenRepository).should().save(argThat(rt ->
+                rt.userId().equals(SOME_AUTH_USER_ID)
+                        && rt.tokenHash().equals(SOME_TOKEN_HASH)
+                        && rt.expiresAt().equals(SOME_AUTH_CREATED_AT.plus(Duration.ofDays(30)))));
     }
 
     @Test
     void shouldReturnExistingUserOnReturningLogin() {
         // given
-        var identity = socialIdentityBuilder().build();
+        var identity = socialIdentityBuilder().userId(null).build();
         given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN)).willReturn(identity);
 
         var existingIdentity = socialIdentityBuilder().build();
@@ -165,6 +171,11 @@ class SocialLoginHandlerTest {
         assertThat(result)
                 .usingRecursiveComparison()
                 .isEqualTo(expected);
+        then(refreshTokenRepository).should().revokeByUserId(SOME_AUTH_USER_ID);
+        then(refreshTokenRepository).should().save(argThat(rt ->
+                rt.userId().equals(SOME_AUTH_USER_ID)
+                        && rt.tokenHash().equals(SOME_TOKEN_HASH)
+                        && rt.expiresAt().equals(SOME_AUTH_CREATED_AT.plus(Duration.ofDays(30)))));
     }
 
     @Test
@@ -173,8 +184,11 @@ class SocialLoginHandlerTest {
         given(socialIdentityVerifier.verify(SOME_PROVIDER, SOME_ID_TOKEN))
                 .willThrow(EmailNotVerifiedException.forEmail(SOME_SOCIAL_EMAIL));
 
-        // when / then
-        assertThatThrownBy(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN))
+        // when
+        var thrown = catchThrowable(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN));
+
+        // then
+        assertThat(thrown)
                 .isInstanceOf(EmailNotVerifiedException.class);
     }
 
@@ -198,8 +212,11 @@ class SocialLoginHandlerTest {
         given(createWalletHandler.handle(SOME_AUTH_USER_ID))
                 .willThrow(new RuntimeException("MPC sidecar unavailable"));
 
-        // when / then
-        assertThatThrownBy(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN))
+        // when
+        var thrown = catchThrowable(() -> socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN));
+
+        // then
+        assertThat(thrown)
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("MPC sidecar unavailable");
     }

--- a/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/stablepay/infrastructure/db/user/RefreshTokenRepositoryAdapterTest.java
@@ -67,6 +67,35 @@ class RefreshTokenRepositoryAdapterTest {
     }
 
     @Test
+    void shouldFindByHashForUpdateAndMapToDomain() {
+        // given
+        var entity = RefreshTokenEntity.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_AUTH_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .issuedAt(Instant.now())
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
+                .revokedAt(null)
+                .build();
+        given(jpaRepository.findByTokenHashForUpdate(SOME_TOKEN_HASH)).willReturn(Optional.of(entity));
+
+        // when
+        var result = adapter.findByHashForUpdate(SOME_TOKEN_HASH);
+
+        // then
+        var expected = RefreshToken.builder()
+                .id(SOME_REFRESH_TOKEN_ID)
+                .userId(SOME_AUTH_USER_ID)
+                .tokenHash(SOME_TOKEN_HASH)
+                .expiresAt(SOME_REFRESH_EXPIRES_AT)
+                .revokedAt(null)
+                .build();
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(Optional.of(expected));
+    }
+
+    @Test
     void shouldReturnEmptyWhenHashNotFound() {
         // given
         given(jpaRepository.findByTokenHash(SOME_TOKEN_HASH)).willReturn(Optional.empty());

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.AuthSession;
 import com.stablepay.domain.auth.model.RefreshToken;
 import com.stablepay.domain.auth.model.SocialIdentity;
 import com.stablepay.domain.auth.port.UserRepository;
@@ -31,6 +32,10 @@ public final class AuthFixtures {
     public static final String SOME_TOKEN_HASH = "sha256-abc123def456";
     public static final Instant SOME_REFRESH_EXPIRES_AT = Instant.parse("2026-05-03T10:00:00Z");
 
+    public static final String SOME_RAW_REFRESH_TOKEN = "r1_dGVzdC1yZWZyZXNoLXRva2Vu";
+    public static final String SOME_ACCESS_TOKEN = "test-access-token";
+    public static final Instant SOME_ACCESS_EXPIRES_AT = Instant.parse("2026-04-03T10:15:00Z");
+
     public static AppUser.AppUserBuilder appUserBuilder() {
         return AppUser.builder()
                 .id(SOME_AUTH_USER_ID)
@@ -53,6 +58,13 @@ public final class AuthFixtures {
                 .userId(SOME_AUTH_USER_ID)
                 .tokenHash(SOME_TOKEN_HASH)
                 .expiresAt(SOME_REFRESH_EXPIRES_AT);
+    }
+
+    public static AuthSession.AuthSessionBuilder authSessionBuilder() {
+        return AuthSession.builder()
+                .accessToken(SOME_ACCESS_TOKEN)
+                .refreshToken(SOME_RAW_REFRESH_TOKEN)
+                .accessExpiresAt(SOME_ACCESS_EXPIRES_AT);
     }
 
     public static UUID createTestUser(UserRepository userRepository) {


### PR DESCRIPTION
## STA Issue
Closes #206

## Changes
- Add `SocialLoginHandler` — verifies Google identity, provisions user + MPC wallet atomically on first login (`@Transactional`, `CreateWalletHandler` called synchronously inline per ADR-022), loads existing user/wallet on returning login, issues JWT + refresh token, returns `LoginResult` with `newUser` flag
- Add `RefreshTokenHandler` — hash-based lookup, validates not-revoked/not-expired, revokes old token, issues new token pair (rotation with single active chain per user), error codes SP-0035/SP-0036
- Add `LogoutHandler` — revokes all refresh tokens for the authenticated user (no JWT denylist)
- Add `LoginResult` domain record (`AuthSession`, `AppUser`, `Wallet`, `boolean newUser`)
- Add `TokenHasher` domain port with `TokenHasherAdapter` infrastructure adapter (delegates to `RefreshTokenGenerator.hash()`)
- Update `AuthFixtures` with `authSessionBuilder()` and refresh/access token constants

## Test coverage (9 tests)
- `SocialLoginHandlerTest`: new user with wallet creation, returning user login, email-not-verified propagation, MPC failure propagation
- `RefreshTokenHandlerTest`: token rotation, token not found, revoked token, expired token
- `LogoutHandlerTest`: revoke all tokens for user

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (9 tests, all passing)
- [ ] Integration tests added/updated (not applicable — domain handler unit tests only)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied
- [x] BDDMockito only (`given()`/`then()`), no generic matchers
- [x] Golden rule: build expected → single `usingRecursiveComparison`
- [x] `// given // when // then` bare markers in all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social login authentication support
  * Added user logout functionality
  * Added token refresh and rotation capabilities

* **Tests**
  * Added comprehensive test coverage for logout, token refresh, and social login features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->