### PR TITLE
STA-105: Add OpenAPI 3.1 spec generated from running backend

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,2036 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "StablePay API",
+        "description": "Cross-border stablecoin remittance API on Solana. Enables instant, low-cost USD to INR remittances via USDC with MPC wallet abstraction and guaranteed delivery.",
+        "contact": {
+            "name": "StablePay Team",
+            "url": "https://github.com/stablepay"
+        },
+        "license": {
+            "name": "MIT"
+        },
+        "version": "0.1.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8080",
+            "description": "Generated server url"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Webhooks",
+            "description": "Inbound webhook endpoints (PSP-signed)"
+        },
+        {
+            "name": "Wallets",
+            "description": "MPC wallet creation"
+        },
+        {
+            "name": "Remittances",
+            "description": "Cross-border remittance creation and tracking"
+        },
+        {
+            "name": "FX Rate",
+            "description": "Foreign exchange rate lookup"
+        },
+        {
+            "name": "Authentication",
+            "description": "Social login, token refresh, and logout"
+        },
+        {
+            "name": "Claims",
+            "description": "Recipient claim page and submission"
+        },
+        {
+            "name": "Funding",
+            "description": "Stripe-backed wallet funding and status queries"
+        }
+    ],
+    "paths": {
+        "/webhooks/stripe": {
+            "post": {
+                "tags": [
+                    "Webhooks"
+                ],
+                "summary": "Receive Stripe webhook",
+                "description": "Verifies the Stripe-Signature header, then dispatches payment_intent.succeeded and payment_intent.payment_failed events to the appropriate funding handler. Always returns 200 once the signature is valid, to prevent Stripe retries on downstream errors.",
+                "operationId": "receive",
+                "parameters": [
+                    {
+                        "name": "Stripe-Signature",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/wallets": {
+            "post": {
+                "tags": [
+                    "Wallets"
+                ],
+                "summary": "Create wallet",
+                "description": "Creates an MPC-backed Solana wallet for the given user",
+                "operationId": "createWallet",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateWalletRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Wallet already exists for this user",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Wallet created",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WalletResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/wallets/{id}/fund": {
+            "post": {
+                "tags": [
+                    "Funding"
+                ],
+                "summary": "Fund wallet via Stripe",
+                "description": "Creates a Stripe PaymentIntent and a funding order. Returns the funding order reference plus a one-time Stripe client secret.",
+                "operationId": "initiateFunding",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FundWalletRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Funding already in progress for this wallet",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Amount validation failed",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Wallet not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Stripe PaymentIntent creation failed",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Funding order created",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FundingOrderResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/remittances": {
+            "get": {
+                "tags": [
+                    "Remittances"
+                ],
+                "summary": "List remittances",
+                "description": "Returns a paginated list of remittances for the authenticated user",
+                "operationId": "listRemittances",
+                "parameters": [
+                    {
+                        "name": "pageable",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/Pageable"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Remittances retrieved",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PageRemittanceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Remittances"
+                ],
+                "summary": "Create remittance",
+                "description": "Initiates a new USD to INR remittance with locked FX rate",
+                "operationId": "createRemittance",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateRemittanceRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error or insufficient balance",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Remittance created",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemittanceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/funding-orders/{fundingId}/refund": {
+            "post": {
+                "tags": [
+                    "Funding"
+                ],
+                "summary": "Refund a funded wallet",
+                "description": "Refunds a FUNDED order via Stripe. Rejects if the sender's on-chain USDC balance or wallet available balance is less than the funding amount. No on-chain USDC is returned \u2014 the sender's test tokens stay in their ATA.",
+                "operationId": "refundFunding",
+                "parameters": [
+                    {
+                        "name": "fundingId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Refund not allowed or balance insufficient",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Funding order not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Stripe refund failed",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Refund completed",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FundingOrderResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/claims/{token}": {
+            "get": {
+                "tags": [
+                    "Claims"
+                ],
+                "summary": "Get claim details",
+                "description": "Retrieves remittance claim details by the claim token sent via SMS",
+                "operationId": "getClaim",
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Claim token not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Claim token expired",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Claim details retrieved",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ClaimResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Claims"
+                ],
+                "summary": "Submit claim",
+                "description": "Submits a claim with the recipient's UPI ID to receive the INR payout",
+                "operationId": "submitClaim",
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SubmitClaimRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Claim already submitted",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Claim token not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Claim token expired",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Claim submitted",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ClaimResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/social": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Social login",
+                "description": "Exchanges a Google ID token for app access and refresh tokens",
+                "operationId": "socialLogin",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SocialLoginRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or unverified ID token",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unsupported auth provider",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "New user created and logged in",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Returning user logged in",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/refresh": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Refresh tokens",
+                "description": "Rotates the refresh token and issues a new access token",
+                "operationId": "refreshToken",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RefreshTokenRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired refresh token",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Tokens refreshed",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/logout": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout",
+                "description": "Revokes all refresh tokens for the authenticated user",
+                "operationId": "logout",
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Not authenticated",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "Logged out successfully"
+                    }
+                }
+            }
+        },
+        "/api/wallets/me": {
+            "get": {
+                "tags": [
+                    "Wallets"
+                ],
+                "summary": "Get my wallet",
+                "description": "Returns the authenticated user's wallet",
+                "operationId": "getMyWallet",
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Wallet not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Wallet found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WalletResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/remittances/{remittanceId}": {
+            "get": {
+                "tags": [
+                    "Remittances"
+                ],
+                "summary": "Get remittance",
+                "description": "Retrieves a remittance by its unique identifier",
+                "operationId": "getRemittance",
+                "parameters": [
+                    {
+                        "name": "remittanceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Remittance not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Remittance found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RemittanceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/fx/{from}-{to}": {
+            "get": {
+                "tags": [
+                    "FX Rate"
+                ],
+                "summary": "Get FX rate",
+                "description": "Returns the current exchange rate for the given currency pair (e.g. USD-INR)",
+                "operationId": "getRate",
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "to",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Unsupported currency corridor",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "FX rate retrieved",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FxRateResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/funding-orders/{fundingId}": {
+            "get": {
+                "tags": [
+                    "Funding"
+                ],
+                "summary": "Get funding order status",
+                "description": "Returns the current status of a funding order. The Stripe client secret is never returned here.",
+                "operationId": "getFundingOrder",
+                "parameters": [
+                    {
+                        "name": "fundingId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Funding order not found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "Gone",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Funding order found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FundingOrderResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "errorCode": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CreateWalletRequest": {
+                "type": "object",
+                "properties": {
+                    "userId": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "userId"
+                ]
+            },
+            "WalletResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "solanaAddress": {
+                        "type": "string"
+                    },
+                    "availableBalance": {
+                        "type": "number"
+                    },
+                    "totalBalance": {
+                        "type": "number"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "FundWalletRequest": {
+                "type": "object",
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "maximum": 10000.0,
+                        "minimum": 1.0
+                    }
+                },
+                "required": [
+                    "amount"
+                ]
+            },
+            "FundingOrderResponse": {
+                "type": "object",
+                "properties": {
+                    "fundingId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "walletId": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "amountUsdc": {
+                        "type": "number"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PAYMENT_CONFIRMED",
+                            "FUNDED",
+                            "FAILED",
+                            "REFUND_INITIATED",
+                            "REFUNDED",
+                            "REFUND_FAILED"
+                        ]
+                    },
+                    "stripePaymentIntentId": {
+                        "type": "string"
+                    },
+                    "stripeClientSecret": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "CreateRemittanceRequest": {
+                "type": "object",
+                "properties": {
+                    "recipientPhone": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "amountUsdc": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "amountUsdc",
+                    "recipientPhone"
+                ]
+            },
+            "RemittanceResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "remittanceId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "recipientPhone": {
+                        "type": "string"
+                    },
+                    "amountUsdc": {
+                        "type": "number"
+                    },
+                    "amountInr": {
+                        "type": "number"
+                    },
+                    "fxRate": {
+                        "type": "number"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "INITIATED",
+                            "ESCROWED",
+                            "CLAIMED",
+                            "DELIVERED",
+                            "DISBURSEMENT_FAILED",
+                            "DEPOSIT_FAILED",
+                            "CLAIM_FAILED",
+                            "REFUND_FAILED",
+                            "REFUNDED",
+                            "CANCELLED"
+                        ]
+                    },
+                    "escrowPda": {
+                        "type": "string"
+                    },
+                    "claimTokenId": {
+                        "type": "string"
+                    },
+                    "smsNotificationFailed": {
+                        "type": "boolean"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "SubmitClaimRequest": {
+                "type": "object",
+                "properties": {
+                    "upiId": {
+                        "type": "string",
+                        "maxLength": 100,
+                        "minLength": 0,
+                        "pattern": ".*@.*"
+                    }
+                },
+                "required": [
+                    "upiId"
+                ]
+            },
+            "ClaimResponse": {
+                "type": "object",
+                "properties": {
+                    "remittanceId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "senderDisplayName": {
+                        "type": "string"
+                    },
+                    "amountUsdc": {
+                        "type": "number"
+                    },
+                    "amountInr": {
+                        "type": "number"
+                    },
+                    "fxRate": {
+                        "type": "number"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "INITIATED",
+                            "ESCROWED",
+                            "CLAIMED",
+                            "DELIVERED",
+                            "DISBURSEMENT_FAILED",
+                            "DEPOSIT_FAILED",
+                            "CLAIM_FAILED",
+                            "REFUND_FAILED",
+                            "REFUNDED",
+                            "CANCELLED"
+                        ]
+                    },
+                    "claimed": {
+                        "type": "boolean"
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "SocialLoginRequest": {
+                "type": "object",
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "idToken": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "required": [
+                    "idToken",
+                    "provider"
+                ]
+            },
+            "AuthResponse": {
+                "type": "object",
+                "properties": {
+                    "accessToken": {
+                        "type": "string"
+                    },
+                    "refreshToken": {
+                        "type": "string"
+                    },
+                    "tokenType": {
+                        "type": "string"
+                    },
+                    "expiresIn": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "user": {
+                        "$ref": "#/components/schemas/UserResponse"
+                    },
+                    "wallet": {
+                        "$ref": "#/components/schemas/WalletResponse"
+                    }
+                }
+            },
+            "UserResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "RefreshTokenRequest": {
+                "type": "object",
+                "properties": {
+                    "refreshToken": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "required": [
+                    "refreshToken"
+                ]
+            },
+            "Pageable": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 0
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": 1
+                    },
+                    "sort": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "PageRemittanceResponse": {
+                "type": "object",
+                "properties": {
+                    "totalPages": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "totalElements": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RemittanceResponse"
+                        }
+                    },
+                    "number": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "sort": {
+                        "$ref": "#/components/schemas/SortObject"
+                    },
+                    "pageable": {
+                        "$ref": "#/components/schemas/PageableObject"
+                    },
+                    "numberOfElements": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "first": {
+                        "type": "boolean"
+                    },
+                    "last": {
+                        "type": "boolean"
+                    },
+                    "empty": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "PageableObject": {
+                "type": "object",
+                "properties": {
+                    "offset": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "sort": {
+                        "$ref": "#/components/schemas/SortObject"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "paged": {
+                        "type": "boolean"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "unpaged": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "SortObject": {
+                "type": "object",
+                "properties": {
+                    "empty": {
+                        "type": "boolean"
+                    },
+                    "sorted": {
+                        "type": "boolean"
+                    },
+                    "unsorted": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "FxRateResponse": {
+                "type": "object",
+                "properties": {
+                    "rate": {
+                        "type": "number"
+                    },
+                    "source": {
+                        "type": "string"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "expiresAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,1296 @@
+openapi: 3.1.0
+info:
+  title: StablePay API
+  description: Cross-border stablecoin remittance API on Solana. Enables instant, low-cost USD to INR remittances via USDC with MPC wallet abstraction and guaranteed delivery.
+  contact:
+    name: StablePay Team
+    url: "https://github.com/stablepay"
+  license:
+    name: MIT
+  version: 0.1.0
+servers:
+  -
+    url: "http://localhost:8080"
+    description: Generated server url
+tags:
+  -
+    name: Webhooks
+    description: Inbound webhook endpoints (PSP-signed)
+  -
+    name: Wallets
+    description: MPC wallet creation
+  -
+    name: Remittances
+    description: Cross-border remittance creation and tracking
+  -
+    name: FX Rate
+    description: Foreign exchange rate lookup
+  -
+    name: Authentication
+    description: Social login, token refresh, and logout
+  -
+    name: Claims
+    description: Recipient claim page and submission
+  -
+    name: Funding
+    description: Stripe-backed wallet funding and status queries
+paths:
+  /webhooks/stripe:
+    post:
+      tags:
+        - Webhooks
+      summary: Receive Stripe webhook
+      description: Verifies the Stripe-Signature header, then dispatches payment_intent.succeeded and payment_intent.payment_failed events to the appropriate funding handler. Always returns 200 once the signature is valid, to prevent Stripe retries on downstream errors.
+      operationId: receive
+      parameters:
+        -
+          name: Stripe-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: OK
+  /api/wallets:
+    post:
+      tags:
+        - Wallets
+      summary: Create wallet
+      description: Creates an MPC-backed Solana wallet for the given user
+      operationId: createWallet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateWalletRequest"
+        required: true
+      responses:
+        409:
+          description: Wallet already exists for this user
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Validation error
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        201:
+          description: Wallet created
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/WalletResponse"
+  /api/wallets/{id}/fund:
+    post:
+      tags:
+        - Funding
+      summary: Fund wallet via Stripe
+      description: Creates a Stripe PaymentIntent and a funding order. Returns the funding order reference plus a one-time Stripe client secret.
+      operationId: initiateFunding
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FundWalletRequest"
+        required: true
+      responses:
+        409:
+          description: Funding already in progress for this wallet
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Amount validation failed
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Wallet not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Stripe PaymentIntent creation failed
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        201:
+          description: Funding order created
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/FundingOrderResponse"
+  /api/remittances:
+    get:
+      tags:
+        - Remittances
+      summary: List remittances
+      description: Returns a paginated list of remittances for the authenticated user
+      operationId: listRemittances
+      parameters:
+        -
+          name: pageable
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Pageable"
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Remittances retrieved
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/PageRemittanceResponse"
+    post:
+      tags:
+        - Remittances
+      summary: Create remittance
+      description: Initiates a new USD to INR remittance with locked FX rate
+      operationId: createRemittance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRemittanceRequest"
+        required: true
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Validation error or insufficient balance
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        201:
+          description: Remittance created
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/RemittanceResponse"
+  /api/funding-orders/{fundingId}/refund:
+    post:
+      tags:
+        - Funding
+      summary: Refund a funded wallet
+      description: "Refunds a FUNDED order via Stripe. Rejects if the sender's on-chain USDC balance or wallet available balance is less than the funding amount. No on-chain USDC is returned \u2014 the sender's test tokens stay in their ATA."
+      operationId: refundFunding
+      parameters:
+        -
+          name: fundingId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        409:
+          description: Refund not allowed or balance insufficient
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Funding order not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Stripe refund failed
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Refund completed
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/FundingOrderResponse"
+  /api/claims/{token}:
+    get:
+      tags:
+        - Claims
+      summary: Get claim details
+      description: Retrieves remittance claim details by the claim token sent via SMS
+      operationId: getClaim
+      parameters:
+        -
+          name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Claim token not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Claim token expired
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Claim details retrieved
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ClaimResponse"
+    post:
+      tags:
+        - Claims
+      summary: Submit claim
+      description: "Submits a claim with the recipient's UPI ID to receive the INR payout"
+      operationId: submitClaim
+      parameters:
+        -
+          name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitClaimRequest"
+        required: true
+      responses:
+        409:
+          description: Claim already submitted
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Claim token not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Claim token expired
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Claim submitted
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ClaimResponse"
+  /api/auth/social:
+    post:
+      tags:
+        - Authentication
+      summary: Social login
+      description: Exchanges a Google ID token for app access and refresh tokens
+      operationId: socialLogin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SocialLoginRequest"
+        required: true
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Invalid or unverified ID token
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Unsupported auth provider
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        201:
+          description: New user created and logged in
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        200:
+          description: Returning user logged in
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+  /api/auth/refresh:
+    post:
+      tags:
+        - Authentication
+      summary: Refresh tokens
+      description: Rotates the refresh token and issues a new access token
+      operationId: refreshToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshTokenRequest"
+        required: true
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Invalid or expired refresh token
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Tokens refreshed
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+  /api/auth/logout:
+    post:
+      tags:
+        - Authentication
+      summary: Logout
+      description: Revokes all refresh tokens for the authenticated user
+      operationId: logout
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Not authenticated
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        204:
+          description: Logged out successfully
+  /api/wallets/me:
+    get:
+      tags:
+        - Wallets
+      summary: Get my wallet
+      description: "Returns the authenticated user's wallet"
+      operationId: getMyWallet
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Wallet not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Wallet found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/WalletResponse"
+  /api/remittances/{remittanceId}:
+    get:
+      tags:
+        - Remittances
+      summary: Get remittance
+      description: Retrieves a remittance by its unique identifier
+      operationId: getRemittance
+      parameters:
+        -
+          name: remittanceId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Remittance not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Remittance found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/RemittanceResponse"
+  /api/fx/{from}-{to}:
+    get:
+      tags:
+        - FX Rate
+      summary: Get FX rate
+      description: Returns the current exchange rate for the given currency pair (e.g. USD-INR)
+      operationId: getRate
+      parameters:
+        -
+          name: from
+          in: path
+          required: true
+          schema:
+            type: string
+        -
+          name: to
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Unsupported currency corridor
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Not Found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: FX rate retrieved
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/FxRateResponse"
+  /api/funding-orders/{fundingId}:
+    get:
+      tags:
+        - Funding
+      summary: Get funding order status
+      description: Returns the current status of a funding order. The Stripe client secret is never returned here.
+      operationId: getFundingOrder
+      parameters:
+        -
+          name: fundingId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        409:
+          description: Conflict
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          description: Unauthorized
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        400:
+          description: Bad Request
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: Funding order not found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        503:
+          description: Service Unavailable
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        410:
+          description: Gone
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        502:
+          description: Bad Gateway
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        200:
+          description: Funding order found
+          content:
+            */*:
+              schema:
+                $ref: "#/components/schemas/FundingOrderResponse"
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        errorCode:
+          type: string
+        message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        path:
+          type: string
+    CreateWalletRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+      required:
+        - userId
+    WalletResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        solanaAddress:
+          type: string
+        availableBalance:
+          type: number
+        totalBalance:
+          type: number
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    FundWalletRequest:
+      type: object
+      properties:
+        amount:
+          type: number
+          maximum: 10000.0
+          minimum: 1.0
+      required:
+        - amount
+    FundingOrderResponse:
+      type: object
+      properties:
+        fundingId:
+          type: string
+          format: uuid
+        walletId:
+          type: integer
+          format: int64
+        amountUsdc:
+          type: number
+        status:
+          type: string
+          enum:
+            - PAYMENT_CONFIRMED
+            - FUNDED
+            - FAILED
+            - REFUND_INITIATED
+            - REFUNDED
+            - REFUND_FAILED
+        stripePaymentIntentId:
+          type: string
+        stripeClientSecret:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    CreateRemittanceRequest:
+      type: object
+      properties:
+        recipientPhone:
+          type: string
+          minLength: 1
+        amountUsdc:
+          type: number
+      required:
+        - amountUsdc
+        - recipientPhone
+    RemittanceResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        remittanceId:
+          type: string
+          format: uuid
+        recipientPhone:
+          type: string
+        amountUsdc:
+          type: number
+        amountInr:
+          type: number
+        fxRate:
+          type: number
+        status:
+          type: string
+          enum:
+            - INITIATED
+            - ESCROWED
+            - CLAIMED
+            - DELIVERED
+            - DISBURSEMENT_FAILED
+            - DEPOSIT_FAILED
+            - CLAIM_FAILED
+            - REFUND_FAILED
+            - REFUNDED
+            - CANCELLED
+        escrowPda:
+          type: string
+        claimTokenId:
+          type: string
+        smsNotificationFailed:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+    SubmitClaimRequest:
+      type: object
+      properties:
+        upiId:
+          type: string
+          maxLength: 100
+          minLength: 0
+          pattern: ".*@.*"
+      required:
+        - upiId
+    ClaimResponse:
+      type: object
+      properties:
+        remittanceId:
+          type: string
+          format: uuid
+        senderDisplayName:
+          type: string
+        amountUsdc:
+          type: number
+        amountInr:
+          type: number
+        fxRate:
+          type: number
+        status:
+          type: string
+          enum:
+            - INITIATED
+            - ESCROWED
+            - CLAIMED
+            - DELIVERED
+            - DISBURSEMENT_FAILED
+            - DEPOSIT_FAILED
+            - CLAIM_FAILED
+            - REFUND_FAILED
+            - REFUNDED
+            - CANCELLED
+        claimed:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+    SocialLoginRequest:
+      type: object
+      properties:
+        provider:
+          type: string
+          minLength: 1
+        idToken:
+          type: string
+          minLength: 1
+      required:
+        - idToken
+        - provider
+    AuthResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        tokenType:
+          type: string
+        expiresIn:
+          type: integer
+          format: int32
+        user:
+          $ref: "#/components/schemas/UserResponse"
+        wallet:
+          $ref: "#/components/schemas/WalletResponse"
+    UserResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    RefreshTokenRequest:
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          minLength: 1
+      required:
+        - refreshToken
+    Pageable:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+          minimum: 0
+        size:
+          type: integer
+          format: int32
+          minimum: 1
+        sort:
+          type: array
+          items:
+            type: string
+    PageRemittanceResponse:
+      type: object
+      properties:
+        totalPages:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/RemittanceResponse"
+        number:
+          type: integer
+          format: int32
+        sort:
+          $ref: "#/components/schemas/SortObject"
+        pageable:
+          $ref: "#/components/schemas/PageableObject"
+        numberOfElements:
+          type: integer
+          format: int32
+        first:
+          type: boolean
+        last:
+          type: boolean
+        empty:
+          type: boolean
+    PageableObject:
+      type: object
+      properties:
+        offset:
+          type: integer
+          format: int64
+        sort:
+          $ref: "#/components/schemas/SortObject"
+        pageSize:
+          type: integer
+          format: int32
+        paged:
+          type: boolean
+        pageNumber:
+          type: integer
+          format: int32
+        unpaged:
+          type: boolean
+    SortObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
+        sorted:
+          type: boolean
+        unsorted:
+          type: boolean
+    FxRateResponse:
+      type: object
+      properties:
+        rate:
+          type: number
+        source:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
## Summary
- Add `docs/api/openapi.json` and `docs/api/openapi.yaml` — OpenAPI 3.1.0 spec captured from the live backend
- 13 API paths, 18 schemas — includes all auth endpoints (social login, refresh, logout) added in STA-99 through STA-103

## Changes
- `docs/api/openapi.json` — full OpenAPI 3.1 spec (JSON, pretty-printed)
- `docs/api/openapi.yaml` — same spec in YAML format

## Checklist
- [x] `./gradlew build` passes
- [x] Spotless formatting applied
- [ ] Unit tests added/updated — N/A (docs only)
- [ ] Integration tests added/updated — N/A (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)