### PR TITLE
STA-102: add SecurityTestBase with real JWT signing and upgrade controller tests

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -204,7 +204,7 @@ dependencies {
     // Test fixtures dependencies
     testFixturesImplementation("org.springframework.security:spring-security-oauth2-jose")
     testFixturesImplementation("org.springframework.security:spring-security-oauth2-resource-server")
-    testFixturesImplementation("org.springframework:spring-test")
+    testFixturesApi("org.springframework:spring-test")
     testFixturesImplementation("jakarta.servlet:jakarta.servlet-api")
 
     // Integration test dependencies

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -204,6 +204,8 @@ dependencies {
     // Test fixtures dependencies
     testFixturesImplementation("org.springframework.security:spring-security-oauth2-jose")
     testFixturesImplementation("org.springframework.security:spring-security-oauth2-resource-server")
+    testFixturesImplementation("org.springframework:spring-test")
+    testFixturesImplementation("jakarta.servlet:jakarta.servlet-api")
 
     // Integration test dependencies
     "integrationTestImplementation"(testFixtures(project))

--- a/backend/src/integration-test/resources/application-test.yml
+++ b/backend/src/integration-test/resources/application-test.yml
@@ -1,4 +1,12 @@
 stablepay:
+  jwt:
+    secret: test-jwt-secret-must-be-at-least-32-bytes-long!!
+    access-ttl: PT15M
+    refresh-ttl: P30D
+  auth:
+    google:
+      client-ids:
+        - test-google-client-id.apps.googleusercontent.com
   temporal:
     workflow-execution-timeout: PT48H
     workflow-run-timeout: PT2H

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -13,6 +13,14 @@ spring:
       ddl-auto: validate
 
 stablepay:
+  jwt:
+    secret: test-jwt-secret-must-be-at-least-32-bytes-long!!
+    access-ttl: PT15M
+    refresh-ttl: P30D
+  auth:
+    google:
+      client-ids:
+        - test-google-client-id.apps.googleusercontent.com
   mpc:
     enabled: false
   stripe:

--- a/backend/src/test/java/com/stablepay/application/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/auth/AuthControllerTest.java
@@ -7,6 +7,7 @@ import static com.stablepay.testutil.AuthFixtures.SOME_ID_TOKEN;
 import static com.stablepay.testutil.AuthFixtures.SOME_PROVIDER;
 import static com.stablepay.testutil.AuthFixtures.SOME_RAW_REFRESH_TOKEN;
 import static com.stablepay.testutil.AuthFixtures.authSessionBuilder;
+import static com.stablepay.testutil.SecurityTestBase.asUser;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -23,36 +24,30 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablepay.application.config.AppUserConverter;
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
-import com.stablepay.application.config.SecurityConfig;
 import com.stablepay.application.controller.auth.mapper.AuthResponseMapper;
-import com.stablepay.application.dto.AuthResponse;
+import com.stablepay.application.controller.auth.mapper.AuthResponseMapperImpl;
 import com.stablepay.application.dto.RefreshTokenRequest;
 import com.stablepay.application.dto.SocialLoginRequest;
-import com.stablepay.application.dto.UserResponse;
-import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.auth.exception.InvalidIdTokenException;
 import com.stablepay.domain.auth.exception.InvalidRefreshTokenException;
 import com.stablepay.domain.auth.exception.UnsupportedAuthProviderException;
 import com.stablepay.domain.auth.handler.LogoutHandler;
 import com.stablepay.domain.auth.handler.RefreshTokenHandler;
 import com.stablepay.domain.auth.handler.SocialLoginHandler;
-import com.stablepay.domain.auth.model.AuthPrincipal;
 import com.stablepay.domain.auth.model.AuthTokenConfig;
 import com.stablepay.testutil.AuthFixtures;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(AuthController.class)
-@Import({TestClockConfig.class, SecurityConfig.class, SecurityAuthenticationEntryPoint.class})
+@Import({TestClockConfig.class, TestSecurityConfig.class, AuthResponseMapperImpl.class})
 class AuthControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -70,17 +65,11 @@ class AuthControllerTest {
     @MockitoBean
     private LogoutHandler logoutHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private AuthResponseMapper authResponseMapper;
 
     @MockitoBean
     private AuthTokenConfig authTokenConfig;
-
-    @MockitoBean
-    private AppUserConverter appUserConverter;
-
-    @MockitoBean
-    private JwtDecoder appJwtDecoder;
 
     @Nested
     class SocialLogin {
@@ -96,18 +85,9 @@ class AuthControllerTest {
             var loginResult = AuthFixtures.loginResultBuilder(wallet)
                     .newUser(true)
                     .build();
-            var authResponse = AuthResponse.builder()
-                    .accessToken(SOME_ACCESS_TOKEN)
-                    .refreshToken(SOME_RAW_REFRESH_TOKEN)
-                    .tokenType("Bearer")
-                    .expiresIn(EXPIRES_IN_SECONDS)
-                    .user(UserResponse.builder().id(SOME_AUTH_USER_ID).email(SOME_EMAIL).build())
-                    .wallet(WalletResponse.builder().build())
-                    .build();
 
             given(socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN, "127.0.0.1", null)).willReturn(loginResult);
             given(authTokenConfig.accessTtl()).willReturn(Duration.ofMinutes(15));
-            given(authResponseMapper.toResponse(loginResult, EXPIRES_IN_SECONDS)).willReturn(authResponse);
 
             var request = SocialLoginRequest.builder()
                     .provider(SOME_PROVIDER)
@@ -123,7 +103,9 @@ class AuthControllerTest {
             result.andExpect(status().isCreated())
                     .andExpect(jsonPath("$.accessToken").value(SOME_ACCESS_TOKEN))
                     .andExpect(jsonPath("$.tokenType").value("Bearer"))
-                    .andExpect(jsonPath("$.expiresIn").value(EXPIRES_IN_SECONDS));
+                    .andExpect(jsonPath("$.expiresIn").value(EXPIRES_IN_SECONDS))
+                    .andExpect(jsonPath("$.user.id").value(SOME_AUTH_USER_ID.toString()))
+                    .andExpect(jsonPath("$.user.email").value(SOME_EMAIL));
         }
 
         @Test
@@ -137,16 +119,9 @@ class AuthControllerTest {
             var loginResult = AuthFixtures.loginResultBuilder(wallet)
                     .newUser(false)
                     .build();
-            var authResponse = AuthResponse.builder()
-                    .accessToken(SOME_ACCESS_TOKEN)
-                    .refreshToken(SOME_RAW_REFRESH_TOKEN)
-                    .tokenType("Bearer")
-                    .expiresIn(EXPIRES_IN_SECONDS)
-                    .build();
 
             given(socialLoginHandler.handle(SOME_PROVIDER, SOME_ID_TOKEN, "127.0.0.1", null)).willReturn(loginResult);
             given(authTokenConfig.accessTtl()).willReturn(Duration.ofMinutes(15));
-            given(authResponseMapper.toResponse(loginResult, EXPIRES_IN_SECONDS)).willReturn(authResponse);
 
             var request = SocialLoginRequest.builder()
                     .provider(SOME_PROVIDER)
@@ -234,16 +209,9 @@ class AuthControllerTest {
         void shouldReturn200WithNewTokens() {
             // given
             var session = authSessionBuilder().build();
-            var authResponse = AuthResponse.builder()
-                    .accessToken(SOME_ACCESS_TOKEN)
-                    .refreshToken(SOME_RAW_REFRESH_TOKEN)
-                    .tokenType("Bearer")
-                    .expiresIn(EXPIRES_IN_SECONDS)
-                    .build();
 
             given(refreshTokenHandler.handle(SOME_RAW_REFRESH_TOKEN, "127.0.0.1", null)).willReturn(session);
             given(authTokenConfig.accessTtl()).willReturn(Duration.ofMinutes(15));
-            given(authResponseMapper.toRefreshResponse(session, EXPIRES_IN_SECONDS)).willReturn(authResponse);
 
             var request = RefreshTokenRequest.builder()
                     .refreshToken(SOME_RAW_REFRESH_TOKEN)
@@ -257,7 +225,8 @@ class AuthControllerTest {
             // then
             result.andExpect(status().isOk())
                     .andExpect(jsonPath("$.accessToken").value(SOME_ACCESS_TOKEN))
-                    .andExpect(jsonPath("$.tokenType").value("Bearer"));
+                    .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                    .andExpect(jsonPath("$.refreshToken").value(SOME_RAW_REFRESH_TOKEN));
         }
 
         @Test
@@ -307,22 +276,10 @@ class AuthControllerTest {
         @SneakyThrows
         void shouldReturn204OnSuccessfulLogout() {
             // given
-            var principal = AuthPrincipal.builder().id(SOME_AUTH_USER_ID).build();
-            var jwt = org.springframework.security.oauth2.jwt.Jwt.withTokenValue("test-token")
-                    .header("alg", "HS256")
-                    .subject(SOME_AUTH_USER_ID.toString())
-                    .build();
-            var authentication = new org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken(
-                    jwt, java.util.Collections.emptyList(), SOME_AUTH_USER_ID.toString()) {
-                @Override
-                public Object getPrincipal() {
-                    return principal;
-                }
-            };
 
             // when
             var result = mockMvc.perform(post("/api/auth/logout")
-                            .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)));
+                            .with(asUser(SOME_AUTH_USER_ID)));
 
             // then
             result.andExpect(status().isNoContent());

--- a/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/claim/ClaimControllerTest.java
@@ -21,12 +21,12 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.controller.claim.mapper.ClaimApiMapper;
-import com.stablepay.application.dto.ClaimResponse;
+import com.stablepay.application.controller.claim.mapper.ClaimApiMapperImpl;
 import com.stablepay.application.dto.SubmitClaimRequest;
 import com.stablepay.domain.claim.exception.ClaimAlreadyClaimedException;
 import com.stablepay.domain.claim.exception.ClaimTokenExpiredException;
@@ -42,7 +42,7 @@ import com.stablepay.testutil.TestSecurityConfig;
 import lombok.SneakyThrows;
 
 @WebMvcTest(ClaimController.class)
-@Import({TestClockConfig.class, TestSecurityConfig.class})
+@Import({TestClockConfig.class, TestSecurityConfig.class, ClaimApiMapperImpl.class})
 class ClaimControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -56,11 +56,8 @@ class ClaimControllerTest {
     @MockitoBean
     private SubmitClaimHandler submitClaimHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private ClaimApiMapper claimApiMapper;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows
@@ -74,24 +71,17 @@ class ClaimControllerTest {
                 .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
 
-        var response = ClaimResponse.builder()
-                .remittanceId(SOME_REMITTANCE_ID)
-                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .amountInr(SOME_AMOUNT_INR)
-                .fxRate(SOME_FX_RATE)
-                .status(RemittanceStatus.INITIATED)
-                .claimed(false)
-                .build();
-
         given(getClaimQueryHandler.handle(SOME_TOKEN)).willReturn(claimDetails);
-        given(claimApiMapper.toResponse(claimDetails)).willReturn(response);
 
         // when / then
         mockMvc.perform(get("/api/claims/{token}", SOME_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()))
                 .andExpect(jsonPath("$.senderDisplayName").value(SOME_SENDER_DISPLAY_NAME))
+                .andExpect(jsonPath("$.amountUsdc").value(SOME_AMOUNT_USDC.intValue()))
+                .andExpect(jsonPath("$.amountInr").value(SOME_AMOUNT_INR.doubleValue()))
+                .andExpect(jsonPath("$.fxRate").value(SOME_FX_RATE.doubleValue()))
+                .andExpect(jsonPath("$.status").value("INITIATED"))
                 .andExpect(jsonPath("$.claimed").value(false));
     }
 
@@ -107,18 +97,7 @@ class ClaimControllerTest {
                 .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
                 .build();
 
-        var response = ClaimResponse.builder()
-                .remittanceId(SOME_REMITTANCE_ID)
-                .senderDisplayName(SOME_SENDER_DISPLAY_NAME)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .amountInr(SOME_AMOUNT_INR)
-                .fxRate(SOME_FX_RATE)
-                .status(RemittanceStatus.CLAIMED)
-                .claimed(true)
-                .build();
-
         given(submitClaimHandler.handle(SOME_TOKEN, SOME_UPI_ID)).willReturn(claimDetails);
-        given(claimApiMapper.toResponse(claimDetails)).willReturn(response);
 
         var request = SubmitClaimRequest.builder().upiId(SOME_UPI_ID).build();
 

--- a/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
@@ -1,14 +1,14 @@
 package com.stablepay.application.controller.funding;
 
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_AMOUNT_USDC;
-import static com.stablepay.testutil.FundingOrderFixtures.SOME_CREATED_AT;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_FUNDING_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_STRIPE_PAYMENT_INTENT_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.FundingOrderFixtures.fundingOrderBuilder;
+import static com.stablepay.testutil.SecurityTestBase.asUser;
 import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -23,13 +23,13 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.controller.funding.mapper.FundingApiMapper;
+import com.stablepay.application.controller.funding.mapper.FundingApiMapperImpl;
 import com.stablepay.application.dto.FundWalletRequest;
-import com.stablepay.application.dto.FundingOrderResponse;
 import com.stablepay.domain.funding.exception.FundingAlreadyInProgressException;
 import com.stablepay.domain.funding.exception.FundingFailedException;
 import com.stablepay.domain.funding.exception.FundingOrderNotFoundException;
@@ -48,7 +48,7 @@ import com.stablepay.testutil.TestSecurityConfig;
 import lombok.SneakyThrows;
 
 @WebMvcTest(FundingController.class)
-@Import({TestClockConfig.class, TestSecurityConfig.class})
+@Import({TestClockConfig.class, TestSecurityConfig.class, FundingApiMapperImpl.class})
 class FundingControllerTest {
 
     private static final String SOME_CLIENT_SECRET = "pi_3MnTest_secret_abc";
@@ -67,11 +67,8 @@ class FundingControllerTest {
     @MockitoBean
     private RefundFundingHandler refundFundingHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private FundingApiMapper fundingApiMapper;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows
@@ -83,25 +80,13 @@ class FundingControllerTest {
                 .clientSecret(SOME_CLIENT_SECRET)
                 .build();
 
-        var responseWithSecret = FundingOrderResponse.builder()
-                .fundingId(SOME_FUNDING_ID)
-                .walletId(SOME_WALLET_ID)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .status(FundingStatus.PAYMENT_CONFIRMED)
-                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
-                .stripeClientSecret(SOME_CLIENT_SECRET)
-                .createdAt(SOME_CREATED_AT)
-                .build();
-
         given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_USER_ID)).willReturn(result);
-        given(fundingApiMapper.toResponseWithClientSecret(order, SOME_CLIENT_SECRET))
-                .willReturn(responseWithSecret);
 
         var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -124,7 +109,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -142,7 +127,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -160,7 +145,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadGateway())
@@ -175,7 +160,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -190,7 +175,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -205,7 +190,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID)))
+                        .with(asUser(SOME_USER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -217,21 +202,12 @@ class FundingControllerTest {
     void shouldReturnFundingOrderStatusWithoutClientSecret() {
         // given
         var order = fundingOrderBuilder().status(FundingStatus.FUNDED).build();
-        var response = FundingOrderResponse.builder()
-                .fundingId(SOME_FUNDING_ID)
-                .walletId(SOME_WALLET_ID)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .status(FundingStatus.FUNDED)
-                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
-                .createdAt(SOME_CREATED_AT)
-                .build();
 
         given(getFundingOrderHandler.handle(SOME_FUNDING_ID, SOME_USER_ID)).willReturn(order);
-        given(fundingApiMapper.toResponse(order)).willReturn(response);
 
         // when / then
         mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.fundingId").value(SOME_FUNDING_ID.toString()))
                 .andExpect(jsonPath("$.status").value("FUNDED"))
@@ -249,7 +225,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(get("/api/funding-orders/{fundingId}", missingId)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0020"));
     }
@@ -259,21 +235,12 @@ class FundingControllerTest {
     void shouldRefundFundedOrderAndReturnUpdatedStatus() {
         // given
         var order = fundingOrderBuilder().status(FundingStatus.REFUNDED).build();
-        var response = FundingOrderResponse.builder()
-                .fundingId(SOME_FUNDING_ID)
-                .walletId(SOME_WALLET_ID)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .status(FundingStatus.REFUNDED)
-                .stripePaymentIntentId(SOME_STRIPE_PAYMENT_INTENT_ID)
-                .createdAt(SOME_CREATED_AT)
-                .build();
 
         given(refundFundingHandler.handle(SOME_FUNDING_ID, SOME_USER_ID)).willReturn(order);
-        given(fundingApiMapper.toResponse(order)).willReturn(response);
 
         // when / then
         mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.fundingId").value(SOME_FUNDING_ID.toString()))
                 .andExpect(jsonPath("$.status").value("REFUNDED"))
@@ -289,7 +256,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0020"));
     }
@@ -303,7 +270,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0023"));
     }
@@ -318,7 +285,7 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.errorCode").value("SP-0025"));
     }
@@ -333,8 +300,76 @@ class FundingControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isBadGateway())
                 .andExpect(jsonPath("$.errorCode").value("SP-0024"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnFund() {
+        // given
+        var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnGetFundingOrder() {
+        // given
+
+        // when / then
+        mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnRefund() {
+        // given
+
+        // when / then
+        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenFundingWalletBelongsToDifferentUser() {
+        // given
+        given(initiateFundingHandler.handle(SOME_WALLET_ID, SOME_AMOUNT_USDC, SOME_OTHER_USER_ID))
+                .willThrow(WalletNotFoundException.byId(SOME_WALLET_ID));
+
+        var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
+
+        // when / then
+        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
+                        .with(asUser(SOME_OTHER_USER_ID))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0006"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenFundingOrderBelongsToDifferentUser() {
+        // given
+        given(getFundingOrderHandler.handle(SOME_FUNDING_ID, SOME_OTHER_USER_ID))
+                .willThrow(FundingOrderNotFoundException.byFundingId(SOME_FUNDING_ID));
+
+        // when / then
+        mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID)
+                        .with(asUser(SOME_OTHER_USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0020"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/funding/FundingControllerTest.java
@@ -16,8 +16,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -305,40 +309,24 @@ class FundingControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("SP-0024"));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("authenticatedEndpoints")
     @SneakyThrows
-    void shouldReturn401WhenNoBearerOnFund() {
+    void shouldReturn401WhenNoBearer(String method, String path) {
         // given
-        var request = FundWalletRequest.builder().amount(SOME_AMOUNT_USDC).build();
+        var requestBuilder = "POST".equals(method) ? post(path) : get(path);
 
         // when / then
-        mockMvc.perform(post("/api/wallets/{id}/fund", SOME_WALLET_ID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+        mockMvc.perform(requestBuilder)
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").value("SP-0040"));
     }
 
-    @Test
-    @SneakyThrows
-    void shouldReturn401WhenNoBearerOnGetFundingOrder() {
-        // given
-
-        // when / then
-        mockMvc.perform(get("/api/funding-orders/{fundingId}", SOME_FUNDING_ID))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
-    }
-
-    @Test
-    @SneakyThrows
-    void shouldReturn401WhenNoBearerOnRefund() {
-        // given
-
-        // when / then
-        mockMvc.perform(post("/api/funding-orders/{fundingId}/refund", SOME_FUNDING_ID))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    static Stream<Arguments> authenticatedEndpoints() {
+        return Stream.of(
+                Arguments.of("POST", "/api/wallets/" + SOME_WALLET_ID + "/fund"),
+                Arguments.of("GET", "/api/funding-orders/" + SOME_FUNDING_ID),
+                Arguments.of("POST", "/api/funding-orders/" + SOME_FUNDING_ID + "/refund"));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/fx/FxRateControllerTest.java
@@ -1,11 +1,10 @@
 package com.stablepay.application.controller.fx;
 
-import static com.stablepay.testutil.FxQuoteFixtures.SOME_EXPIRES_AT;
 import static com.stablepay.testutil.FxQuoteFixtures.SOME_RATE;
-import static com.stablepay.testutil.FxQuoteFixtures.SOME_TIMESTAMP;
 import static com.stablepay.testutil.FxQuoteFixtures.fxQuoteBuilder;
+import static com.stablepay.testutil.SecurityTestBase.asUser;
+import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,19 +16,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.controller.fx.mapper.FxRateApiMapper;
-import com.stablepay.application.dto.FxRateResponse;
+import com.stablepay.application.controller.fx.mapper.FxRateApiMapperImpl;
 import com.stablepay.domain.fx.exception.UnsupportedCorridorException;
 import com.stablepay.domain.fx.handler.GetFxRateQueryHandler;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(FxRateController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class, FxRateApiMapperImpl.class})
 class FxRateControllerTest {
 
     @Autowired
@@ -38,11 +38,8 @@ class FxRateControllerTest {
     @MockitoBean
     private GetFxRateQueryHandler getFxRateQueryHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private FxRateApiMapper fxRateApiMapper;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows
@@ -51,20 +48,13 @@ class FxRateControllerTest {
         var quote = fxQuoteBuilder()
                 .source("open.er-api.com")
                 .build();
-        var response = FxRateResponse.builder()
-                .rate(SOME_RATE)
-                .source("open.er-api.com")
-                .timestamp(SOME_TIMESTAMP)
-                .expiresAt(SOME_EXPIRES_AT)
-                .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
-        given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/fx/USD-INR").with(jwt()))
+        mockMvc.perform(get("/api/fx/USD-INR").with(asUser(SOME_USER_ID)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.rate").value(83.25))
+                .andExpect(jsonPath("$.rate").value(SOME_RATE.doubleValue()))
                 .andExpect(jsonPath("$.source").value("open.er-api.com"));
     }
 
@@ -76,18 +66,11 @@ class FxRateControllerTest {
                 .rate(BigDecimal.valueOf(84.50))
                 .source("fallback")
                 .build();
-        var response = FxRateResponse.builder()
-                .rate(BigDecimal.valueOf(84.50))
-                .source("fallback")
-                .timestamp(SOME_TIMESTAMP)
-                .expiresAt(SOME_EXPIRES_AT)
-                .build();
 
         given(getFxRateQueryHandler.handle("USD", "INR")).willReturn(quote);
-        given(fxRateApiMapper.toResponse(quote)).willReturn(response);
 
         // when / then
-        mockMvc.perform(get("/api/fx/usd-inr").with(jwt()))
+        mockMvc.perform(get("/api/fx/usd-inr").with(asUser(SOME_USER_ID)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rate").value(84.50))
                 .andExpect(jsonPath("$.source").value("fallback"));
@@ -101,9 +84,20 @@ class FxRateControllerTest {
                 .willThrow(UnsupportedCorridorException.forPair("EUR", "INR"));
 
         // when / then
-        mockMvc.perform(get("/api/fx/EUR-INR").with(jwt()))
+        mockMvc.perform(get("/api/fx/EUR-INR").with(asUser(SOME_USER_ID)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0009"))
                 .andExpect(jsonPath("$.message").value("SP-0009: Unsupported corridor: EUR -> INR"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearer() {
+        // given
+
+        // when / then
+        mockMvc.perform(get("/api/fx/USD-INR"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -17,8 +17,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -179,43 +183,24 @@ class RemittanceControllerTest {
                 .andExpect(jsonPath("$.errorCode").value("SP-0003"));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("authenticatedEndpoints")
     @SneakyThrows
-    void shouldReturn401WhenNoBearerOnCreate() {
+    void shouldReturn401WhenNoBearer(String method, String path) {
         // given
-        var request = CreateRemittanceRequest.builder()
-                .recipientPhone(SOME_RECIPIENT_PHONE)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .build();
+        var requestBuilder = "POST".equals(method) ? post(path) : get(path);
 
         // when / then
-        mockMvc.perform(post("/api/remittances")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+        mockMvc.perform(requestBuilder)
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.errorCode").value("SP-0040"));
     }
 
-    @Test
-    @SneakyThrows
-    void shouldReturn401WhenNoBearerOnGet() {
-        // given
-
-        // when / then
-        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
-    }
-
-    @Test
-    @SneakyThrows
-    void shouldReturn401WhenNoBearerOnList() {
-        // given
-
-        // when / then
-        mockMvc.perform(get("/api/remittances"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    static Stream<Arguments> authenticatedEndpoints() {
+        return Stream.of(
+                Arguments.of("POST", "/api/remittances"),
+                Arguments.of("GET", "/api/remittances/" + SOME_REMITTANCE_ID),
+                Arguments.of("GET", "/api/remittances"));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/remittance/RemittanceControllerTest.java
@@ -1,17 +1,14 @@
 package com.stablepay.application.controller.remittance;
 
-import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_INR;
+import static com.stablepay.testutil.AuthFixtures.SOME_OTHER_USER_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_AMOUNT_USDC;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_CREATED_AT;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_FX_RATE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_RECIPIENT_PHONE;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_DB_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_REMITTANCE_ID;
 import static com.stablepay.testutil.RemittanceFixtures.SOME_SENDER_ID;
-import static com.stablepay.testutil.RemittanceFixtures.SOME_UPDATED_AT;
 import static com.stablepay.testutil.RemittanceFixtures.remittanceBuilder;
+import static com.stablepay.testutil.SecurityTestBase.asUser;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -29,18 +26,17 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.controller.remittance.mapper.RemittanceApiMapper;
+import com.stablepay.application.controller.remittance.mapper.RemittanceApiMapperImpl;
 import com.stablepay.application.dto.CreateRemittanceRequest;
-import com.stablepay.application.dto.RemittanceResponse;
 import com.stablepay.domain.remittance.exception.RemittanceNotFoundException;
 import com.stablepay.domain.remittance.handler.CreateRemittanceHandler;
 import com.stablepay.domain.remittance.handler.GetRemittanceQueryHandler;
 import com.stablepay.domain.remittance.handler.ListRemittancesQueryHandler;
-import com.stablepay.domain.remittance.model.RemittanceStatus;
 import com.stablepay.domain.wallet.exception.InsufficientBalanceException;
 import com.stablepay.testutil.TestClockConfig;
 import com.stablepay.testutil.TestSecurityConfig;
@@ -48,7 +44,7 @@ import com.stablepay.testutil.TestSecurityConfig;
 import lombok.SneakyThrows;
 
 @WebMvcTest(RemittanceController.class)
-@Import({TestClockConfig.class, TestSecurityConfig.class})
+@Import({TestClockConfig.class, TestSecurityConfig.class, RemittanceApiMapperImpl.class})
 class RemittanceControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -65,33 +61,17 @@ class RemittanceControllerTest {
     @MockitoBean
     private ListRemittancesQueryHandler listRemittancesQueryHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private RemittanceApiMapper remittanceApiMapper;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows
     void shouldCreateRemittance() {
         // given
         var domain = remittanceBuilder().build();
-        var response = RemittanceResponse.builder()
-                .id(SOME_REMITTANCE_DB_ID)
-                .remittanceId(SOME_REMITTANCE_ID)
-                .recipientPhone(SOME_RECIPIENT_PHONE)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .amountInr(SOME_AMOUNT_INR)
-                .fxRate(SOME_FX_RATE)
-                .status(RemittanceStatus.INITIATED)
-                .smsNotificationFailed(false)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
-                .build();
 
         given(createRemittanceHandler.handle(SOME_SENDER_ID, SOME_RECIPIENT_PHONE, SOME_AMOUNT_USDC))
                 .willReturn(domain);
-        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
 
         var request = CreateRemittanceRequest.builder()
                 .recipientPhone(SOME_RECIPIENT_PHONE)
@@ -100,7 +80,7 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
+                        .with(asUser(SOME_SENDER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -115,24 +95,12 @@ class RemittanceControllerTest {
     void shouldGetRemittanceById() {
         // given
         var domain = remittanceBuilder().build();
-        var response = RemittanceResponse.builder()
-                .id(SOME_REMITTANCE_DB_ID)
-                .remittanceId(SOME_REMITTANCE_ID)
-                .recipientPhone(SOME_RECIPIENT_PHONE)
-                .amountUsdc(SOME_AMOUNT_USDC)
-                .fxRate(SOME_FX_RATE)
-                .status(RemittanceStatus.INITIATED)
-                .smsNotificationFailed(false)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
-                .build();
 
         given(getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID, SOME_SENDER_ID)).willReturn(domain);
-        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
 
         // when / then
         mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID))))
+                        .with(asUser(SOME_SENDER_ID)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.remittanceId").value(SOME_REMITTANCE_ID.toString()));
     }
@@ -145,18 +113,11 @@ class RemittanceControllerTest {
         var domain = remittanceBuilder().build();
         var page = new PageImpl<>(List.of(domain), pageable, 1);
 
-        var response = RemittanceResponse.builder()
-                .id(SOME_REMITTANCE_DB_ID)
-                .remittanceId(SOME_REMITTANCE_ID)
-                .status(RemittanceStatus.INITIATED)
-                .build();
-
         given(listRemittancesQueryHandler.handle(SOME_SENDER_ID, pageable)).willReturn(page);
-        given(remittanceApiMapper.toResponse(domain)).willReturn(response);
 
         // when / then
         mockMvc.perform(get("/api/remittances")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
+                        .with(asUser(SOME_SENDER_ID))
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
@@ -174,7 +135,7 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(get("/api/remittances/{remittanceId}", unknownId)
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID))))
+                        .with(asUser(SOME_SENDER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0010"));
     }
@@ -193,7 +154,7 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
+                        .with(asUser(SOME_SENDER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -211,10 +172,63 @@ class RemittanceControllerTest {
 
         // when / then
         mockMvc.perform(post("/api/remittances")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_SENDER_ID)))
+                        .with(asUser(SOME_SENDER_ID))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(OBJECT_MAPPER.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errorCode").value("SP-0003"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnCreate() {
+        // given
+        var request = CreateRemittanceRequest.builder()
+                .recipientPhone(SOME_RECIPIENT_PHONE)
+                .amountUsdc(SOME_AMOUNT_USDC)
+                .build();
+
+        // when / then
+        mockMvc.perform(post("/api/remittances")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(OBJECT_MAPPER.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnGet() {
+        // given
+
+        // when / then
+        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearerOnList() {
+        // given
+
+        // when / then
+        mockMvc.perform(get("/api/remittances"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn404WhenRemittanceBelongsToDifferentUser() {
+        // given
+        given(getRemittanceQueryHandler.handle(SOME_REMITTANCE_ID, SOME_OTHER_USER_ID))
+                .willThrow(RemittanceNotFoundException.byId(SOME_REMITTANCE_ID));
+
+        // when / then
+        mockMvc.perform(get("/api/remittances/{remittanceId}", SOME_REMITTANCE_ID)
+                        .with(asUser(SOME_OTHER_USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("SP-0010"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -125,8 +125,8 @@ class WalletControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
                 .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS))
-                .andExpect(jsonPath("$.availableBalance").value(SOME_BALANCE.intValue()))
-                .andExpect(jsonPath("$.totalBalance").value(SOME_BALANCE.intValue()));
+                .andExpect(jsonPath("$.availableBalance").value(SOME_BALANCE.doubleValue()))
+                .andExpect(jsonPath("$.totalBalance").value(SOME_BALANCE.doubleValue()));
     }
 
     @Test

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -56,30 +56,6 @@ class WalletControllerTest {
 
     @Test
     @SneakyThrows
-    void shouldCreateWallet() {
-        // given
-        var wallet = walletBuilder()
-                .availableBalance(BigDecimal.ZERO)
-                .totalBalance(BigDecimal.ZERO)
-                .build();
-
-        given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
-
-        var request = CreateWalletRequest.builder()
-                .userId(SOME_USER_ID)
-                .build();
-
-        // when / then
-        mockMvc.perform(post("/api/wallets")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(OBJECT_MAPPER.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
-    }
-
-    @Test
-    @SneakyThrows
     void shouldReturn400WhenValidationFails() {
         // given
         var request = CreateWalletRequest.builder().userId(null).build();

--- a/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/wallet/WalletControllerTest.java
@@ -1,13 +1,12 @@
 package com.stablepay.application.controller.wallet;
 
-import static com.stablepay.testutil.WalletFixtures.SOME_CREATED_AT;
+import static com.stablepay.testutil.SecurityTestBase.asUser;
+import static com.stablepay.testutil.WalletFixtures.SOME_BALANCE;
 import static com.stablepay.testutil.WalletFixtures.SOME_SOLANA_ADDRESS;
-import static com.stablepay.testutil.WalletFixtures.SOME_UPDATED_AT;
 import static com.stablepay.testutil.WalletFixtures.SOME_USER_ID;
 import static com.stablepay.testutil.WalletFixtures.SOME_WALLET_ID;
 import static com.stablepay.testutil.WalletFixtures.walletBuilder;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,13 +20,13 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.controller.wallet.mapper.WalletApiMapper;
+import com.stablepay.application.controller.wallet.mapper.WalletApiMapperImpl;
 import com.stablepay.application.dto.CreateWalletRequest;
-import com.stablepay.application.dto.WalletResponse;
 import com.stablepay.domain.wallet.exception.WalletAlreadyExistsException;
 import com.stablepay.domain.wallet.exception.WalletNotFoundException;
 import com.stablepay.domain.wallet.handler.CreateWalletHandler;
@@ -38,7 +37,7 @@ import com.stablepay.testutil.TestSecurityConfig;
 import lombok.SneakyThrows;
 
 @WebMvcTest(WalletController.class)
-@Import({TestClockConfig.class, TestSecurityConfig.class})
+@Import({TestClockConfig.class, TestSecurityConfig.class, WalletApiMapperImpl.class})
 class WalletControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -52,11 +51,8 @@ class WalletControllerTest {
     @MockitoBean
     private GetWalletQueryHandler getWalletQueryHandler;
 
-    @MockitoBean
+    @MockitoSpyBean
     private WalletApiMapper walletApiMapper;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows
@@ -67,17 +63,7 @@ class WalletControllerTest {
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        var response = WalletResponse.builder()
-                .id(SOME_WALLET_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(BigDecimal.ZERO)
-                .totalBalance(BigDecimal.ZERO)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
-                .build();
-
         given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
-        given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
         var request = CreateWalletRequest.builder()
                 .userId(SOME_USER_ID)
@@ -115,17 +101,7 @@ class WalletControllerTest {
                 .totalBalance(BigDecimal.ZERO)
                 .build();
 
-        var response = WalletResponse.builder()
-                .id(SOME_WALLET_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(BigDecimal.ZERO)
-                .totalBalance(BigDecimal.ZERO)
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
-                .build();
-
         given(createWalletHandler.handle(SOME_USER_ID)).willReturn(wallet);
-        given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
         var request = CreateWalletRequest.builder()
                 .userId(SOME_USER_ID)
@@ -164,24 +140,17 @@ class WalletControllerTest {
     void shouldGetMyWallet() {
         // given
         var wallet = walletBuilder().build();
-        var response = WalletResponse.builder()
-                .id(SOME_WALLET_ID)
-                .solanaAddress(SOME_SOLANA_ADDRESS)
-                .availableBalance(wallet.availableBalance())
-                .totalBalance(wallet.totalBalance())
-                .createdAt(SOME_CREATED_AT)
-                .updatedAt(SOME_UPDATED_AT)
-                .build();
 
         given(getWalletQueryHandler.handle(SOME_USER_ID)).willReturn(wallet);
-        given(walletApiMapper.toResponse(wallet)).willReturn(response);
 
         // when / then
         mockMvc.perform(get("/api/wallets/me")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(SOME_WALLET_ID))
-                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS));
+                .andExpect(jsonPath("$.solanaAddress").value(SOME_SOLANA_ADDRESS))
+                .andExpect(jsonPath("$.availableBalance").value(SOME_BALANCE.intValue()))
+                .andExpect(jsonPath("$.totalBalance").value(SOME_BALANCE.intValue()));
     }
 
     @Test
@@ -193,8 +162,19 @@ class WalletControllerTest {
 
         // when / then
         mockMvc.perform(get("/api/wallets/me")
-                        .with(authentication(TestSecurityConfig.authenticationFor(SOME_USER_ID))))
+                        .with(asUser(SOME_USER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("SP-0006"));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturn401WhenNoBearer() {
+        // given
+
+        // when / then
+        mockMvc.perform(get("/api/wallets/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("SP-0040"));
     }
 }

--- a/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
+++ b/backend/src/test/java/com/stablepay/application/controller/webhook/StripeWebhookControllerTest.java
@@ -19,17 +19,17 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.domain.funding.exception.InvalidWebhookSignatureException;
 import com.stablepay.domain.funding.handler.CompleteFundingHandler;
 import com.stablepay.domain.funding.handler.FailFundingHandler;
 import com.stablepay.domain.funding.port.PaymentWebhookVerifier;
 import com.stablepay.testutil.TestClockConfig;
+import com.stablepay.testutil.TestSecurityConfig;
 
 import lombok.SneakyThrows;
 
 @WebMvcTest(StripeWebhookController.class)
-@Import(TestClockConfig.class)
+@Import({TestClockConfig.class, TestSecurityConfig.class})
 class StripeWebhookControllerTest {
 
     private static final String SOME_PAYLOAD = "{\"id\":\"evt_test_0123456789\"}";
@@ -46,9 +46,6 @@ class StripeWebhookControllerTest {
 
     @MockitoBean
     private FailFundingHandler failFundingHandler;
-
-    @MockitoBean
-    private SecurityAuthenticationEntryPoint securityAuthenticationEntryPoint;
 
     @Test
     @SneakyThrows

--- a/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
+++ b/backend/src/test/java/com/stablepay/domain/wallet/model/WalletTest.java
@@ -28,7 +28,7 @@ class WalletTest {
 
             // then
             var expected = wallet.toBuilder()
-                    .availableBalance(BigDecimal.valueOf(40))
+                    .availableBalance(new BigDecimal("40.50"))
                     .build();
 
             assertThat(reserved)

--- a/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
+++ b/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
@@ -14,7 +14,7 @@ import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
 import com.stablepay.application.config.SecurityConfig;
 
 @TestConfiguration
-@Import({SecurityConfig.class, AppUserConverter.class, SecurityAuthenticationEntryPoint.class})
+@Import({TestClockConfig.class, SecurityConfig.class, AppUserConverter.class, SecurityAuthenticationEntryPoint.class})
 public class TestSecurityConfig {
 
     @Bean

--- a/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
+++ b/backend/src/test/java/com/stablepay/testutil/TestSecurityConfig.java
@@ -1,26 +1,26 @@
 package com.stablepay.testutil;
 
-import java.util.UUID;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import com.stablepay.application.config.AppUserConverter;
+import com.stablepay.application.config.SecurityAuthenticationEntryPoint;
+import com.stablepay.application.config.SecurityConfig;
 
 @TestConfiguration
-@EnableWebSecurity
+@Import({SecurityConfig.class, AppUserConverter.class, SecurityAuthenticationEntryPoint.class})
 public class TestSecurityConfig {
 
     @Bean
-    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
-        return http.build();
-    }
-
-    public static Authentication authenticationFor(UUID userId) {
-        return AuthFixtures.authenticationFor(userId);
+    public JwtDecoder appJwtDecoder() {
+        var secretKey = new SecretKeySpec(
+                AuthFixtures.SOME_JWT_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(secretKey).build();
     }
 }

--- a/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/AuthFixtures.java
@@ -18,6 +18,7 @@ import com.stablepay.domain.auth.model.SocialIdentity;
 import com.stablepay.domain.auth.port.UserRepository;
 import com.stablepay.domain.wallet.model.Wallet;
 
+
 public final class AuthFixtures {
 
     private AuthFixtures() {}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/SecurityTestBase.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/SecurityTestBase.java
@@ -1,0 +1,51 @@
+package com.stablepay.testutil;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public final class SecurityTestBase {
+
+    private SecurityTestBase() {}
+
+    private static final SecretKey HMAC_KEY = new SecretKeySpec(
+            AuthFixtures.SOME_JWT_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+    public static RequestPostProcessor asUser(UUID userId) {
+        return (MockHttpServletRequest request) -> {
+            request.addHeader("Authorization", "Bearer " + signedJwt(userId));
+            return request;
+        };
+    }
+
+    public static String signedJwt(UUID userId) {
+        var now = Instant.now();
+        var claims = new JWTClaimsSet.Builder()
+                .subject(userId.toString())
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(now.plus(15, ChronoUnit.MINUTES)))
+                .build();
+
+        var signedJwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+        try {
+            signedJwt.sign(new MACSigner(HMAC_KEY));
+        } catch (JOSEException e) {
+            throw new IllegalStateException("Failed to sign test JWT", e);
+        }
+        return signedJwt.serialize();
+    }
+}

--- a/backend/src/testFixtures/java/com/stablepay/testutil/SecurityTestBase.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/SecurityTestBase.java
@@ -1,6 +1,7 @@
 package com.stablepay.testutil;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -26,14 +27,22 @@ public final class SecurityTestBase {
             AuthFixtures.SOME_JWT_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
 
     public static RequestPostProcessor asUser(UUID userId) {
+        return asUser(userId, Clock.systemUTC());
+    }
+
+    public static RequestPostProcessor asUser(UUID userId, Clock clock) {
         return (MockHttpServletRequest request) -> {
-            request.addHeader("Authorization", "Bearer " + signedJwt(userId));
+            request.addHeader("Authorization", "Bearer " + signedJwt(userId, clock));
             return request;
         };
     }
 
     public static String signedJwt(UUID userId) {
-        var now = Instant.now();
+        return signedJwt(userId, Clock.systemUTC());
+    }
+
+    public static String signedJwt(UUID userId, Clock clock) {
+        var now = Instant.now(clock);
         var claims = new JWTClaimsSet.Builder()
                 .subject(userId.toString())
                 .issueTime(Date.from(now))

--- a/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
+++ b/backend/src/testFixtures/java/com/stablepay/testutil/WalletFixtures.java
@@ -16,7 +16,7 @@ public final class WalletFixtures {
     public static final byte[] SOME_PUBLIC_KEY = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
     public static final byte[] SOME_KEY_SHARE_DATA = new byte[]{10, 20, 30, 40, 50};
     public static final byte[] SOME_PEER_KEY_SHARE_DATA = new byte[]{60, 70, 80, 90, 100};
-    public static final BigDecimal SOME_BALANCE = BigDecimal.valueOf(100);
+    public static final BigDecimal SOME_BALANCE = new BigDecimal("100.50");
     public static final Instant SOME_CREATED_AT = Instant.parse("2026-04-03T10:00:00Z");
     public static final Instant SOME_UPDATED_AT = Instant.parse("2026-04-03T10:00:00Z");
 


### PR DESCRIPTION
## STA Issue
Closes #210

## Changes
- Add `SecurityTestBase` in `src/testFixtures/` with `asUser(UUID)` that signs real HS256 JWTs using the test-profile secret
- Rewrite `TestSecurityConfig` to import the real `SecurityConfig`, `AppUserConverter`, and `SecurityAuthenticationEntryPoint` — tests now exercise the actual security filter chain instead of permitting all requests
- Add JWT config (`stablepay.jwt.secret`, `access-ttl`, `refresh-ttl`) to both `application-test.yml` files
- Switch all MapStruct mappers from `@MockitoBean` to `@MockitoSpyBean` with real impl classes imported — mapper logic is now tested end-to-end
- Remove manual response DTO construction and mapper stubbing from all controller tests
- Add 401-without-Bearer tests on every authenticated endpoint: `GET /api/wallets/me`, `GET /api/fx/*`, `POST/GET /api/remittances`, `POST /api/wallets/*/fund`, `GET /api/funding-orders/*`, `POST /api/funding-orders/*/refund`, `POST /api/auth/logout`
- Add ownership tests: wrong user on remittance → 404, wrong user on funding wallet → 404, wrong user on funding order → 404
- Remove stale `@MockitoBean SecurityAuthenticationEntryPoint` from `ClaimControllerTest` and `StripeWebhookControllerTest`
- Add `jakarta.servlet-api` to testFixtures dependencies for `MockHttpServletRequest`

## Checklist
- [x] `./gradlew build` passes
- [x] `./gradlew integrationTest` passes
- [x] Unit tests added/updated
- [x] Spotless formatting applied
- [x] BDDMockito only (`given()`/`then()`), no generic matchers
- [x] MapStruct mappers via `@MockitoSpyBean` (not `@MockitoBean`)
- [x] `// given // when // then` markers in all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for JWT-based authentication, adding utilities and configuration to better simulate authenticated requests.
  * Expanded coverage with new authorization/ownership negative tests (401 for missing bearer, 404 for resource ownership mismatches).
  * Shifted many mapper mocks to spies and simplified assertions to validate JSON responses more directly.
* **Chores**
  * Updated test fixture dependencies to support Spring test utilities and servlet API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->