### PR TITLE
STA-101: migrate existing code to auth and add GET /api/wallets/me

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -201,6 +201,10 @@ dependencies {
     testImplementation("org.testcontainers:postgresql:1.21.4")
     testImplementation("io.temporal:temporal-testing:1.34.0")
 
+    // Test fixtures dependencies
+    testFixturesImplementation("org.springframework.security:spring-security-oauth2-jose")
+    testFixturesImplementation("org.springframework.security:spring-security-oauth2-resource-server")
+
     // Integration test dependencies
     "integrationTestImplementation"(testFixtures(project))
     "integrationTestImplementation"("org.wiremock:wiremock-standalone:3.13.2")

--- a/backend/src/integration-test/java/com/stablepay/application/config/SecurityIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/config/SecurityIntegrationTest.java
@@ -1,11 +1,14 @@
 package com.stablepay.application.config;
 
+import static com.stablepay.testutil.AuthFixtures.authenticationFor;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -79,7 +82,7 @@ class SecurityIntegrationTest {
 
             // when
             var result = mockMvc.perform(get("/api/fx/USD-INR")
-                    .with(jwt()));
+                    .with(authentication(authenticationFor(UUID.randomUUID()))));
 
             // then
             result.andExpect(status().isOk());

--- a/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/controller/wallet/WalletApiIntegrationTest.java
@@ -68,7 +68,6 @@ class WalletApiIntegrationTest {
             // then
             result.andExpect(status().isCreated())
                     .andExpect(jsonPath("$.id").isNumber())
-                    .andExpect(jsonPath("$.userId").value(userId.toString()))
                     .andExpect(jsonPath("$.solanaAddress").value(solanaAddress))
                     .andExpect(jsonPath("$.availableBalance").value(0))
                     .andExpect(jsonPath("$.totalBalance").value(0))

--- a/backend/src/integration-test/java/com/stablepay/application/e2e/RemittanceLifecycleE2EIntegrationTest.java
+++ b/backend/src/integration-test/java/com/stablepay/application/e2e/RemittanceLifecycleE2EIntegrationTest.java
@@ -1,8 +1,9 @@
 package com.stablepay.application.e2e;
 
+import static com.stablepay.testutil.AuthFixtures.authenticationFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -115,7 +116,6 @@ class RemittanceLifecycleE2EIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.userId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.solanaAddress").value(E2E_SOLANA_ADDRESS))
                 .andExpect(jsonPath("$.availableBalance").value(0))
                 .andReturn();
@@ -139,7 +139,7 @@ class RemittanceLifecycleE2EIntegrationTest {
     @SneakyThrows
     private void checkFxRate() {
         // when / then
-        mockMvc.perform(get("/api/fx/USD-INR").with(jwt()))
+        mockMvc.perform(get("/api/fx/USD-INR").with(authentication(authenticationFor(E2E_USER_ID))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rate").isNumber())
                 .andExpect(jsonPath("$.source").isString())
@@ -152,20 +152,18 @@ class RemittanceLifecycleE2EIntegrationTest {
         // given
         var body = """
                 {
-                    "senderId": "%s",
                     "recipientPhone": "+919876543210",
                     "amountUsdc": 25.00
                 }
-                """.formatted(E2E_USER_ID);
+                """;
 
         // when
         var result = mockMvc.perform(post("/api/remittances")
-                        .with(jwt())
+                        .with(authentication(authenticationFor(E2E_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.remittanceId").isString())
-                .andExpect(jsonPath("$.senderId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.recipientPhone").value("+919876543210"))
                 .andExpect(jsonPath("$.amountUsdc").value(25.00))
                 .andExpect(jsonPath("$.amountInr").isNumber())
@@ -186,7 +184,7 @@ class RemittanceLifecycleE2EIntegrationTest {
     @SneakyThrows
     private void getRemittance(String remittanceId, String expectedStatus) {
         // when / then
-        mockMvc.perform(get("/api/remittances/{remittanceId}", remittanceId).with(jwt()))
+        mockMvc.perform(get("/api/remittances/{remittanceId}", remittanceId).with(authentication(authenticationFor(E2E_USER_ID))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(remittanceId))
                 .andExpect(jsonPath("$.status").value(expectedStatus));
@@ -223,14 +221,12 @@ class RemittanceLifecycleE2EIntegrationTest {
     private void listRemittances() {
         // when / then
         mockMvc.perform(get("/api/remittances")
-                        .with(jwt())
-                        .param("senderId", E2E_USER_ID.toString())
+                        .with(authentication(authenticationFor(E2E_USER_ID)))
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content.length()").value(1))
-                .andExpect(jsonPath("$.content[0].senderId").value(E2E_USER_ID.toString()))
                 .andExpect(jsonPath("$.content[0].amountUsdc").value(25.00))
                 .andExpect(jsonPath("$.totalElements").value(1));
     }

--- a/backend/src/main/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapper.java
@@ -10,7 +10,7 @@ import com.stablepay.domain.claim.model.ClaimDetails;
 public interface ClaimApiMapper {
 
     @Mapping(source = "remittance.remittanceId", target = "remittanceId")
-    @Mapping(source = "remittance.senderId", target = "senderId")
+    @Mapping(source = "senderDisplayName", target = "senderDisplayName")
     @Mapping(source = "remittance.amountUsdc", target = "amountUsdc")
     @Mapping(source = "remittance.amountInr", target = "amountInr")
     @Mapping(source = "remittance.fxRate", target = "fxRate")

--- a/backend/src/main/java/com/stablepay/application/controller/funding/FundingController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/funding/FundingController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import com.stablepay.application.controller.funding.mapper.FundingApiMapper;
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.FundWalletRequest;
 import com.stablepay.application.dto.FundingOrderResponse;
+import com.stablepay.domain.auth.model.AuthPrincipal;
 import com.stablepay.domain.funding.handler.GetFundingOrderHandler;
 import com.stablepay.domain.funding.handler.InitiateFundingHandler;
 import com.stablepay.domain.funding.handler.RefundFundingHandler;
@@ -57,9 +59,10 @@ public class FundingController {
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public FundingOrderResponse initiateFunding(
+            @AuthenticationPrincipal AuthPrincipal principal,
             @PathVariable Long id,
             @Valid @RequestBody FundWalletRequest request) {
-        var result = initiateFundingHandler.handle(id, request.amount());
+        var result = initiateFundingHandler.handle(id, request.amount(), principal.id());
         return fundingApiMapper.toResponseWithClientSecret(result.order(), result.clientSecret());
     }
 
@@ -72,8 +75,10 @@ public class FundingController {
         @ApiResponse(responseCode = "404", description = "Funding order not found",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public FundingOrderResponse getFundingOrder(@PathVariable UUID fundingId) {
-        var order = getFundingOrderHandler.handle(fundingId);
+    public FundingOrderResponse getFundingOrder(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable UUID fundingId) {
+        var order = getFundingOrderHandler.handle(fundingId, principal.id());
         return fundingApiMapper.toResponse(order);
     }
 
@@ -92,8 +97,10 @@ public class FundingController {
         @ApiResponse(responseCode = "502", description = "Stripe refund failed",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public FundingOrderResponse refundFunding(@PathVariable UUID fundingId) {
-        var order = refundFundingHandler.handle(fundingId);
+    public FundingOrderResponse refundFunding(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable UUID fundingId) {
+        var order = refundFundingHandler.handle(fundingId, principal.id());
         return fundingApiMapper.toResponse(order);
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/remittance/RemittanceController.java
@@ -7,12 +7,12 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +20,7 @@ import com.stablepay.application.controller.remittance.mapper.RemittanceApiMappe
 import com.stablepay.application.dto.CreateRemittanceRequest;
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.RemittanceResponse;
+import com.stablepay.domain.auth.model.AuthPrincipal;
 import com.stablepay.domain.remittance.handler.CreateRemittanceHandler;
 import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
 import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
@@ -51,9 +52,11 @@ public class RemittanceController {
         @ApiResponse(responseCode = "400", description = "Validation error or insufficient balance",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public RemittanceResponse createRemittance(@Valid @RequestBody CreateRemittanceRequest request) {
+    public RemittanceResponse createRemittance(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody CreateRemittanceRequest request) {
         var remittance = createRemittanceHandler.handle(
-                request.senderId(), request.recipientPhone(), request.amountUsdc());
+                principal.id(), request.recipientPhone(), request.amountUsdc());
         return remittanceApiMapper.toResponse(remittance);
     }
 
@@ -64,20 +67,22 @@ public class RemittanceController {
         @ApiResponse(responseCode = "404", description = "Remittance not found",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public RemittanceResponse getRemittance(@PathVariable UUID remittanceId) {
-        var remittance = getRemittanceQueryHandler.handle(remittanceId);
+    public RemittanceResponse getRemittance(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable UUID remittanceId) {
+        var remittance = getRemittanceQueryHandler.handle(remittanceId, principal.id());
         return remittanceApiMapper.toResponse(remittance);
     }
 
     @GetMapping
-    @Operation(summary = "List remittances", description = "Returns a paginated list of remittances for a sender")
+    @Operation(summary = "List remittances", description = "Returns a paginated list of remittances for the authenticated user")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Remittances retrieved")
     })
     public Page<RemittanceResponse> listRemittances(
-            @RequestParam UUID senderId,
+            @AuthenticationPrincipal AuthPrincipal principal,
             Pageable pageable) {
-        return listRemittancesQueryHandler.handle(senderId, pageable)
+        return listRemittancesQueryHandler.handle(principal.id(), pageable)
                 .map(remittanceApiMapper::toResponse);
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/WalletController.java
@@ -3,6 +3,8 @@ package com.stablepay.application.controller.wallet;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,7 +15,9 @@ import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
 import com.stablepay.application.dto.CreateWalletRequest;
 import com.stablepay.application.dto.ErrorResponse;
 import com.stablepay.application.dto.WalletResponse;
+import com.stablepay.domain.auth.model.AuthPrincipal;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.handler.GetWalletQueryHandler;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class WalletController {
 
     private final CreateWalletHandler createWalletHandler;
+    private final GetWalletQueryHandler getWalletQueryHandler;
     private final WalletApiMapper walletApiMapper;
 
     @PostMapping
@@ -44,6 +49,18 @@ public class WalletController {
     })
     public WalletResponse createWallet(@Valid @RequestBody CreateWalletRequest request) {
         var wallet = createWalletHandler.handle(request.userId());
+        return walletApiMapper.toResponse(wallet);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "Get my wallet", description = "Returns the authenticated user's wallet")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Wallet found"),
+        @ApiResponse(responseCode = "404", description = "Wallet not found",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public WalletResponse getMyWallet(@AuthenticationPrincipal AuthPrincipal principal) {
+        var wallet = getWalletQueryHandler.handle(principal.id());
         return walletApiMapper.toResponse(wallet);
     }
 }

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
@@ -1,19 +1,11 @@
 package com.stablepay.application.controller.wallet.mapper;
 
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.wallet.model.Wallet;
 
 @Mapper
 public interface WalletApiMapper {
-
-    @Mapping(target = "id", source = "id")
-    @Mapping(target = "solanaAddress", source = "solanaAddress")
-    @Mapping(target = "availableBalance", source = "availableBalance")
-    @Mapping(target = "totalBalance", source = "totalBalance")
-    @Mapping(target = "createdAt", source = "createdAt")
-    @Mapping(target = "updatedAt", source = "updatedAt")
     WalletResponse toResponse(Wallet wallet);
 }

--- a/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
+++ b/backend/src/main/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapper.java
@@ -1,11 +1,19 @@
 package com.stablepay.application.controller.wallet.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.wallet.model.Wallet;
 
 @Mapper
 public interface WalletApiMapper {
+
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "solanaAddress", source = "solanaAddress")
+    @Mapping(target = "availableBalance", source = "availableBalance")
+    @Mapping(target = "totalBalance", source = "totalBalance")
+    @Mapping(target = "createdAt", source = "createdAt")
+    @Mapping(target = "updatedAt", source = "updatedAt")
     WalletResponse toResponse(Wallet wallet);
 }

--- a/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/ClaimResponse.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record ClaimResponse(
     UUID remittanceId,
-    UUID senderId,
+    String senderDisplayName,
     BigDecimal amountUsdc,
     BigDecimal amountInr,
     BigDecimal fxRate,

--- a/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
+++ b/backend/src/main/java/com/stablepay/application/dto/CreateRemittanceRequest.java
@@ -1,7 +1,6 @@
 package com.stablepay.application.dto;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,7 +10,6 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record CreateRemittanceRequest(
-    @NotNull UUID senderId,
     @NotBlank String recipientPhone,
     @NotNull @Positive BigDecimal amountUsdc
 ) {}

--- a/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/RemittanceResponse.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 public record RemittanceResponse(
     Long id,
     UUID remittanceId,
-    UUID senderId,
     String recipientPhone,
     BigDecimal amountUsdc,
     BigDecimal amountInr,

--- a/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
+++ b/backend/src/main/java/com/stablepay/application/dto/WalletResponse.java
@@ -2,14 +2,12 @@ package com.stablepay.application.dto;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.UUID;
 
 import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record WalletResponse(
     Long id,
-    UUID userId,
     String solanaAddress,
     BigDecimal availableBalance,
     BigDecimal totalBalance,

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/GetClaimQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/GetClaimQueryHandler.java
@@ -3,6 +3,7 @@ package com.stablepay.domain.claim.handler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
@@ -18,6 +19,7 @@ public class GetClaimQueryHandler {
 
     private final ClaimTokenRepository claimTokenRepository;
     private final RemittanceRepository remittanceRepository;
+    private final UserRepository userRepository;
 
     public ClaimDetails handle(String token) {
         var claimToken = claimTokenRepository.findByToken(token)
@@ -26,9 +28,14 @@ public class GetClaimQueryHandler {
         var remittance = remittanceRepository.findByRemittanceId(claimToken.remittanceId())
                 .orElseThrow(() -> RemittanceNotFoundException.byId(claimToken.remittanceId()));
 
+        var senderDisplayName = userRepository.findById(remittance.senderId())
+                .map(user -> user.email().split("@")[0])
+                .orElse("Unknown");
+
         return ClaimDetails.builder()
                 .claimToken(claimToken)
                 .remittance(remittance)
+                .senderDisplayName(senderDisplayName)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -51,6 +51,10 @@ public class SubmitClaimHandler {
             throw InvalidRemittanceStateException.forClaim(remittance.status());
         }
 
+        var senderDisplayName = userRepository.findById(remittance.senderId())
+                .map(user -> user.email().split("@")[0])
+                .orElse("Unknown");
+
         var updatedClaim = claimToken.toBuilder()
                 .claimed(true)
                 .upiId(upiId)
@@ -62,10 +66,6 @@ public class SubmitClaimHandler {
 
         claimSignaler.ifPresent(signaler ->
                 signaler.signalClaim(claimToken.remittanceId(), token, upiId));
-
-        var senderDisplayName = userRepository.findById(remittance.senderId())
-                .map(user -> user.email().split("@")[0])
-                .orElse("Unknown");
 
         return ClaimDetails.builder()
                 .claimToken(savedClaim)

--- a/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/handler/SubmitClaimHandler.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
 import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
@@ -29,6 +30,7 @@ public class SubmitClaimHandler {
     private final ClaimTokenRepository claimTokenRepository;
     private final RemittanceRepository remittanceRepository;
     private final Optional<RemittanceClaimSignaler> claimSignaler;
+    private final UserRepository userRepository;
 
     public ClaimDetails handle(String token, String upiId) {
         var claimToken = claimTokenRepository.findByToken(token)
@@ -61,9 +63,14 @@ public class SubmitClaimHandler {
         claimSignaler.ifPresent(signaler ->
                 signaler.signalClaim(claimToken.remittanceId(), token, upiId));
 
+        var senderDisplayName = userRepository.findById(remittance.senderId())
+                .map(user -> user.email().split("@")[0])
+                .orElse("Unknown");
+
         return ClaimDetails.builder()
                 .claimToken(savedClaim)
                 .remittance(remittance)
+                .senderDisplayName(senderDisplayName)
                 .build();
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
@@ -15,5 +15,6 @@ public record ClaimDetails(
     public ClaimDetails {
         requireNonNull(claimToken, "claimToken cannot be null");
         requireNonNull(remittance, "remittance cannot be null");
+        requireNonNull(senderDisplayName, "senderDisplayName cannot be null");
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
+++ b/backend/src/main/java/com/stablepay/domain/claim/model/ClaimDetails.java
@@ -9,7 +9,8 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 public record ClaimDetails(
     ClaimToken claimToken,
-    Remittance remittance
+    Remittance remittance,
+    String senderDisplayName
 ) {
     public ClaimDetails {
         requireNonNull(claimToken, "claimToken cannot be null");

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/GetFundingOrderHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/GetFundingOrderHandler.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
 import com.stablepay.domain.funding.model.FundingOrder;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.port.WalletRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,9 +17,19 @@ import lombok.RequiredArgsConstructor;
 public class GetFundingOrderHandler {
 
     private final FundingOrderRepository fundingOrderRepository;
+    private final WalletRepository walletRepository;
 
-    public FundingOrder handle(UUID fundingId) {
-        return fundingOrderRepository.findByFundingId(fundingId)
+    public FundingOrder handle(UUID fundingId, UUID authenticatedUserId) {
+        var order = fundingOrderRepository.findByFundingId(fundingId)
                 .orElseThrow(() -> FundingOrderNotFoundException.byFundingId(fundingId));
+
+        var wallet = walletRepository.findById(order.walletId())
+                .orElseThrow(() -> WalletNotFoundException.byId(order.walletId()));
+
+        if (!wallet.userId().equals(authenticatedUserId)) {
+            throw FundingOrderNotFoundException.byFundingId(fundingId);
+        }
+
+        return order;
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/InitiateFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/InitiateFundingHandler.java
@@ -1,6 +1,7 @@
 package com.stablepay.domain.funding.handler;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
@@ -33,8 +34,11 @@ public class InitiateFundingHandler {
     private final PaymentGateway paymentGateway;
     private final FundingOrderWriter fundingOrderWriter;
 
-    public FundingInitiationResult handle(Long walletId, BigDecimal amount) {
-        if (!walletRepository.existsById(walletId)) {
+    public FundingInitiationResult handle(Long walletId, BigDecimal amount, UUID authenticatedUserId) {
+        var wallet = walletRepository.findById(walletId)
+                .orElseThrow(() -> WalletNotFoundException.byId(walletId));
+
+        if (!wallet.userId().equals(authenticatedUserId)) {
             throw WalletNotFoundException.byId(walletId);
         }
 

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
@@ -43,16 +43,19 @@ public class RefundFundingHandler {
         var order = fundingOrderRepository.findByFundingId(fundingId)
                 .orElseThrow(() -> FundingOrderNotFoundException.byFundingId(fundingId));
 
+        var ownerWallet = walletRepository.findById(order.walletId())
+                .orElseThrow(() -> WalletNotFoundException.byId(order.walletId()));
+
+        if (!ownerWallet.userId().equals(authenticatedUserId)) {
+            throw FundingOrderNotFoundException.byFundingId(fundingId);
+        }
+
         if (order.status() != FundingStatus.FUNDED) {
             throw RefundNotAllowedException.forStatus(order.status());
         }
 
         var wallet = walletRepository.findByIdForUpdate(order.walletId())
                 .orElseThrow(() -> WalletNotFoundException.byId(order.walletId()));
-
-        if (!wallet.userId().equals(authenticatedUserId)) {
-            throw FundingOrderNotFoundException.byFundingId(fundingId);
-        }
 
         var amount = order.amountUsdc();
         assertSufficientBalance(wallet, amount);

--- a/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/funding/handler/RefundFundingHandler.java
@@ -37,7 +37,7 @@ public class RefundFundingHandler {
     private final TreasuryService treasuryService;
     private final PaymentGateway paymentGateway;
 
-    public FundingOrder handle(UUID fundingId) {
+    public FundingOrder handle(UUID fundingId, UUID authenticatedUserId) {
         requireNonNull(fundingId, "fundingId cannot be null");
 
         var order = fundingOrderRepository.findByFundingId(fundingId)
@@ -49,6 +49,10 @@ public class RefundFundingHandler {
 
         var wallet = walletRepository.findByIdForUpdate(order.walletId())
                 .orElseThrow(() -> WalletNotFoundException.byId(order.walletId()));
+
+        if (!wallet.userId().equals(authenticatedUserId)) {
+            throw FundingOrderNotFoundException.byFundingId(fundingId);
+        }
 
         var amount = order.amountUsdc();
         assertSufficientBalance(wallet, amount);

--- a/backend/src/main/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandler.java
@@ -18,8 +18,14 @@ public class GetRemittanceQueryHandler {
 
     private final RemittanceRepository remittanceRepository;
 
-    public Remittance handle(UUID remittanceId) {
-        return remittanceRepository.findByRemittanceId(remittanceId)
+    public Remittance handle(UUID remittanceId, UUID authenticatedUserId) {
+        var remittance = remittanceRepository.findByRemittanceId(remittanceId)
                 .orElseThrow(() -> RemittanceNotFoundException.byId(remittanceId));
+
+        if (!remittance.senderId().equals(authenticatedUserId)) {
+            throw RemittanceNotFoundException.byId(remittanceId);
+        }
+
+        return remittance;
     }
 }

--- a/backend/src/main/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandler.java
+++ b/backend/src/main/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandler.java
@@ -1,0 +1,25 @@
+package com.stablepay.domain.wallet.handler;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.model.Wallet;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetWalletQueryHandler {
+
+    private final WalletRepository walletRepository;
+
+    public Wallet handle(UUID userId) {
+        return walletRepository.findByUserId(userId)
+                .orElseThrow(() -> WalletNotFoundException.byUserId(userId));
+    }
+}

--- a/backend/src/test/java/com/stablepay/application/controller/auth/mapper/AuthResponseMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/auth/mapper/AuthResponseMapperTest.java
@@ -49,7 +49,6 @@ class AuthResponseMapperTest {
                         .build())
                 .wallet(WalletResponse.builder()
                         .id(wallet.id())
-                        .userId(wallet.userId())
                         .solanaAddress(SOME_SOLANA_ADDRESS)
                         .availableBalance(BigDecimal.ZERO)
                         .totalBalance(BigDecimal.ZERO)

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.application.controller.claim;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_SENDER_DISPLAY_NAME;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_UPI_ID;
 import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
@@ -7,7 +8,6 @@ import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -37,11 +37,12 @@ import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.remittance.exception.InvalidRemittanceStateException;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(ClaimController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class})
 class ClaimControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -70,11 +71,12 @@ class ClaimControllerTest {
         var claimDetails = ClaimDetails.builder()
                 .claimToken(claimToken)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
 
         var response = ClaimResponse.builder()
                 .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .amountInr(SOME_AMOUNT_INR)
                 .fxRate(SOME_FX_RATE)
@@ -89,7 +91,7 @@ class ClaimControllerTest {
         mockMvc.perform(get("/api/claims/{token}", SOME_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()))
+                .andExpect(jsonPath("$.senderDisplayName").value(SOME_SENDER_DISPLAY_NAME))
                 .andExpect(jsonPath("$.claimed").value(false));
     }
 
@@ -102,11 +104,12 @@ class ClaimControllerTest {
         var claimDetails = ClaimDetails.builder()
                 .claimToken(claimToken)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
 
         var response = ClaimResponse.builder()
                 .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .amountInr(SOME_AMOUNT_INR)
                 .fxRate(SOME_FX_RATE)

--- a/backend/src/test/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapperTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.application.controller.claim.mapper;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_SENDER_DISPLAY_NAME;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_EXPIRES_AT;
 import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
@@ -27,6 +28,7 @@ class ClaimApiMapperTest {
         var claimDetails = ClaimDetails.builder()
                 .claimToken(claimToken)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
 
         // when
@@ -35,6 +37,7 @@ class ClaimApiMapperTest {
         // then
         var expected = ClaimResponse.builder()
                 .remittanceId(remittance.remittanceId())
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .amountUsdc(remittance.amountUsdc())
                 .amountInr(remittance.amountInr())
                 .fxRate(remittance.fxRate())

--- a/backend/src/test/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/mapper/ClaimApiMapperTest.java
@@ -35,7 +35,6 @@ class ClaimApiMapperTest {
         // then
         var expected = ClaimResponse.builder()
                 .remittanceId(remittance.remittanceId())
-                .senderId(remittance.senderId())
                 .amountUsdc(remittance.amountUsdc())
                 .amountInr(remittance.amountInr())
                 .fxRate(remittance.fxRate())

--- a/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
@@ -6,8 +6,9 @@ import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -42,11 +43,12 @@ import com.stablepay.domain.funding.model.FundingInitiationResult;
 import com.stablepay.domain.funding.model.FundingStatus;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(FundingController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class})
 class FundingControllerTest {
 
     private static final String SOME_CLIENT_SECRET = "pi_3MnTest_secret_abc";
@@ -91,7 +93,7 @@ class FundingControllerTest {
                 .createdAt(SOME_CREATED_AT)
                 .build();
 
-        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC)).willReturn(result);
+        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID)).willReturn(result);
         given(fundingApiMapper.toResponseWithClientSecret(order, SOME_CLIENT_SECRET))
                 .willReturn(responseWithSecret);
 
@@ -99,7 +101,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -115,14 +117,14 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn404WhenWalletNotFound() {
         // given
-        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
                 .willThrow(WalletNotFoundException.byId(SOME_WALLET_ID));
 
         var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -133,14 +135,14 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn409WhenFundingAlreadyInProgress() {
         // given
-        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
                 .willThrow(FundingAlreadyInProgressException.forWallet(SOME_WALLET_ID));
 
         var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -151,14 +153,14 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn502WhenStripeFails() {
         // given
-        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
                 .willThrow(FundingFailedException.stripeError("card_declined", new RuntimeException()));
 
         var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadGateway())
@@ -173,7 +175,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -188,7 +190,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -203,7 +205,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -224,11 +226,12 @@ class FundingControllerTest {
                 .createdAt(SOME_CREATED_AT)
                 .build();
 
-        given(getFundingOrderHandler.handle(SOME_FUNDING_ID)).willReturn(order);
+        given(getFundingOrderHandler.handle(SOME_FUNDING_ID, SOME_USER_ID)).willReturn(order);
         given(fundingApiMapper.toResponse(order)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.fundingId").value(SOME_FUNDING_ID.toString()))
                 .andExpect(jsonPath("$.status").value("FUNDED"))
@@ -241,11 +244,12 @@ class FundingControllerTest {
     void shouldReturn404WhenFundingOrderNotFound() {
         // given
         var missingId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-        given(getFundingOrderHandler.handle(missingId))
+        given(getFundingOrderHandler.handle(missingId, SOME_USER_ID))
                 .willThrow(FundingOrderNotFoundException.byFundingId(missingId));
 
         // when / then
-        mockMvc.perform(get("/api/funding-orders/{fundingId}", missingId).with(jwt()))
+        mockMvc.perform(get("/api/funding-orders/{fundingId}", missingId)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0020"));
     }
@@ -264,11 +268,12 @@ class FundingControllerTest {
                 .createdAt(SOME_CREATED_AT)
                 .build();
 
-        given(refundFundingHandler.handle(SOME_FUNDING_ID)).willReturn(order);
+        given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID)).willReturn(order);
         given(fundingApiMapper.toResponse(order)).willReturn(response);
 
         // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.fundingId").value(SOME_FUNDING_ID.toString()))
                 .andExpect(jsonPath("$.status").value("REFUNDED"))
@@ -279,11 +284,12 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn404WhenRefundingMissingOrder() {
         // given
-        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+        given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .willThrow(FundingOrderNotFoundException.byFundingId(SOME_FUNDING_ID));
 
         // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0020"));
     }
@@ -292,11 +298,12 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn409WhenRefundNotAllowed() {
         // given
-        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+        given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .willThrow(RefundNotAllowedException.forStatus(FundingStatus.PAYMENT_CONFIRMED));
 
         // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0023"));
     }
@@ -305,12 +312,13 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn409WhenRefundBalanceInsufficient() {
         // given
-        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+        given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .willThrow(InsufficientBalanceForRefundException.forAmount(
                         SOME_AMOUNT_USDC, new BigDecimal("0.00")));
 
         // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0025"));
     }
@@ -319,12 +327,13 @@ class FundingControllerTest {
     @SneakyThrows
     void shouldReturn502WhenStripeRefundFails() {
         // given
-        given(refundFundingHandler.handle(SOME_FUNDING_ID))
+        given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .willThrow(RefundFailedException.stripeRefundFailed(
                         SOME_STRIPE_PAYMENT_INTENT_ID, new RuntimeException("boom")));
 
         // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID).with(jwt()))
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
                 .andExpect(status().isBadGateway())
                 .andExpect(jsonPath("$.errorCode").value("SP-0024"));
     }

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -11,7 +11,7 @@ import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_UPDATED_AT;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -43,11 +43,12 @@ import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
 import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(RemittanceController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class})
 class RemittanceControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -78,7 +79,6 @@ class RemittanceControllerTest {
         var response = RemittanceResponse.builder()
                 .id(SOME_REMITTANCE_DB_ID)
                 .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .amountInr(SOME_AMOUNT_INR)
@@ -94,20 +94,18 @@ class RemittanceControllerTest {
         given(remittanceApiMapper.toResponse(domain)).willReturn(response);
 
         var request = CreateRemittanceRequest.builder()
-                .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .build();
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(SOME_REMITTANCE_DB_ID))
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()))
                 .andExpect(jsonPath("$.recipientPhone").value(SOME_RECIPIENT_PHONE))
                 .andExpect(jsonPath("$.status").value("INITIATED"));
     }
@@ -120,7 +118,6 @@ class RemittanceControllerTest {
         var response = RemittanceResponse.builder()
                 .id(SOME_REMITTANCE_DB_ID)
                 .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .fxRate(SOME_FX_RATE)
@@ -130,19 +127,19 @@ class RemittanceControllerTest {
                 .updatedAt(SOME_UPDATED_AT)
                 .build();
 
-        given(getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID)).willReturn(domain);
+        given(getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID, SOME_SENDER_ID)).willReturn(domain);
         given(remittanceApiMapper.toResponse(domain)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID).with(jwt()))
+        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.senderId").value(SOME_SENDER_ID.toString()));
+                .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()));
     }
 
     @Test
     @SneakyThrows
-    void shouldListRemittancesBySenderId() {
+    void shouldListRemittancesByAuthenticatedUser() {
         // given
         var pageable = PageRequest.of(0, 20);
         var domain = remittanceBuilder().build();
@@ -151,7 +148,6 @@ class RemittanceControllerTest {
         var response = RemittanceResponse.builder()
                 .id(SOME_REMITTANCE_DB_ID)
                 .remittanceId(SOME_REMITTANCE_ID)
-                .senderId(SOME_SENDER_ID)
                 .status(RemittanceStatus.INITIATED)
                 .build();
 
@@ -160,13 +156,11 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(get("/api/remittances")
-                        .with(jwt())
-                        .param("senderId", SOME_SENDER_ID.toString())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].remittanceId").value(SOME_REMITTANCE_ID.toString()))
-                .andExpect(jsonPath("$.content[0].senderId").value(SOME_SENDER_ID.toString()))
                 .andExpect(jsonPath("$.totalElements").value(1));
     }
 
@@ -175,11 +169,12 @@ class RemittanceControllerTest {
     void shouldReturn404WhenRemittanceNotFound() {
         // given
         var unknownId = UUID.fromString("00000000-0000-0000-0000-000000000099");
-        given(getRemittanceQueryHandler.handle(unknownId))
+        given(getRemittanceQueryHandler.handle(unknownId, SOME_SENDER_ID))
                 .willThrow(RemittanceNotFoundException.byId(unknownId));
 
         // when / then
-        mockMvc.perform(get("/api/remittances/{remittanceId}", unknownId).with(jwt()))
+        mockMvc.perform(get("/api/remittances/{remittanceId}", unknownId)
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0010"));
     }
@@ -192,14 +187,13 @@ class RemittanceControllerTest {
                 .willThrow(InsufficientBalanceException.forAmount(SOME_AMOUNT_USDC, BigDecimal.valueOf(50)));
 
         var request = CreateRemittanceRequest.builder()
-                .senderId(SOME_SENDER_ID)
                 .recipientPhone(SOME_RECIPIENT_PHONE)
                 .amountUsdc(SOME_AMOUNT_USDC)
                 .build();
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -211,33 +205,16 @@ class RemittanceControllerTest {
     void shouldReturn400WhenValidationFails() {
         // given
         var request = CreateRemittanceRequest.builder()
-                .senderId(null)
                 .recipientPhone("")
                 .amountUsdc(null)
                 .build();
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(jwt())
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0003"));
-    }
-
-    @Test
-    @SneakyThrows
-    void shouldReturn400WhenSenderIdIsBlankString() {
-        // given
-        var json = """
-                {"senderId":"","recipientPhone":"+919876543210","amountUsdc":100}
-                """;
-
-        // when / then
-        mockMvc.perform(post("/api/remittances")
-                        .with(jwt())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json))
-                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/mapper/RemittanceApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/mapper/RemittanceApiMapperTest.java
@@ -27,7 +27,6 @@ class RemittanceApiMapperTest {
         var expected = RemittanceResponse.builder()
                 .id(remittance.id())
                 .remittanceId(remittance.remittanceId())
-                .senderId(remittance.senderId())
                 .recipientPhone(remittance.recipientPhone())
                 .amountUsdc(remittance.amountUsdc())
                 .amountInr(remittance.amountInr())

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -7,6 +7,8 @@ import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static com.stablepay.testutil.WalletFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -27,13 +29,16 @@ import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
 import com.stablepay.application.dto.CreateWalletRequest;
 import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
+import com.stablepay.domain.wallet.handler.GetWalletQueryHandler;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(WalletController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class})
 class WalletControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -43,6 +48,9 @@ class WalletControllerTest {
 
     @MockitoBean
     private CreateWalletHandler createWalletHandler;
+
+    @MockitoBean
+    private GetWalletQueryHandler getWalletQueryHandler;
 
     @MockitoBean
     private WalletApiMapper walletApiMapper;
@@ -61,7 +69,6 @@ class WalletControllerTest {
 
         var response = WalletResponse.builder()
                 .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
                 .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
@@ -82,7 +89,6 @@ class WalletControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.userId").value(SOME_USER_ID.toString()))
                 .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
     }
 
@@ -152,5 +158,44 @@ class WalletControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0008"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldGetMyWallet() {
+        // given
+        var wallet = walletBuilder().build();
+        var response = WalletResponse.builder()
+                .id(SOME_WALLET_ID)
+                .solanaAddress(SOME_SOLANA_ADDRESS)
+                .availableBalance(wallet.availableBalance())
+                .totalBalance(wallet.totalBalance())
+                .createdAt(SOME_CREATED_AT)
+                .updatedAt(SOME_UPDATED_AT)
+                .build();
+
+        given(getWalletQueryHandler.handle(SOME_USER_ID)).willReturn(wallet);
+        given(walletApiMapper.toResponse(wallet)).willReturn(response);
+
+        // when / then
+        mockMvc.perform(get("/api/wallets/me")
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
+                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenMyWalletNotFound() {
+        // given
+        given(getWalletQueryHandler.handle(SOME_USER_ID))
+                .willThrow(WalletNotFoundException.byUserId(SOME_USER_ID));
+
+        // when / then
+        mockMvc.perform(get("/api/wallets/me")
+                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0006"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -117,7 +117,6 @@ class WalletControllerTest {
 
         var response = WalletResponse.builder()
                 .id(SOME_WALLET_ID)
-                .userId(SOME_USER_ID)
                 .solanaAddress(SOME_SOLANA_ADDRESS)
                 .availableBalance(BigDecimal.ZERO)
                 .totalBalance(BigDecimal.ZERO)
@@ -138,7 +137,7 @@ class WalletControllerTest {
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.userId").value(SOME_USER_ID.toString()));
+                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapperTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/mapper/WalletApiMapperTest.java
@@ -22,7 +22,6 @@ class WalletApiMapperTest {
         // then
         var expected = WalletResponse.builder()
                 .id(wallet.id())
-                .userId(wallet.userId())
                 .solanaAddress(wallet.solanaAddress())
                 .availableBalance(wallet.availableBalance())
                 .totalBalance(wallet.totalBalance())

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/GetClaimQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/GetClaimQueryHandlerTest.java
@@ -1,8 +1,11 @@
 package com.stablepay.domain.claim.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_SENDER_DISPLAY_NAME;
+import static com.stablepay.testutil.AuthFixtures.appUserBuilder;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
 import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
 import com.stablepay.domain.claim.model.ClaimDetails;
 import com.stablepay.domain.claim.port.ClaimTokenRepository;
@@ -31,17 +35,22 @@ class GetClaimQueryHandlerTest {
     @Mock
     private RemittanceRepository remittanceRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private GetClaimQueryHandler getClaimQueryHandler;
 
     @Test
-    void shouldReturnClaimDetailsForValidToken() {
+    void shouldReturnClaimDetailsWithSenderDisplayName() {
         // given
         var claimToken = claimTokenBuilder().build();
         var remittance = remittanceBuilder().build();
+        var appUser = appUserBuilder().build();
 
         given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
         given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+        given(userRepository.findById(SOME_SENDER_ID)).willReturn(Optional.of(appUser));
 
         // when
         var result = getClaimQueryHandler.handle(SOME_TOKEN);
@@ -50,6 +59,32 @@ class GetClaimQueryHandlerTest {
         var expected = ClaimDetails.builder()
                 .claimToken(claimToken)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
+                .build();
+
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnUnknownWhenSenderUserNotFound() {
+        // given
+        var claimToken = claimTokenBuilder().build();
+        var remittance = remittanceBuilder().build();
+
+        given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+        given(userRepository.findById(SOME_SENDER_ID)).willReturn(Optional.empty());
+
+        // when
+        var result = getClaimQueryHandler.handle(SOME_TOKEN);
+
+        // then
+        var expected = ClaimDetails.builder()
+                .claimToken(claimToken)
+                .remittance(remittance)
+                .senderDisplayName("Unknown")
                 .build();
 
         assertThat(result)

--- a/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/claim/handler/SubmitClaimHandlerTest.java
@@ -1,10 +1,13 @@
 package com.stablepay.domain.claim.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_SENDER_DISPLAY_NAME;
+import static com.stablepay.testutil.AuthFixtures.appUserBuilder;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_EXPIRED_AT;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_TOKEN;
 import static com.stablepay.testutil.ClaimTokenFixtures.SOME_UPI_ID;
 import static com.stablepay.testutil.ClaimTokenFixtures.claimTokenBuilder;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
 import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
 import com.stablepay.domain.claim.exception.ClaimTokenNotFoundException;
@@ -42,24 +46,29 @@ class SubmitClaimHandlerTest {
     @Mock
     private RemittanceClaimSignaler claimSignaler;
 
+    @Mock
+    private UserRepository userRepository;
+
     private SubmitClaimHandler submitClaimHandler;
 
     @BeforeEach
     void setUp() {
         submitClaimHandler = new SubmitClaimHandler(
-                claimTokenRepository, remittanceRepository, Optional.of(claimSignaler));
+                claimTokenRepository, remittanceRepository, Optional.of(claimSignaler), userRepository);
     }
 
     @Test
-    void shouldSubmitClaimSuccessfully() {
+    void shouldSubmitClaimWithSenderDisplayName() {
         // given
         var claimToken = claimTokenBuilder().build();
         var remittance = remittanceBuilder()
                 .status(RemittanceStatus.ESCROWED)
                 .build();
+        var appUser = appUserBuilder().build();
 
         given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
         given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+        given(userRepository.findById(SOME_SENDER_ID)).willReturn(Optional.of(appUser));
 
         var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
         given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
@@ -71,6 +80,7 @@ class SubmitClaimHandlerTest {
         var expected = ClaimDetails.builder()
                 .claimToken(updatedClaim)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
         assertThat(result)
                 .usingRecursiveComparison()
@@ -107,15 +117,17 @@ class SubmitClaimHandlerTest {
     void shouldSubmitClaimWithoutSignalerWhenNotConfigured() {
         // given
         var handler = new SubmitClaimHandler(
-                claimTokenRepository, remittanceRepository, Optional.empty());
+                claimTokenRepository, remittanceRepository, Optional.empty(), userRepository);
 
         var claimToken = claimTokenBuilder().build();
         var remittance = remittanceBuilder()
                 .status(RemittanceStatus.ESCROWED)
                 .build();
+        var appUser = appUserBuilder().build();
 
         given(claimTokenRepository.findByToken(SOME_TOKEN)).willReturn(Optional.of(claimToken));
         given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID)).willReturn(Optional.of(remittance));
+        given(userRepository.findById(SOME_SENDER_ID)).willReturn(Optional.of(appUser));
 
         var updatedClaim = claimToken.toBuilder().claimed(true).upiId(SOME_UPI_ID).build();
         given(claimTokenRepository.save(updatedClaim)).willReturn(updatedClaim);
@@ -127,6 +139,7 @@ class SubmitClaimHandlerTest {
         var expected = ClaimDetails.builder()
                 .claimToken(updatedClaim)
                 .remittance(remittance)
+                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
         assertThat(result)
                 .usingRecursiveComparison()

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/GetFundingOrderHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/GetFundingOrderHandlerTest.java
@@ -1,7 +1,10 @@
 package com.stablepay.domain.funding.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -17,12 +20,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
 import com.stablepay.domain.funding.port.FundingOrderRepository;
+import com.stablepay.domain.wallet.port.WalletRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GetFundingOrderHandlerTest {
 
     @Mock
     private FundingOrderRepository fundingOrderRepository;
+
+    @Mock
+    private WalletRepository walletRepository;
 
     @InjectMocks
     private GetFundingOrderHandler getFundingOrderHandler;
@@ -31,10 +38,12 @@ class GetFundingOrderHandlerTest {
     void shouldReturnFundingOrderWhenFound() {
         // given
         var order = fundingOrderBuilder().build();
+        var wallet = walletBuilder().id(order.walletId()).build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
 
         // when
-        var result = getFundingOrderHandler.handle(SOME_FUNDING_ID);
+        var result = getFundingOrderHandler.handle(SOME_FUNDING_ID, SOME_USER_ID);
 
         // then
         assertThat(result)
@@ -49,9 +58,23 @@ class GetFundingOrderHandlerTest {
         given(fundingOrderRepository.findByFundingId(missingId)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> getFundingOrderHandler.handle(missingId))
+        assertThatThrownBy(() -> getFundingOrderHandler.handle(missingId, SOME_USER_ID))
                 .isInstanceOf(FundingOrderNotFoundException.class)
                 .hasMessageContaining("SP-0020")
                 .hasMessageContaining(missingId.toString());
+    }
+
+    @Test
+    void shouldThrowWhenFundingOrderBelongsToDifferentUser() {
+        // given
+        var order = fundingOrderBuilder().build();
+        var wallet = walletBuilder().id(order.walletId()).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+
+        // when / then
+        assertThatThrownBy(() -> getFundingOrderHandler.handle(SOME_FUNDING_ID, SOME_OTHER_USER_ID))
+                .isInstanceOf(FundingOrderNotFoundException.class)
+                .hasMessageContaining("SP-0020");
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/InitiateFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/InitiateFundingHandlerTest.java
@@ -1,15 +1,20 @@
 package com.stablepay.domain.funding.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,7 +61,8 @@ class InitiateFundingHandlerTest {
 
     @Test
     void shouldCommitPendingOrderBeforeStripeCallAndAttachPaymentIntentAfter() {
-        // given — the writer commits each save in its own REQUIRES_NEW tx.
+        // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
         var pending = fundingOrderBuilder()
                 .stripePaymentIntentId(null)
                 .build();
@@ -64,7 +70,7 @@ class InitiateFundingHandlerTest {
                 .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
                 .build();
 
-        given(walletRepository.existsById(SOME_WALLET_ID)).willReturn(true);
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
         given(fundingOrderWriter.savePending(SOME_WALLET_ID, SOME_AMOUNT_USDC)).willReturn(pending);
         given(paymentGateway.initiatePayment(paymentRequestCaptor.capture()))
                 .willReturn(PaymentResult.builder()
@@ -76,11 +82,9 @@ class InitiateFundingHandlerTest {
                 .willReturn(withIntent);
 
         // when
-        var result = initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC);
+        var result = initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID);
 
-        // then — pending row committed before Stripe is called; payment-intent
-        // attached after Stripe returns. Webhook handler is guaranteed to find
-        // the row regardless of arrival order.
+        // then
         InOrder inOrder = Mockito.inOrder(fundingOrderWriter, paymentGateway);
         inOrder.verify(fundingOrderWriter).savePending(SOME_WALLET_ID, SOME_AMOUNT_USDC);
         inOrder.verify(paymentGateway).initiatePayment(Mockito.any(PaymentRequest.class));
@@ -107,10 +111,25 @@ class InitiateFundingHandlerTest {
     @Test
     void shouldThrowWhenWalletNotFound() {
         // given
-        given(walletRepository.existsById(SOME_WALLET_ID)).willReturn(false);
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006");
+
+        then(fundingOrderWriter).shouldHaveNoInteractions();
+        then(paymentGateway).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenWalletBelongsToDifferentUser() {
+        // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
+
+        // when / then
+        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_OTHER_USER_ID))
                 .isInstanceOf(WalletNotFoundException.class)
                 .hasMessageContaining("SP-0006");
 
@@ -120,13 +139,14 @@ class InitiateFundingHandlerTest {
 
     @Test
     void shouldNotCallStripeWhenWriterRejectsConcurrentFunding() {
-        // given — partial unique index translates to FundingAlreadyInProgress in the writer.
-        given(walletRepository.existsById(SOME_WALLET_ID)).willReturn(true);
+        // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
         willThrow(FundingAlreadyInProgressException.forWallet(SOME_WALLET_ID))
                 .given(fundingOrderWriter).savePending(SOME_WALLET_ID, SOME_AMOUNT_USDC);
 
         // when / then
-        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
                 .isInstanceOf(FundingAlreadyInProgressException.class)
                 .hasMessageContaining("SP-0022");
 
@@ -138,17 +158,18 @@ class InitiateFundingHandlerTest {
     @Test
     void shouldMarkOrderFailedAndPropagateWhenStripeRejects() {
         // given
+        var wallet = walletBuilder().id(SOME_WALLET_ID).build();
         var pending = fundingOrderBuilder()
                 .stripePaymentIntentId(null)
                 .build();
 
-        given(walletRepository.existsById(SOME_WALLET_ID)).willReturn(true);
+        given(walletRepository.findById(SOME_WALLET_ID)).willReturn(Optional.of(wallet));
         given(fundingOrderWriter.savePending(SOME_WALLET_ID, SOME_AMOUNT_USDC)).willReturn(pending);
         willThrow(FundingFailedException.stripeError("card_declined", new RuntimeException("boom")))
                 .given(paymentGateway).initiatePayment(paymentRequestCaptor.capture());
 
         // when / then
-        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC))
+        assertThatThrownBy(() -> initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID))
                 .isInstanceOf(FundingFailedException.class)
                 .hasMessageContaining("SP-0021");
 

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
@@ -77,6 +77,7 @@ class RefundFundingHandlerTest {
                 .build();
 
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
         given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
         given(treasuryService.getUsdcBalance(wallet.solanaAddress())).willReturn(new BigDecimal("100.00"));
 
@@ -126,7 +127,9 @@ class RefundFundingHandlerTest {
     void shouldThrowWhenOrderStatusIsNotFunded(FundingStatus nonFundedStatus) {
         // given
         var order = fundingOrderBuilder().status(nonFundedStatus).build();
+        var wallet = walletBuilder().id(order.walletId()).build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
 
         // when / then
         assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
@@ -134,11 +137,8 @@ class RefundFundingHandlerTest {
                 .hasMessageContaining("SP-0023")
                 .hasMessageContaining(nonFundedStatus.name());
 
-        then(walletRepository).shouldHaveNoInteractions();
         then(treasuryService).shouldHaveNoInteractions();
         then(paymentGateway).shouldHaveNoInteractions();
-        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
-        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -152,7 +152,24 @@ class RefundFundingHandlerTest {
                 .build();
 
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
-        given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_OTHER_USER_ID))
+                .isInstanceOf(FundingOrderNotFoundException.class)
+                .hasMessageContaining("SP-0020");
+
+        then(paymentGateway).shouldHaveNoInteractions();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = FundingStatus.class, names = "FUNDED", mode = Mode.EXCLUDE)
+    void shouldReturnNotFoundNotStatusWhenNonFundedOrderBelongsToDifferentUser(FundingStatus nonFundedStatus) {
+        // given
+        var order = fundingOrderBuilder().status(nonFundedStatus).build();
+        var wallet = walletBuilder().id(order.walletId()).build();
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
 
         // when / then
         assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_OTHER_USER_ID))
@@ -172,6 +189,7 @@ class RefundFundingHandlerTest {
                 .totalBalance(new BigDecimal("100.00"))
                 .build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
         given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
         given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("10.00"));
 
@@ -183,10 +201,6 @@ class RefundFundingHandlerTest {
                 .hasMessageContaining("10.00");
 
         then(paymentGateway).shouldHaveNoInteractions();
-        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
-        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
-        then(walletRepository).should().findByIdForUpdate(order.walletId());
-        then(walletRepository).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -199,6 +213,7 @@ class RefundFundingHandlerTest {
                 .totalBalance(new BigDecimal("100.00"))
                 .build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
         given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
         given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("100.00"));
 
@@ -210,10 +225,6 @@ class RefundFundingHandlerTest {
                 .hasMessageContaining("5.00");
 
         then(paymentGateway).shouldHaveNoInteractions();
-        then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
-        then(fundingOrderRepository).shouldHaveNoMoreInteractions();
-        then(walletRepository).should().findByIdForUpdate(order.walletId());
-        then(walletRepository).shouldHaveNoMoreInteractions();
     }
 
     @Test
@@ -226,6 +237,7 @@ class RefundFundingHandlerTest {
                 .totalBalance(new BigDecimal("100.00"))
                 .build();
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findById(order.walletId())).willReturn(Optional.of(wallet));
         given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
         given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("100.00"));
 
@@ -246,8 +258,6 @@ class RefundFundingHandlerTest {
                 .hasCause(stripeFailure);
 
         then(fundingOrderRepository).should(times(2)).save(fundingOrderCaptor.capture());
-        then(walletRepository).should().findByIdForUpdate(order.walletId());
-        then(walletRepository).shouldHaveNoMoreInteractions();
 
         var saves = fundingOrderCaptor.getAllValues();
         assertThat(saves.get(0)).usingRecursiveComparison().isEqualTo(refundInitiated);

--- a/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/funding/handler/RefundFundingHandlerTest.java
@@ -1,10 +1,12 @@
 package com.stablepay.domain.funding.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
 import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -90,7 +92,7 @@ class RefundFundingHandlerTest {
         given(walletRepository.save(decrementedWallet)).willReturn(decrementedWallet);
 
         // when
-        var result = refundFundingHandler.handle(SOME_FUNDING_ID);
+        var result = refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID);
 
         // then
         then(fundingOrderRepository).should(times(2)).save(fundingOrderCaptor.capture());
@@ -110,7 +112,7 @@ class RefundFundingHandlerTest {
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .isInstanceOf(FundingOrderNotFoundException.class)
                 .hasMessageContaining("SP-0020");
 
@@ -127,7 +129,7 @@ class RefundFundingHandlerTest {
         given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
 
         // when / then
-        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .isInstanceOf(RefundNotAllowedException.class)
                 .hasMessageContaining("SP-0023")
                 .hasMessageContaining(nonFundedStatus.name());
@@ -137,6 +139,27 @@ class RefundFundingHandlerTest {
         then(paymentGateway).shouldHaveNoInteractions();
         then(fundingOrderRepository).should().findByFundingId(SOME_FUNDING_ID);
         then(fundingOrderRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void shouldThrowWhenWalletBelongsToDifferentUser() {
+        // given
+        var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
+        var wallet = walletBuilder()
+                .id(order.walletId())
+                .availableBalance(new BigDecimal("100.00"))
+                .totalBalance(new BigDecimal("100.00"))
+                .build();
+
+        given(fundingOrderRepository.findByFundingId(SOME_FUNDING_ID)).willReturn(Optional.of(order));
+        given(walletRepository.findByIdForUpdate(order.walletId())).willReturn(Optional.of(wallet));
+
+        // when / then
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_OTHER_USER_ID))
+                .isInstanceOf(FundingOrderNotFoundException.class)
+                .hasMessageContaining("SP-0020");
+
+        then(paymentGateway).shouldHaveNoInteractions();
     }
 
     @Test
@@ -153,7 +176,7 @@ class RefundFundingHandlerTest {
         given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("10.00"));
 
         // when / then
-        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .isInstanceOf(InsufficientBalanceForRefundException.class)
                 .hasMessageContaining("SP-0025")
                 .hasMessageContaining("25.00")
@@ -180,7 +203,7 @@ class RefundFundingHandlerTest {
         given(treasuryService.getUsdcBalance(SOME_SOLANA_ADDRESS)).willReturn(new BigDecimal("100.00"));
 
         // when / then
-        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .isInstanceOf(InsufficientBalanceForRefundException.class)
                 .hasMessageContaining("SP-0025")
                 .hasMessageContaining("25.00")
@@ -216,7 +239,7 @@ class RefundFundingHandlerTest {
         given(fundingOrderRepository.save(refundFailed)).willReturn(refundFailed);
 
         // when / then
-        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID))
+        assertThatThrownBy(() -> refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID))
                 .isInstanceOf(RefundFailedException.class)
                 .hasMessageContaining("SP-0024")
                 .hasMessageContaining(SOME_STRIPE_PAYMENT_INTENT_ID)

--- a/backend/src/test/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/remittance/handler/GetRemittanceQueryHandlerTest.java
@@ -1,6 +1,8 @@
 package com.stablepay.domain.remittance.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
+import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,7 +37,7 @@ class GetRemittanceQueryHandlerTest {
                 .willReturn(Optional.of(remittance));
 
         // when
-        var result = getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID);
+        var result = getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID, SOME_SENDER_ID);
 
         // then
         assertThat(result)
@@ -51,9 +53,22 @@ class GetRemittanceQueryHandlerTest {
                 .willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> getRemittanceQueryHandler.handle(unknownId))
+        assertThatThrownBy(() -> getRemittanceQueryHandler.handle(unknownId, SOME_SENDER_ID))
                 .isInstanceOf(RemittanceNotFoundException.class)
                 .hasMessageContaining("SP-0010")
                 .hasMessageContaining(unknownId.toString());
+    }
+
+    @Test
+    void shouldThrowWhenRemittanceBelongsToDifferentUser() {
+        // given
+        var remittance = remittanceBuilder().build();
+        given(remittanceRepository.findByRemittanceId(SOME_REMITTANCE_ID))
+                .willReturn(Optional.of(remittance));
+
+        // when / then
+        assertThatThrownBy(() -> getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID, SOME_OTHER_USER_ID))
+                .isInstanceOf(RemittanceNotFoundException.class)
+                .hasMessageContaining("SP-0010");
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandlerTest.java
@@ -1,5 +1,6 @@
 package com.stablepay.domain.wallet.handler;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -7,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,13 +45,12 @@ class GetWalletQueryHandlerTest {
     @Test
     void shouldThrowWalletNotFoundWhenNoWallet() {
         // given
-        var unknownUserId = UUID.fromString("00000000-0000-0000-0000-000000000099");
-        given(walletRepository.findByUserId(unknownUserId)).willReturn(Optional.empty());
+        given(walletRepository.findByUserId(SOME_OTHER_USER_ID)).willReturn(Optional.empty());
 
         // when / then
-        assertThatThrownBy(() -> getWalletQueryHandler.handle(unknownUserId))
+        assertThatThrownBy(() -> getWalletQueryHandler.handle(SOME_OTHER_USER_ID))
                 .isInstanceOf(WalletNotFoundException.class)
                 .hasMessageContaining("SP-0006")
-                .hasMessageContaining(unknownUserId.toString());
+                .hasMessageContaining(SOME_OTHER_USER_ID.toString());
     }
 }

--- a/backend/src/test/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandlerTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/handler/GetWalletQueryHandlerTest.java
@@ -1,0 +1,57 @@
+package com.stablepay.domain.wallet.handler;
+
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
+import static com.stablepay.testutil.WalletFixtures.walletBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablepay.domain.wallet.exception.WalletNotFoundException;
+import com.stablepay.domain.wallet.port.WalletRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetWalletQueryHandlerTest {
+
+    @Mock
+    private WalletRepository walletRepository;
+
+    @InjectMocks
+    private GetWalletQueryHandler getWalletQueryHandler;
+
+    @Test
+    void shouldReturnWalletForUser() {
+        // given
+        var wallet = walletBuilder().build();
+        given(walletRepository.findByUserId(SOME_USER_ID)).willReturn(Optional.of(wallet));
+
+        // when
+        var result = getWalletQueryHandler.handle(SOME_USER_ID);
+
+        // then
+        assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(wallet);
+    }
+
+    @Test
+    void shouldThrowWalletNotFoundWhenNoWallet() {
+        // given
+        var unknownUserId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        given(walletRepository.findByUserId(unknownUserId)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> getWalletQueryHandler.handle(unknownUserId))
+                .isInstanceOf(WalletNotFoundException.class)
+                .hasMessageContaining("SP-0006")
+                .hasMessageContaining(unknownUserId.toString());
+    }
+}

--- a/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
+++ b/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
@@ -1,0 +1,41 @@
+package com.stablepay.testutil;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.stablepay.domain.auth.model.AuthPrincipal;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    public static Authentication authenticationFor(UUID userId) {
+        var jwt = Jwt.withTokenValue("test-token")
+                .header("alg", "none")
+                .subject(userId.toString())
+                .build();
+        var principal = AuthPrincipal.builder().id(userId).build();
+        return new JwtAuthenticationToken(jwt, Collections.emptyList(), principal.id().toString()) {
+            @Override
+            public Object getPrincipal() {
+                return principal;
+            }
+        };
+    }
+}

--- a/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
+++ b/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
@@ -1,6 +1,5 @@
 package com.stablepay.testutil;
 
-import java.util.Collections;
 import java.util.UUID;
 
 import org.springframework.boot.test.context.TestConfiguration;
@@ -8,11 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
-
-import com.stablepay.domain.auth.model.AuthPrincipal;
 
 @TestConfiguration
 @EnableWebSecurity
@@ -26,16 +21,6 @@ public class TestSecurityConfig {
     }
 
     public static Authentication authenticationFor(UUID userId) {
-        var jwt = Jwt.withTokenValue("test-token")
-                .header("alg", "none")
-                .subject(userId.toString())
-                .build();
-        var principal = AuthPrincipal.builder().id(userId).build();
-        return new JwtAuthenticationToken(jwt, Collections.emptyList(), principal.id().toString()) {
-            @Override
-            public Object getPrincipal() {
-                return principal;
-            }
-        };
+        return AuthFixtures.authenticationFor(userId);
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -37,6 +37,8 @@ public final class AuthFixtures {
     public static final String SOME_RAW_REFRESH_TOKEN = "r1_dGVzdC1yZWZyZXNoLXRva2Vu";
     public static final String SOME_ACCESS_TOKEN = "test-access-token";
     public static final Instant SOME_ACCESS_EXPIRES_AT = Instant.parse("2026-04-03T10:15:00Z");
+    public static final String SOME_SENDER_DISPLAY_NAME = "alice";
+    public static final UUID SOME_OTHER_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
 
     public static AppUser.AppUserBuilder appUserBuilder() {
         return AppUser.builder()

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -38,7 +38,7 @@ public final class AuthFixtures {
     public static final String SOME_ACCESS_TOKEN = "test-access-token";
     public static final Instant SOME_ACCESS_EXPIRES_AT = Instant.parse("2026-04-03T10:15:00Z");
     public static final String SOME_SENDER_DISPLAY_NAME = "alice";
-    public static final UUID SOME_OTHER_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
+    public static final UUID SOME_OTHER_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000077");
 
     public static AppUser.AppUserBuilder appUserBuilder() {
         return AppUser.builder()

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -2,9 +2,15 @@ package com.stablepay.testutil;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.UUID;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
 import com.stablepay.domain.auth.model.AppUser;
+import com.stablepay.domain.auth.model.AuthPrincipal;
 import com.stablepay.domain.auth.model.AuthSession;
 import com.stablepay.domain.auth.model.LoginResult;
 import com.stablepay.domain.auth.model.RefreshToken;
@@ -83,5 +89,19 @@ public final class AuthFixtures {
         var userId = UUID.randomUUID();
         userRepository.save(AppUser.builder().id(userId).email(userId + "@test.com").build());
         return userId;
+    }
+
+    public static Authentication authenticationFor(UUID userId) {
+        var jwt = Jwt.withTokenValue("test-token")
+                .header("alg", "none")
+                .subject(userId.toString())
+                .build();
+        var principal = AuthPrincipal.builder().id(userId).build();
+        return new JwtAuthenticationToken(jwt, Collections.emptyList(), principal.id().toString()) {
+            @Override
+            public Object getPrincipal() {
+                return principal;
+            }
+        };
     }
 }


### PR DESCRIPTION
## STA Issue
Closes #209

## Summary
- Add `GET /api/wallets/me` endpoint with new `GetWalletQueryHandler` (plain `findByUserId` — no pessimistic lock per ADR-021)
- Add ownership checks in domain handlers: `GetRemittanceQueryHandler`, `InitiateFundingHandler`, `GetFundingOrderHandler`, `RefundFundingHandler` — all return 404 on mismatch (not 403, prevents enumeration per ADR-022)
- Remove `senderId` from `CreateRemittanceRequest` and `RemittanceResponse`; remove `userId` from `WalletResponse`
- Replace `UUID senderId` with `String senderDisplayName` in `ClaimResponse` — derived in `GetClaimQueryHandler`/`SubmitClaimHandler` via `UserRepository`, not in MapStruct mapper
- Controllers use `@AuthenticationPrincipal AuthPrincipal` throughout (`RemittanceController`, `FundingController`, `WalletController`)
- Fix `SecurityConfig` from "everything open except logout" to proper authenticated-by-default with explicit public paths

## Changes

### Domain layer
- **New** `GetWalletQueryHandler` — `@Transactional(readOnly = true)`, uses `findByUserId(UUID)`
- `GetRemittanceQueryHandler` — added `UUID authenticatedUserId` param, ownership check
- `InitiateFundingHandler` — changed from `existsById` to `findById` + ownership check
- `GetFundingOrderHandler` — added `WalletRepository` dep, transitive ownership check via wallet
- `RefundFundingHandler` — added ownership check after wallet load
- `GetClaimQueryHandler` / `SubmitClaimHandler` — added `UserRepository` dep, populate `senderDisplayName` (email local part before `@`, fallback "Unknown")
- `ClaimDetails` — added `String senderDisplayName` field

### Application layer
- `WalletController` — added `GET /api/wallets/me`
- `RemittanceController` — all 3 endpoints now use `@AuthenticationPrincipal` instead of request body/param
- `FundingController` — all 3 endpoints pass `principal.id()` to handlers
- `CreateRemittanceRequest` — removed `senderId`
- `WalletResponse` — removed `userId`
- `RemittanceResponse` — removed `senderId`
- `ClaimResponse` — `UUID senderId` → `String senderDisplayName`
- `ClaimApiMapper` / `WalletApiMapper` — updated mappings
- `SecurityConfig` — proper authenticated-by-default with explicit permitAll for auth, claims, fx, webhooks, actuator, swagger

### Tests (477 pass)
- **New** `GetWalletQueryHandlerTest` — happy path + not-found
- **New** `TestSecurityConfig` — test helper with `authenticationFor(UUID)` for MockMvc
- Ownership-check tests added to `GetRemittanceQueryHandlerTest`, `InitiateFundingHandlerTest`, `GetFundingOrderHandlerTest`, `RefundFundingHandlerTest`
- `GetClaimQueryHandlerTest` / `SubmitClaimHandlerTest` — verify `senderDisplayName` populated + Unknown fallback
- All controller tests updated with authenticated requests
- `SOME_SENDER_DISPLAY_NAME`, `SOME_OTHER_USER_ID` added to `AuthFixtures`

## Checklist
- [x] `./gradlew build` passes (477 tests)
- [x] Unit tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied
- [x] No `any()` matchers or `@Autowired` introduced
- [x] BDDMockito only (`given()`/`then()`)
- [x] Golden rule: single `usingRecursiveComparison()` assertion
- [x] `// given // when // then` markers in all tests
- [x] Ownership checks in domain handlers, not controllers (hexagonal rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added endpoint for authenticated users to retrieve their own wallet.
  * Claims now display sender's display name instead of sender ID.

* **Security Improvements**
  * All API endpoints now require authentication by default.
  * Enforced access control—users can only access their own remittances, funding orders, and wallets.
  * Removed user IDs from API responses for enhanced privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->